### PR TITLE
 Issue with angular client scrolling

### DIFF
--- a/src/lib/connectors/angular.js
+++ b/src/lib/connectors/angular.js
@@ -51,7 +51,6 @@ AngularConnector.prototype.request = function (params, cb) {
             }
         });
     });
-  });
 
   return function () {
     abort.resolve();


### PR DESCRIPTION
We encountered situations when the promise for $http was not always resolved (we used the search and scroll API's). 
The issue was that the $http calls were made outside of an angular scope and the promise created at line 10039 ( var promise = $q.when(config);) from angular version 1.1.5 is not automatically resolved and execution stopped at line 10055
