### PR TITLE
Correct dead timeout in the docs.

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -122,7 +122,7 @@ Default::: `30000`
 
 `deadTimeout`[[config-dead-timeout]]:: `Number` -- Milliseconds that a dead connection will wait before attempting to revive itself.
 
-Default::: `30000`
+Default::: `60000`
 
 
 `pingTimeout`[[config-ping-timeout]]:: `Number` -- Milliseconds that a ping request can take before timing out.


### PR DESCRIPTION
It's set to one minute in the [code](https://github.com/elastic/elasticsearch-js/blob/7d14e7d24e5017eb29d6b0998eb6b0e04c2cacb8/src/lib/connection_pool.js#L37).