### PR TITLE
Issue133 - jQuery.ajax HTTP method set as "type:", not "method:".

### DIFF
--- a/src/lib/connectors/jquery.js
+++ b/src/lib/connectors/jquery.js
@@ -20,7 +20,7 @@ JqueryConnector.prototype.request = function (params, cb) {
   var ajax = {
     url: this.host.makeUrl(params),
     data: params.body,
-    method: params.method,
+    type: params.method,
     dataType: 'text',
     headers: this.host.getHeaders(params.headers),
     done: cb


### PR DESCRIPTION
Set the HTTP method using the `type` attribute (instead of the `method` attribute), as defined in the [jQuery.ajax documentation](https://api.jquery.com/jquery.ajax/).
