### PR TITLE
user:password@ removal on log warning

### DIFF
--- a/src/lib/connection_pool.js
+++ b/src/lib/connection_pool.js
@@ -222,7 +222,7 @@ ConnectionPool.prototype._selectDeadConnection = function (cb) {
     if (timeout.conn.status === 'dead') {
       timeout.revive(function (err) {
         if (err) {
-          log.warning('Unable to revive connection: ' + timeout.conn.id);
+          log.warning('Unable to revive connection: ' + timeout.conn.id.replace(/\w+:\w+@/, ''));
           process.nextTick(next);
         } else {
           cb(void 0, timeout.conn);


### PR DESCRIPTION
based on the described issue https://github.com/elastic/elasticsearch-js/issues/260, this pull request has a simple solution of logging a connection id without the user:password combination.

`Unable to revive connection: http://user:password@localhost:9200/` will turn into `Unable to revive connection: http://localhost:9200/`
