### PR TITLE
Fix 2014 typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # elasticsearch-js changelog
 
-## 8.1 (Sep 8 2014)
+## 8.1 (Sep 8 2015)
  - Added apiVersion `"2.x"`, which will semi-regularly be updated to match the latest development at [elastic/elasticsearch#2.x](https://github.com/elastic/elasticsearch/tree/2.x)
  - Removed node engine upper-bound, supporting 4.0 and versions beyond.
 


### PR DESCRIPTION
Simple fix for changelog which listed `8.1`'s release date as September *2014*