### PR TITLE
do not mutate incoming params object

### DIFF
--- a/src/lib/client_action.js
+++ b/src/lib/client_action.js
@@ -118,7 +118,7 @@ var castType = {
 };
 
 function resolveUrl(url, params) {
-  var vars = {}, i, key;
+  var vars = {}, i, key, params = _.clone(params);
 
   if (url.req) {
     // url has required params

--- a/test/unit/specs/client_action.js
+++ b/test/unit/specs/client_action.js
@@ -813,6 +813,16 @@ describe('Client Action runner', function () {
         done();
       });
     });
+
+    it('does not modify the incoming params object', function () {
+      var action = makeClientAction({ url: { req: { index: { type: 'string' } } } }),
+          params = { index: 'index' },
+          before = JSON.stringify(params);
+
+      action(params);
+
+      expect(JSON.stringify(params)).to.equal(before);
+    });
   });
 
 });


### PR DESCRIPTION
I stumbled over this when I tried to reuse a `{index: "myIndex"}` object and the second request failed because the index was missing.

There are some `delete` calls in `client_action.js` which maybe should be replaced by building new objects, but for now this should do.
