### PR TITLE
Mistake in count + filtered exemple

### DIFF
--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -233,9 +233,9 @@ client.count({
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count(
+client.count({
   index: 'index_name',
-  body: {
+  query: {
     filtered: {
       filter: {
         terms: {


### PR DESCRIPTION
When using filtered it needs to be in a query not body or you get an error message like 

```
'BroadcastShardOperationFailedException[[indexName][1] ]; nested: QueryParsingException[[indexName] request does not support [filtered]];
```

+ an opening { was missing 