### PR TITLE
Travis resurgence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,10 @@
 language: node_js
-node_js: false
-matrix:
-  include:
-    - node_js: "0.8"
-      env: ES_BRANCH=master
-    - node_js: "0.10"
-      env: ES_BRANCH=master COVERAGE=1
-    - node_js: "0.10"
-      env: ES_RELEASE=0.90.10 ES_BRANCH=0.90 NODE_UNIT=0
-    - node_js: "0.10"
-      env: ES_RELEASE=0.90.9 ES_BRANCH=0.90 NODE_UNIT=0
-    - node_js: "0.10"
-      env: NODE_UNIT=0 NODE_INTEGRATION=0 TEST_BROWSER=chrome
-    - node_js: "0.10"
-      env: NODE_UNIT=0 NODE_INTEGRATION=0 TEST_BROWSER=firefox
-    - node_js: "0.10"
-      env: NODE_UNIT=0 NODE_INTEGRATION=0 TEST_BROWSER=ie
-  exclude:
-    - node_js: false
-
+node_js: "0.10"
+env:
+  - ES_BRANCH=master COVERAGE=1
+  - ES_BRANCH=1.0 NODE_UNIT=0
+  - ES_BRANCH=0.90 NODE_UNIT=0
+  - NODE_UNIT=0 NODE_INTEGRATION=0 BROWSER_UNIT=1
 script: ./scripts/ci.sh
 email:
   recipients:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 The official low-level Elasticsearch client for Node.js and the browser.
 
-[![Build Status](https://www.codeship.io/projects/f0c2b4a0-61c9-0131-3fd3-367b94dc0d60/status?branch=1.5)](https://www.codeship.io/projects/12289)
-<br>
-[![Coverage Status](https://coveralls.io/repos/elasticsearch/elasticsearch-js/badge.png)](https://coveralls.io/r/elasticsearch/elasticsearch-js)
+[![Build Status](https://travis-ci.org/elasticsearch/elasticsearch-js.png?branch=1.5)](https://travis-ci.org/elasticsearch/elasticsearch-js) [![Coverage Status](https://coveralls.io/repos/elasticsearch/elasticsearch-js/badge.png)](https://coveralls.io/r/elasticsearch/elasticsearch-js)
 
 ## Features
 
@@ -21,13 +19,13 @@ npm install elasticsearch
 ```
 
 <!-- wow bling -->
-<!-- [![NPM Stats](https://nodei.co/npm/elasticsearch.png?downloads=true)](https://npmjs.org/package/elasticsearch) -->
+[![NPM Stats](https://nodei.co/npm/elasticsearch.png?downloads=true)](https://npmjs.org/package/elasticsearch)
 
 ## Browser Builds
 
-<!-- [![Selenium Tests Status](https://saucelabs.com/browser-matrix/elasticsearch-js.svg)](https://saucelabs.com/u/elasticsearch-js) -->
+[![Selenium Tests Status](https://saucelabs.com/browser-matrix/elasticsearch-js.svg)](https://saucelabs.com/u/elasticsearch-js)
 
-We also provide builds of the elasticsearch.js client for use in the browser. These versions of the client are currently ***experimental***. We test these builds using [saucelabs](https://saucelabs.com/u/elasticsearch-js) in Chrome, Firefox, and Internet Explorer 10, and 11. We also test in IE 9, but there is a known issue with making non-standard (get/post) requests across domains.
+We also provide builds of the elasticsearch.js client for use in the browser. These versions of the client are currently *experimental*.
 
 ### Bower
 If you use bower to manage your dependencies, then just run:
@@ -48,7 +46,7 @@ bower install elasticsearch
 
 ## Supported Elasticsearch Versions
 
-<!-- [![Build Status](https://build.elasticsearch.org/job/es-js_nightly/badge/icon)](https://build.elasticsearch.org/job/es-js_nightly/) -->
+[Jenkins](https://build.elasticsearch.org/job/es-js_nightly/)
 
 Elasticsearch.js provides support for, and is regularly tested against, Elasticsearch releases **0.90.5 and greater**. We also test against the latest changes in the 0.90 and master branches of the Elasticsearch repository. To tell the client which version of Elastisearch you are using, and therefore the API it should provide, set the `apiVerson` config param. [More info](http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/current/configuration.html#_config_options)
 


### PR DESCRIPTION
Now that elasticsearch/elasticsearch stopped using Travis, we can switch back.
