### PR TITLE
Fixes a bug that causes HTTPS to never be used.

### DIFF
--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -39,7 +39,7 @@ function HttpConnector(host, config) {
     maxKeepAliveTime: 3e5 // 5 minutes
   });
 
-  var KeepAliveAgent_ = this.host.protocol === 'https' ? KeepAliveAgent : KeepAliveAgent.HttpsAgent;
+  var KeepAliveAgent_ = this.host.protocol === 'https' ? KeepAliveAgent.HttpsAgent : KeepAliveAgent;
 
   this.agent = new KeepAliveAgent_({
     maxSockets: config.maxSockets,


### PR DESCRIPTION
Fixes a bug that causes HTTPS to never be used. Without using the HttpsAgent version of KeepAliveAgent the connections always default to http instead of https, even when https is specified as the protocol.
