### PR TITLE
Add bodybuilder to list of query building libraries.

### DIFF
--- a/docs/_descriptions/search.asciidoc
+++ b/docs/_descriptions/search.asciidoc
@@ -1,4 +1,4 @@
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 

--- a/docs/api_conventions.asciidoc
+++ b/docs/api_conventions.asciidoc
@@ -11,7 +11,7 @@ By default, all api methods accept the following parameters. They are omitted fr
 `body`::
 `String, Anything` -- The body to send along with this request. If the body is a string it will be passed along as is, otherwise it is passed to the serializer and converted to either JSON or a newline seperated list of JSON objects based on the API method.
 +
-NOTE: the https://github.com/fullscale/elastic.js[elastic.js] library can be used to make building request bodies simpler.
+NOTE: the https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/danpaz/bodybuilder[bodybuilder] libraries can be used to make building request bodies simpler.
 
 `ignore`::
 +

--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -1443,7 +1443,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_0_90.asciidoc
+++ b/docs/api_methods_0_90.asciidoc
@@ -1119,7 +1119,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_1_0.asciidoc
+++ b/docs/api_methods_1_0.asciidoc
@@ -1294,7 +1294,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_1_1.asciidoc
+++ b/docs/api_methods_1_1.asciidoc
@@ -1308,7 +1308,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_1_2.asciidoc
+++ b/docs/api_methods_1_2.asciidoc
@@ -1308,7 +1308,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_1_3.asciidoc
+++ b/docs/api_methods_1_3.asciidoc
@@ -1452,7 +1452,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_1_4.asciidoc
+++ b/docs/api_methods_1_4.asciidoc
@@ -1555,7 +1555,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_1_5.asciidoc
+++ b/docs/api_methods_1_5.asciidoc
@@ -1559,7 +1559,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_1_6.asciidoc
+++ b/docs/api_methods_1_6.asciidoc
@@ -1598,7 +1598,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_1_7.asciidoc
+++ b/docs/api_methods_1_7.asciidoc
@@ -1598,7 +1598,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_2_0.asciidoc
+++ b/docs/api_methods_2_0.asciidoc
@@ -1443,7 +1443,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/holidayextras/esq[esq] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
 
 
 


### PR DESCRIPTION
Adding [bodybuilder](https://github.com/danpaz/bodybuilder) as yet another option of query builders. This one supports [combining query clauses using boolean queries](https://www.elastic.co/guide/en/elasticsearch/guide/current/bool-query.html), e.g.

```js
new Bodybuilder().query('match', 'title', 'quick')
                 .notQuery('match', 'title', 'lazy')
                 .orQuery('match', 'title', 'brown')
                 .orQuery('match', 'title', 'dog')
                 .build()
```
creates
```js
{
  "query": {
     "bool": {
        "must":     [  { "match": { "title": "quick" }} ],
        "must_not": [  { "match": { "title": "lazy"  }} ],
        "should":   [
                        { "match": { "title": "brown" }},
                        { "match": { "title": "dog"   }}
                    ]
        }
    }
}
```

The library is under active development (e.g. need to support the new way of combining filters and queries in the 2.0 dsl) and my hope is to draw new contributors to the project by adding it to these docs.

I have signed the CLA.