### PR TITLE
Fix to use node.js 4.x (due to convergence)

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "generate": "node scripts/generate"
   },
   "engines": {
-    "node": ">=0.8 <3.0",
-    "iojs": ">=1.5"
+    "node": ">=0.8 <3.0 || >=4.0",
+    "iojs": ">=1.5 <4.0"
   }
 }


### PR DESCRIPTION
This is due to the convergence as announced on https://nodejs.org/en/blog/release/v4.0.0/