### PR TITLE
Update elasticsearch-js msearch body format

### DIFF
--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -1220,7 +1220,7 @@ client.msearch({
     { query: { match_all: {} } },
 
     // query_string query, on index/mytype
-    { index: 'myindex', type: 'mytype' },
+    { _index: 'myindex', _type: 'mytype' },
     { query: { query_string: { query: '"Test 1"' } } }
   ]
 });


### PR DESCRIPTION
Although _msearch using the web API will allow the body to not have leading underscores before the keys "index" and "type" (e.g. `{"index": "my-index", "type": "my-type"}
{"query": ... }`), the Javascript Elasticsearch client.msearch will give the error "SearchPhaseExecutionException[Failed to execute phase [query], all shards failed]" if the body follows the same format. Adding the leading underscores fixes this issue.