### PR TITLE
implement config.sniffedNodesProtocol

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -164,6 +164,10 @@ Defaults:::
   * jQuery Build: `"jquery"`
 
 
+`sniffedNodesProtocol`[[config-sniffed-nodes-protocol]]:: `String` -- Defines the protocol that will be used to communicate with nodes discovered during sniffing.
+
+Default::: If all of the hosts/host passed to the client via configuration use the same protocol then this defaults to that protocol, otherwise it defaults to `"http"`.
+
 
 `ssl`[[config-ssl]]:: `Object` -- An object defining HTTPS/SSL configuration to use for all nodes. The properties of this mimic the options accepted by http://nodejs.org/docs/latest/api/tls.html#tls_tls_connect_port_host_options_callback[`tls.connect()`] with the exception of `rejectUnauthorized`, which defaults to `false` allowing self-signed certificates to work out-of-the-box.
 +

--- a/src/lib/connection_pool.js
+++ b/src/lib/connection_pool.js
@@ -328,6 +328,12 @@ ConnectionPool.prototype.setHosts = function (hosts) {
   }
 };
 
+ConnectionPool.prototype.getAllHosts = function () {
+  return _.values(this.index).map(function (connection) {
+    return connection.host;
+  });
+};
+
 /**
  * Close the conncetion pool, as well as all of it's connections
  */

--- a/src/lib/transport/find_common_protocol.js
+++ b/src/lib/transport/find_common_protocol.js
@@ -1,0 +1,14 @@
+var isEmpty = require('lodash').isEmpty;
+
+module.exports = function (hosts) {
+  if (isEmpty(hosts)) return false;
+
+  var commonProtocol = hosts.shift().protocol;
+  for (var i = 0; i < hosts.length; i++) {
+    if (commonProtocol !== hosts[i].protocol) {
+      return false;
+    }
+  }
+
+  return commonProtocol;
+}


### PR DESCRIPTION
Fixes #264

If you use https to protect traffic between esjs client and the nodes in your cluster then you can't use sniffing. This is because we use the /_nodes/_all/clear API to populate the connection pool and that API does not know that the nodes speak HTTPS. This change implements the `config.sniffedNodesProtocol` to fix this.

`sniffedNodesProtocol` can be set to a string which will be used as the protocol configuration for each Host object created during sniffing, plain and simple. The default value for this configuration depends on the hosts initially passed to the client, if all of the nodes have the same protocol that protocol is used.