### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "through2-map": "~1.4.0",
     "xmlbuilder": "~0.4.3"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^2.9.14",
     "chalk": "^1.0.0",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/

Updated to "Apache-2.0" per https://spdx.org/licenses/