### PR TITLE
Fill coverage holes

### DIFF
--- a/grunt/config/mochacov.js
+++ b/grunt/config/mochacov.js
@@ -5,23 +5,15 @@ module.exports = {
   options: {
     require: ['should']
   },
-  coverage: {
-    src: unitTests,
-    options: {
-      reporter: 'mocha-lcov-reporter',
-      coveralls: {
-        serviceName: 'travis-ci',
-        repoToken: process.env.ESJS_COVERALS_REPO_TOKEN
-      }
-    }
-  },
   unit: {
     src: unitTests
   },
   integration: {
     src: integrationTests
   },
-  make_html_unit_cov: {
+
+  // run the unit tests, and update coverage.html
+  make_coverage_html: {
     src: unitTests,
     options: {
       reporter: 'html-cov',
@@ -29,4 +21,14 @@ module.exports = {
     }
   },
 
+  // for use by travis
+  ship_coverage: {
+    src: unitTests,
+    options: {
+      reporter: 'mocha-lcov-reporter',
+      coveralls: {
+        serviceName: 'travis-ci'
+      }
+    }
+  }
 };

--- a/grunt/config/open.js
+++ b/grunt/config/open.js
@@ -1,5 +1,5 @@
 module.exports = {
-  html_unit_cov: {
+  coverage: {
     path: 'coverage.html',
     app: 'Google Chrome'
   }

--- a/grunt/config/watch.js
+++ b/grunt/config/watch.js
@@ -2,16 +2,16 @@ module.exports = {
   source: {
     files: [
       'src/**/*.js',
-      'test/unit/**/*.js',
       'grunt/**/*.js',
+      'test/unit/**/*.js',
       'Gruntfile.js'
     ],
     tasks: [
       'jshint',
-      'run:unit_tests'
+      'mochacov:unit'
     ],
     options: {
-      interrupt: true,
+      interrupt: true
     }
   }
 };

--- a/grunt/tasks.js
+++ b/grunt/tasks.js
@@ -2,7 +2,6 @@ module.exports = function (grunt) {
 
   // Default task runs the build process.
   grunt.registerTask('default', [
-    'generate',
     'test'
   ]);
 
@@ -13,17 +12,17 @@ module.exports = function (grunt) {
   grunt.registerTask('test', [
     'jshint',
     'mochacov:unit',
-    'run:generate',
+    'generate',
     'mochacov:integration',
   ]);
 
   grunt.registerTask('coverage', [
-    'mochacov:make_html_unit_cov',
-    'open:html_unit_cov'
+    'mochacov:make_coverage_html',
+    'open:coverage'
   ]);
 
   grunt.registerTask('travis', [
     'test',
-    'mochacov:coverage'
+    'mochacov:ship_coverage'
   ]);
 };

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "scripts": {
     "test": "grunt test",
-    "coverage": "mocha test/unit/test_*.js --require blanket -R html-cov > coverage.html && open -a \"Google Chrome\" ./coverage.html",
     "blanket": {
       "pattern": "src"
     }

--- a/test/unit/test_client.js
+++ b/test/unit/test_client.js
@@ -17,6 +17,12 @@ describe('Client instances creation', function () {
     }).should.throw(/previous "elasticsearch" module/);
   });
 
+  it('Succeeds even not called with new', function () {
+    var client = es.Client();
+    client.bulk.should.eql(api.bulk);
+    client.cluster.nodeStats.should.eql(api.cluster.prototype.nodeStats);
+  });
+
   it('inherits the api', function () {
     client.bulk.should.eql(api.bulk);
     client.cluster.nodeStats.should.eql(api.cluster.prototype.nodeStats);


### PR DESCRIPTION
- Added `grunt coverage` task, which will show create a coverage report and open it in Chrome
- Polished some Grunt config options while testing livereload capabilities in grunt-watch
- tests for connection_pool selection with no living connections
- tests for connection abstract's mini request implementation for ping.
