### PR TITLE
Add support for Basic Authentication in Angular client.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
     "chalk": "~0.3.0",
     "forever-agent": "~0.5.2",
     "lodash-node": "~2.3.0",
-    "when": "~2.6.0",
-    "js-base64": "~2.1.2"
+    "when": "~2.6.0"
   },
   "repository": {
     "type": "git",

--- a/src/lib/connectors/angular.js
+++ b/src/lib/connectors/angular.js
@@ -9,30 +9,26 @@ module.exports = AngularConnector;
 var _ = require('../utils');
 var ConnectionAbstract = require('../connection');
 var ConnectionFault = require('../errors').ConnectionFault;
-var base64 = require('js-base64').Base64;
 
 function AngularConnector(host, config) {
   ConnectionAbstract.call(this, host, config);
   this.defer = config.defer;
   this.$http = config.$http;
+  if(this.host.auth) {
+    this.$http.defaults.headers.common.Authorization = 'Basic ' + Buffer(this.host.auth, 'utf8').toString('base64');
+  }
 }
 _.inherits(AngularConnector, ConnectionAbstract);
 
 AngularConnector.prototype.request = function (params, cb) {
   var abort = this.defer();
-  var headers = {};
-  if(this.host.auth) {
-    headers['Authorization'] = 'Basic ' + base64.encode(this.host.auth);
-  }
   this.$http({
     method: params.method,
     url: this.host.makeUrl(params),
     data: params.body,
     cache: false,
     transformRequest: [],
-    transformResponse: [],
-    headers: headers,
-    withCredentials: !!this.host.auth
+    transformResponse: []
   }).then(function (response) {
     cb(null, response.data, response.status, response.headers());
   }, function (err) {


### PR DESCRIPTION
In order to use Basic Authentication with Angular's `$http` provider you must add the `Authorization` header yourself.

This PR Base64 encodes the `username:password` from the `host.auth` property, adds it to the `Authorization` header and sets `withCredentials: true`. 
