### PR TITLE
Update quick_start.asciidoc

### DIFF
--- a/docs/quick_start.asciidoc
+++ b/docs/quick_start.asciidoc
@@ -112,7 +112,7 @@ NOTE: In this example, `request` and `response` are http://expressjs.com/api.htm
 
 [source,js]
 -----------------
-var pageNum = request.param('page', 0);
+var pageNum = request.param('page', 1);
 var perPage = request.param('per_page', 15);
 var userQuery = request.param('search_query');
 var userId = request.session.userId;


### PR DESCRIPTION
Since the `from` property is doing this `from: (pageNum - 1) * perPage,` logic, I think the default for `pageNum` should be `1`. Otherwise it would results it `-15` when `pageNum` and `perPage` are defaults.
