### PR TITLE
Fixed opening bracket for parameter - client.count

### DIFF
--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -233,7 +233,7 @@ client.count({
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count(
+client.count({
   index: 'index_name',
   body: {
     filtered: {


### PR DESCRIPTION
The opening bracket was missing for the json object passed as first parameter. On the api docs. See diff.