### PR TITLE
updated the browser dependancy for lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "./src/lib/loggers/index.js": "./src/lib/loggers/browser_index.js",
     "./src/lib/apis/index.js": "./src/lib/apis/browser_index.js",
     "./test/mocks/server.js": "./test/mocks/browser_server.js",
-    "lodash": "./node_modules/lodash-compat/index.js"
+    "lodash": "lodash-compat"
   },
   "config": {
     "blanket": {


### PR DESCRIPTION
When using the module with browserify it fails to load the lodash dependancy with the latest version of npm, removing the relative path resolves this issue