### PR TITLE
Fix non-working example in quick_start

### DIFF
--- a/docs/quick_start.asciidoc
+++ b/docs/quick_start.asciidoc
@@ -122,30 +122,32 @@ client.search({
   from: (pageNum - 1) * perPage,
   size: perPage,
   body: {
-    filtered: {
-      query: {
-        match: {
-          // match the query agains all of
-          // the fields in the posts index
-          _all: userQuery
-        }
-      },
-      filter: {
-        // only return documents that are
-        // public or owned by the current user
-        or: [
-          {
-            term: { privacy: "public" }
-          },
-          {
-            term: { owner: userId }
+    query: {
+      filtered: {
+        query: {
+          match: {
+            // match the query agains all of
+            // the fields in the posts index
+            _all: userQuery
           }
-        ]
+        },
+        filter: {
+          // only return documents that are
+          // public or owned by the current user
+          or: [
+            {
+              term: { privacy: "public" }
+            },
+            {
+              term: { owner: userId }
+            }
+          ]
+        }
       }
     }
   }
 }, function (error, response) {
-  if (err) {
+  if (error) {
     // handle error
     return;
   }


### PR DESCRIPTION
- Wrap the 'filtered' object in a top-level query object (otherwise same issue as https://github.com/elasticsearch/elasticsearch/issues/1688)
- Fix typo (err => error) in the callback.
It's nice to be able to start from a working example and iterate from here. Thanks!