### PR TITLE
Always send Content-Length header. Fixes compatibility issues with el…

### DIFF
--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -185,6 +185,7 @@ HttpConnector.prototype.request = function (params, cb) {
     request.setHeader('Content-Length', Buffer.byteLength(params.body, 'utf8'));
     request.end(params.body);
   } else {
+    request.setHeader('Content-Length', 0);
     request.end();
   }
 

--- a/test/mocks/request.js
+++ b/test/mocks/request.js
@@ -12,6 +12,7 @@ var http = require('http');
 function MockRequest() {
   sinon.stub(this, 'end');
   sinon.stub(this, 'write');
+  sinon.stub(this, 'setHeader');
   this.log = sinon.stub(this.log);
 }
 util.inherits(MockRequest, http.ClientRequest);


### PR DESCRIPTION
…asticsearch behind nginx.

See https://github.com/elastic/cookbook-elasticsearch/issues/38 or http://serverfault.com/questions/164220/is-there-a-way-to-avoid-nginx-411-content-length-required-errors