### PR TITLE
Fix/205

### DIFF
--- a/scripts/generate/index.js
+++ b/scripts/generate/index.js
@@ -31,7 +31,7 @@ var path = require('path');
 var fromRoot = path.join.bind(path, require('find-root')(__dirname));
 var utils = require(fromRoot('grunt/utils'));
 var _ = require(fromRoot('src/lib/utils'));
-var esUrl = 'https://github.com/elasticsearch/elasticsearch.git';
+var esUrl = 'https://github.com/elastic/elasticsearch.git';
 var branches;
 
 if (process.env.npm_config_argv) {

--- a/src/lib/apis/1_x.js
+++ b/src/lib/apis/1_x.js
@@ -1017,6 +1017,7 @@ api.cluster.prototype.state = ca({
             'metadata',
             'nodes',
             'routing_table',
+            'routing_nodes',
             'master_node',
             'version'
           ]
@@ -1037,6 +1038,7 @@ api.cluster.prototype.state = ca({
             'metadata',
             'nodes',
             'routing_table',
+            'routing_nodes',
             'master_node',
             'version'
           ]
@@ -6096,7 +6098,7 @@ api.termvector = ca({
  * @param {String} params.consistency - Explicit write consistency setting for the operation
  * @param {String, String[], Boolean} params.fields - A comma-separated list of fields to return in the response
  * @param {String} params.lang - The script language (default: groovy)
- * @param {String} params.parent - ID of the parent document
+ * @param {String} params.parent - ID of the parent document. Is is only used for routing and when for the upsert request
  * @param {Boolean} params.refresh - Refresh the index after performing the operation
  * @param {String} [params.replication=sync] - Specific replication type
  * @param {Number} params.retryOnConflict - Specify how many times should the operation be retried when a conflict occurs (default: 0)

--- a/src/lib/apis/master.js
+++ b/src/lib/apis/master.js
@@ -1008,6 +1008,7 @@ api.cluster.prototype.state = ca({
             'metadata',
             'nodes',
             'routing_table',
+            'routing_nodes',
             'master_node',
             'version'
           ]
@@ -1028,6 +1029,7 @@ api.cluster.prototype.state = ca({
             'metadata',
             'nodes',
             'routing_table',
+            'routing_nodes',
             'master_node',
             'version'
           ]
@@ -4112,7 +4114,7 @@ api.mget = ca({
  * @param {String} params.searchScroll - A scroll search request definition
  * @param {Number} params.searchSize - The number of documents to return (default: 10)
  * @param {String} params.searchSource - A specific search request definition (instead of using the request body)
- * @param {String} params.searchType - Specific search type (eg. `dfs_then_fetch`, `count`, etc)
+ * @param {String} params.searchType - Specific search type (eg. `dfs_then_fetch`, `scan`, etc)
  * @param {String, String[], Boolean} params.searchTypes - A comma-separated list of types to perform the query against (default: the same type as the document)
  * @param {String, String[], Boolean} params.stopWords - A list of stop words to be ignored
  * @param {String} params.id - The document ID
@@ -6017,6 +6019,7 @@ api.termvectors = ca({
  * @param {String} params.consistency - Explicit write consistency setting for the operation
  * @param {String, String[], Boolean} params.fields - A comma-separated list of fields to return in the response
  * @param {String} params.lang - The script language (default: groovy)
+ * @param {String} params.parent - ID of the parent document. Is is only used for routing and when for the upsert request
  * @param {Boolean} params.refresh - Refresh the index after performing the operation
  * @param {Number} params.retryOnConflict - Specify how many times should the operation be retried when a conflict occurs (default: 0)
  * @param {String} params.routing - Specific routing value
@@ -6046,6 +6049,9 @@ api.update = ca({
       type: 'list'
     },
     lang: {
+      type: 'string'
+    },
+    parent: {
       type: 'string'
     },
     refresh: {

--- a/src/lib/connectors/angular.js
+++ b/src/lib/connectors/angular.js
@@ -10,37 +10,20 @@ var _ = require('../utils');
 var ConnectionAbstract = require('../connection');
 var ConnectionFault = require('../errors').ConnectionFault;
 
-function makeAuthHeader(auth) {
-  return 'Basic ' + (new Buffer(auth, 'utf8')).toString('base64');
-}
-
 function AngularConnector(host, config) {
   ConnectionAbstract.call(this, host, config);
+
   var self = this;
-  self.headerDefaults = {};
-
-  if (self.host.auth) {
-    self.headerDefaults.Authorization = makeAuthHeader(self.host.auth);
-  }
-
   config.$injector.invoke(['$http', '$q', function ($http, $q) {
     self.$q = $q;
     self.$http = $http;
   }]);
+
 }
 _.inherits(AngularConnector, ConnectionAbstract);
 
-AngularConnector.prototype.request = function (userParams, cb) {
+AngularConnector.prototype.request = function (params, cb) {
   var abort = this.$q.defer();
-  var params = _.cloneDeep(userParams);
-
-  params.headers = _.defaults(params.headers || {}, this.headerDefaults);
-  if (params.auth) {
-    params.headers.Authorization = makeAuthHeader(params.auth);
-  }
-
-  // inform the host not to use the auth, by overriding it in the params
-  params.auth = false;
 
   this.$http({
     method: params.method,

--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -106,7 +106,6 @@ HttpConnector.prototype.makeReqParams = function (params) {
   var reqParams = {
     method: params.method || 'GET',
     protocol: host.protocol + ':',
-    auth: host.auth,
     hostname: host.host,
     port: host.port,
     path: (host.path || '') + (params.path || ''),

--- a/src/lib/connectors/jquery.js
+++ b/src/lib/connectors/jquery.js
@@ -26,12 +26,6 @@ JqueryConnector.prototype.request = function (params, cb) {
     done: cb
   };
 
-  if (params.auth) {
-    var auths = params.auth.split(':');
-    ajax.username = auths[0];
-    ajax.password = auths[1];
-  }
-
   var jqXHR = jQuery.ajax(ajax)
     .done(function (data, textStatus, jqXHR) {
       cb(null, data, jqXHR.statusCode(), {

--- a/src/lib/connectors/xhr.js
+++ b/src/lib/connectors/xhr.js
@@ -53,16 +53,21 @@ if (!getXhr) {
 XhrConnector.prototype.request = function (params, cb) {
   var xhr = getXhr();
   var timeoutId;
-  var url = this.host.makeUrl(params);
-  var headers = this.host.getHeaders(params.headers);
-
+  var host = this.host;
   var log = this.log;
+
+  var url = host.makeUrl(params);
+  var headers = host.getHeaders(params.headers);
   var async = params.async === false ? false : asyncDefault;
 
-  if (params.auth) {
-    xhr.open(params.method || 'GET', url, async, params.auth.user, params.auth.pass);
-  } else {
-    xhr.open(params.method || 'GET', url, async);
+  xhr.open(params.method || 'GET', url, async);
+
+  if (headers) {
+    for (var key in headers) {
+      if (headers[key] !== void 0) {
+        xhr.setRequestHeader(key, headers[key]);
+      }
+    }
   }
 
   xhr.onreadystatechange = function () {
@@ -73,14 +78,6 @@ XhrConnector.prototype.request = function (params, cb) {
       cb(err, xhr.responseText, xhr.status);
     }
   };
-
-  if (headers) {
-    for (var key in headers) {
-      if (headers[key] !== void 0) {
-        xhr.setRequestHeader(key, headers[key]);
-      }
-    }
-  }
 
   xhr.send(params.body || void 0);
 

--- a/test/unit/browser_builds/angular.js
+++ b/test/unit/browser_builds/angular.js
@@ -82,44 +82,4 @@ describe('Angular esFactory', function () {
       return prom;
     });
   });
-
-  describe('$http', function () {
-    bootstrap({
-      bluebirdPromises: true
-    });
-
-    it('uses the auth header provided', function () {
-      var authString = 'user:password';
-      var authHeader = 'Basic ' + (new Buffer(authString, 'utf8')).toString('base64');
-      var $httpParams = null;
-      var client = esFactory({
-        host: {
-          host: 'some-other-es-host.com',
-          auth: authString
-        }
-      });
-
-      // once the client calls the $http method, flush the requests and trigger an
-      // error if the expected request was not made
-      var connection = client.transport.connectionPool.getConnections().pop();
-      var stub = sinon.stub(connection, '$http', function (params) {
-        $httpParams = params;
-        return Promise.resolve({
-          data: null,
-          status: 200,
-          headers: function () {
-            return {};
-          }
-        });
-      });
-
-      var prom = client.ping({
-        requestTimeout: 1000
-      });
-      return prom.then(function () {
-        expect($httpParams).to.have.property('headers');
-        expect($httpParams.headers).to.have.property('Authorization', authHeader);
-      });
-    });
-  });
 });

--- a/test/unit/browser_builds/generic.js
+++ b/test/unit/browser_builds/generic.js
@@ -6,9 +6,11 @@ describe('elasticsearch namespace', function () {
   it('is defined on the window', function () {
     expect(es).to.be.ok();
   });
+
   it('has Client, ConnectionPool, Transport, and errors keys', function () {
     expect(es).to.have.keys('Client', 'ConnectionPool', 'Transport', 'errors');
   });
+
   it('can create a client', function () {
     var client = new es.Client({ hosts: null });
     expect(client).to.have.keys('transport');

--- a/test/unit/browser_builds/jquery.js
+++ b/test/unit/browser_builds/jquery.js
@@ -5,9 +5,11 @@ describe('jQuery.es namespace', function () {
   it('is defined on the global jQuery', function () {
     expect($.es).to.be.ok();
   });
+
   it('has Client, ConnectionPool, Transport, and errors keys', function () {
     expect($.es).to.have.keys('Client', 'ConnectionPool', 'Transport', 'errors');
   });
+
   it('can create a client', function () {
     var client = new $.es.Client({ hosts: null });
     expect(client).to.have.keys('transport');

--- a/test/unit/specs/host.js
+++ b/test/unit/specs/host.js
@@ -9,7 +9,6 @@ var hostDefaults = {
   host: 'localhost',
   port: 9200,
   path: '',
-  auth: null,
   query: {},
   headers: null,
   suggestCompression: false,
@@ -44,7 +43,7 @@ describe('Host class', function () {
       var headers = { 'X-Special-Routing-Header': 'pie' };
       var host = new Host({ headers: headers });
 
-      expect(host.headers).to.be(headers);
+      expect(host.headers).to.eql(headers);
     });
 
     describe('from a string', function () {
@@ -56,7 +55,6 @@ describe('Host class', function () {
           host: 'pizza.com',
           port: 420,
           path: '/pizza/cheese',
-          auth: 'john:dude',
           query: {
             shrooms: 'true'
           }
@@ -122,7 +120,7 @@ describe('Host class', function () {
         expect(host.host).to.eql('pizza.com');
         expect(host.port).to.eql(888);
         expect(host.path).to.eql('/path');
-        expect(host.auth).to.eql('joe:diner');
+        expect(host.headers).to.eql({ Authorization: 'Basic ' + (new Buffer('joe:diner')).toString('base64') });
         expect(host.query).to.eql({
           query: 'yes'
         });
@@ -151,9 +149,8 @@ describe('Host class', function () {
         path: '/this and that',
         query: {
           param: 1
-        },
-        auth: 'user:pass'
-      })).to.be('http://user:pass@localhost:9200/prefix/this and that?user_id=123&param=1');
+        }
+      })).to.be('http://localhost:9200/prefix/this and that?user_id=123&param=1');
     });
 
     it('ensures that path starts with a forward-slash', function () {
@@ -179,7 +176,7 @@ describe('Host class', function () {
       expect(host.makeUrl()).to.be('http://john/');
 
       host = new Host({ host: 'italy', path: '/pie', auth: 'user:pass'});
-      expect(host.makeUrl()).to.be('http://user:pass@italy:9200/pie');
+      expect(host.makeUrl()).to.be('http://italy:9200/pie');
     });
 
     it('outputs valid relative urls when the host is empty', function () {

--- a/test/unit/specs/http_connector.js
+++ b/test/unit/specs/http_connector.js
@@ -72,10 +72,10 @@ describe('Http Connector', function () {
       var con = new HttpConnection(host, {});
       var reqParams = con.makeReqParams();
 
+      expect(reqParams).to.not.have.property('auth');
       expect(reqParams).to.eql({
         method: 'GET',
         protocol: 'http:',
-        auth: 'john:dude',
         hostname: 'pizza.com',
         port: 9200,
         path: '/pizza/cheese?shrooms=true',
@@ -142,7 +142,6 @@ describe('Http Connector', function () {
       expect(reqParams).to.eql({
         method: 'PUT',
         protocol: 'http:',
-        auth: null,
         hostname: 'google.com',
         port: 80,
         path: '/stuff',


### PR DESCRIPTION
Fixes #205 

This moved all authentication juggling out of the connectors and handles it generically using headers in the `Host` class.

 - flatten auth config to an Authorization header when the Host is created
 - remove individual Authorization handling from connectors
 - removed incomplete support for per-request auth
 - use per-request headers to provide your own Authorization header per request