### PR TITLE
Fix minor typo in the docs: upcomming: upcoming

### DIFF
--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -2,7 +2,7 @@
 == 1.1 API
 
 
-NOTE: This is currently the default API, but in upcomming versions that will change. We recommend setting the `apiVersion` config param when you instantiate your client to make sure that the API does not change unexpectedly.
+NOTE: This is currently the default API, but in upcoming versions that will change. We recommend setting the `apiVersion` config param when you instantiate your client to make sure that the API does not change unexpectedly.
 
 [[js-api-method-index]]
 * <<api-bulk,bulk>>


### PR DESCRIPTION
Fix a minor typo in the docs: upcomming -> upcoming
