### PR TITLE
Fixing domain callbacks

### DIFF
--- a/src/lib/transport.js
+++ b/src/lib/transport.js
@@ -140,6 +140,10 @@ Transport.prototype.request = function (params, cb) {
 
   // determine the response based on the presense of a callback
   if (typeof cb === 'function') {
+    // handle callbacks within a domain
+    if (process.domain) {
+      cb = process.domain.bind(cb);
+    }
     ret = {
       abort: abortRequest
     };

--- a/test/unit/specs/transport.js
+++ b/test/unit/specs/transport.js
@@ -670,6 +670,35 @@ describe('Transport Class', function () {
       });
     });
 
+    describe('handles process.domain', function () {
+      if (process && process.hasOwnProperty('domain')) {
+        it('works without a domain', function () {
+          expect(process.domain).to.be(null);
+          var tran = new Transport();
+          shortCircuitRequest(tran);
+          tran.request({}, function(err, result, status) {
+            expect(process.domain).to.be(null);
+          });
+        });
+
+        it('binds the callback to the correct domain', function () {
+          expect(process.domain).to.be(null);
+          var domain = require('domain').create();
+          domain.run(function() {
+            var tran = new Transport();
+            shortCircuitRequest(tran);
+            expect(process.domain).not.to.be(null);
+            var startingDomain = process.domain
+            tran.request({}, function(err, result, status) {
+              expect(process.domain).not.to.be(null);
+              expect(process.domain).to.be(startingDomain);
+              process.domain.exit();
+            });
+          });
+        });
+      }
+    });
+
     describe('aborting', function () {
       it('prevents the request from starting if called in the same tick', function () {
         var tran = new Transport({


### PR DESCRIPTION
We're in the process of converting from postgres to elasticsearch for search.

This module's connection pool is breaking our use of node's domains. Because connections are created with one domain and might service a request for a different domain later when they're reused.

I've modeled my fix after similar fixes in node-pg:
https://github.com/brianc/node-postgres/commit/779c8064f2873b190d6f671b6ecef75852688526
https://github.com/brianc/node-postgres/commit/9c87253aff3609dd3444d53ce5878b1112c7c646

Please let me know what you think.