### PR TITLE
Add 2.0 api to the indexes

### DIFF
--- a/src/lib/apis/browser_index.js
+++ b/src/lib/apis/browser_index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  '2.0': require('./2_0'),
   '1.7': require('./1_7'),
   '1.6': require('./1_6'),
   '1.5': require('./1_5')

--- a/src/lib/apis/index.js
+++ b/src/lib/apis/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   'master': require('./master'),
+  '2.0': require('./2_0'),
   '1.7': require('./1_7'),
   '1.6': require('./1_6'),
   '1.5': require('./1_5'),


### PR DESCRIPTION
Enable 2.0 api, which was added in 6.1.0 but not included in the server and browser indexes