### PR TITLE
Update quick_start.asciidoc

### DIFF
--- a/docs/quick_start.asciidoc
+++ b/docs/quick_start.asciidoc
@@ -123,30 +123,31 @@ client.search({
   from: (pageNum - 1) * perPage,
   size: perPage,
   body: {
-    filtered: {
-      query: {
-        match: {
-          // match the query agains all of
-          // the fields in the posts index
-          _all: userQuery
-        }
-      },
-      filter: {
-        // only return documents that are
-        // public or owned by the current user
-        or: [
-          {
-            term: { privacy: "public" }
-          },
-          {
-            term: { owner: userId }
+    query: {
+      filtered: {
+        query: {
+          match: {
+            // match the query agains all of
+            // the fields in the posts index
+            _all: userQuery
           }
-        ]
+        },
+        filter: {
+          // only return documents that are
+          // public or owned by the current user
+          or: [
+            {
+              term: { privacy: "public" }
+            },
+            {
+              term: { owner: userId }
+            }
+          ]
+        }
       }
     }
-  }
-}, function (error, response) {
-  if (err) {
+  }, function (error, response) {
+    if (err) {
     // handle error
     return;
   }


### PR DESCRIPTION
Fixed the example with the filtered query, missing the top-level `query` parameter

See https://github.com/elastic/elasticsearch/issues/1688#issuecomment-109646788