### PR TITLE
Fix scroll api documentation

### DIFF
--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -1551,6 +1551,7 @@ var allTitles = [];
 // first we do a search, and specify a scroll timeout
 client.search({
   index: 'myindex',
+  search_type: 'scan',
   // Set to 30 seconds because we are calling right back
   scroll: '30s',
   fields: ['title'],


### PR DESCRIPTION
This example does not work without: "search_type: 'scan'"