### PR TITLE
Fix link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ client.search({
 });
 ```
 
-More examples and detailed information about each method are available [here](http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/master/index.html)
+More examples and detailed information about each method are available [here](http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/current/index.html)
 
 ## License
 


### PR DESCRIPTION
Linked to /current/ not /master/
