### PR TITLE
fix a bug in yaml_doc method do_match that was causing tests to pass that should have failed

### DIFF
--- a/test/integration/yaml_suite/yaml_doc.js
+++ b/test/integration/yaml_suite/yaml_doc.js
@@ -471,16 +471,16 @@ YamlDoc.prototype = {
     _.forOwn(args, function (val, path) {
       var isRef = _.isString(val) && val[0] === '$';
       var isRE = _.isString(val) && val[0] === '/' && path[path.length - 1] === '/';
-
+      var response_val;
       if (isRef) {
-        val = this.get(val === '$body' ? '' : val);
+        response_val = this.get(val === '$body' ? '' : val);
       } else if (isRE) {
-        val = new RegExp(val);
+        response_val = new RegExp(val);
       } else {
-        val = this.get(path);
+        response_val = this.get(path);
       }
 
-      var assert = expect(val).to[isRE ? 'match' : 'eql'](val, 'path: ' + path);
+      var assert = expect(response_val).to[isRE ? 'match' : 'eql'](val, 'path: ' + path);
     }, this);
   },
 


### PR DESCRIPTION
If you change a value in the "create/10_with_id.yaml" the tests will still pass...

For example ---- go ahead and change the match _id to 10 from 1 and run the tests again, they still pass.

Obviously when you re-run the tests do not do the generation grunt task but simply run 

  grunt.registerTask('testmatch-nogeneration', [
    'run:es_1.2',
    'mochacov:integration_1.2',
    'stop:es_1.2'
  ]);

Reason being if you look at the commit of this file from February 3, I believe that is when the bug could have been introduced...

https://github.com/stormtracks/elasticsearch-js/commit/f7f98572a3721bcbc65593f9aadc49181c4626bd

My fix allows the tests now to fail --- with the above scenario.  Hope that committing to the master branch
is the right place to add this fix.

Also --- not one hundred percent sure my fix is exactly correct as I did not test the cases for 

```
var isRef = _.isString(val) && val[0] === '$';
var isRE = _.isString(val) && val[0] === '/' && path[path.length - 1] === '/';
```

But only the default case else case when things fall through.

Please advise if more work needs to be done.

Thanks,
Michael Angerman
stormnode@gmail.com
Corvallis, Oregon
