### PR TITLE
allow to set http.agent to false by setting noAgent to true in client…

### DIFF
--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -44,7 +44,7 @@ function HttpConnector(host, config) {
     maxSockets: 11
   });
 
-  this.agent = this.createAgent(config);
+  this.agent = config.noAgent ? false : this.createAgent(config);
 }
 _.inherits(HttpConnector, ConnectionAbstract);
 


### PR DESCRIPTION
This adds the new option `noAgent` which, if set to true, sets the http.agent to `false`. This fixes #327.