### PR TITLE
Implement createNodeAgent config

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -343,3 +343,22 @@ var client = new elasticsearch.Client({
   }
 })
 -----
+
+
+
+`createNodeAgent`[[config-createNodeAgent]]:: `Function` -- Override the way that the client creates node.js `Agent`[https://nodejs.org/api/http.html#http_class_http_agent] objects. The value of this property will be executed every time a new Node is added to the client (either from the initial seed or from sniffing) and can return any value that node's http(s) module accepts as `agent:` configuration.
++
+The function is called with two arguments, first an `HttpConnector`[http://github.com/spalger/elasticsearch-js/blob/master/src/lib/connectors/http.js] object and the second the config object initially passed when creating the client.
+
+Default::: `HttpConnector#createAgent()`
+
+Disable Agent creation:::
++
+[source,js]
+-----
+var client = new elasticsearch.Client({
+  createNodeAgent: function () {
+    return false;
+  }
+});
+-----

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -242,6 +242,27 @@ see https://github.com/elasticsearch/elasticsearch-js/blob/master/src/lib/nodes_
 
 
 
+
+`createNodeAgent`[[config-create-node-agent]]:: `Function` -- Override the way that the client creates node.js `Agent`[https://nodejs.org/api/http.html#http_class_http_agent] objects. The value of this property will be executed every time a new Node is added to the client (either from the initial seed or from sniffing) and can return any value that node's http(s) module accepts as `agent:` configuration.
++
+The function is called with two arguments, first an `HttpConnector`[http://github.com/spalger/elasticsearch-js/blob/master/src/lib/connectors/http.js] object and the second the config object initially passed when creating the client.
+
+Default::: `HttpConnector#createAgent()`
+
+Disable Agent creation:::
++
+[source,js]
+-----
+var client = new elasticsearch.Client({
+  createNodeAgent: function () {
+    return false;
+  }
+});
+-----
+
+
+
+
 === Examples
 
 Connect to just a single seed node, and use sniffing to find the rest of the cluster.
@@ -342,23 +363,4 @@ var client = new elasticsearch.Client({
     }, []);
   }
 })
------
-
-
-
-`createNodeAgent`[[config-createNodeAgent]]:: `Function` -- Override the way that the client creates node.js `Agent`[https://nodejs.org/api/http.html#http_class_http_agent] objects. The value of this property will be executed every time a new Node is added to the client (either from the initial seed or from sniffing) and can return any value that node's http(s) module accepts as `agent:` configuration.
-+
-The function is called with two arguments, first an `HttpConnector`[http://github.com/spalger/elasticsearch-js/blob/master/src/lib/connectors/http.js] object and the second the config object initially passed when creating the client.
-
-Default::: `HttpConnector#createAgent()`
-
-Disable Agent creation:::
-+
-[source,js]
------
-var client = new elasticsearch.Client({
-  createNodeAgent: function () {
-    return false;
-  }
-});
 -----

--- a/scripts/generate/templates/configuration_docs.tmpl
+++ b/scripts/generate/templates/configuration_docs.tmpl
@@ -334,3 +334,22 @@ var client = new elasticsearch.Client({
   }
 })
 -----
+
+
+
+`createNodeAgent`[[config-createNodeAgent]]:: `Function` -- Override the way that the client creates node.js `Agent`[https://nodejs.org/api/http.html#http_class_http_agent] objects. The value of this property will be executed every time a new Node is added to the client (either from the initial seed or from sniffing) and can return any value that node's http(s) module accepts as `agent:` configuration.
++
+The function is called with two arguments, first an `HttpConnector`[http://github.com/spalger/elasticsearch-js/blob/master/src/lib/connectors/http.js] object and the second the config object initially passed when creating the client.
+
+Default::: `HttpConnector#createAgent()`
+
+Disable Agent creation:::
++
+[source,js]
+-----
+var client = new elasticsearch.Client({
+  createNodeAgent: function () {
+    return false;
+  }
+});
+-----

--- a/scripts/generate/templates/configuration_docs.tmpl
+++ b/scripts/generate/templates/configuration_docs.tmpl
@@ -233,6 +233,27 @@ see https://github.com/elasticsearch/elasticsearch-js/blob/master/src/lib/nodes_
 
 
 
+
+`createNodeAgent`[[config-create-node-agent]]:: `Function` -- Override the way that the client creates node.js `Agent`[https://nodejs.org/api/http.html#http_class_http_agent] objects. The value of this property will be executed every time a new Node is added to the client (either from the initial seed or from sniffing) and can return any value that node's http(s) module accepts as `agent:` configuration.
++
+The function is called with two arguments, first an `HttpConnector`[http://github.com/spalger/elasticsearch-js/blob/master/src/lib/connectors/http.js] object and the second the config object initially passed when creating the client.
+
+Default::: `HttpConnector#createAgent()`
+
+Disable Agent creation:::
++
+[source,js]
+-----
+var client = new elasticsearch.Client({
+  createNodeAgent: function () {
+    return false;
+  }
+});
+-----
+
+
+
+
 === Examples
 
 Connect to just a single seed node, and use sniffing to find the rest of the cluster.
@@ -333,23 +354,4 @@ var client = new elasticsearch.Client({
     }, []);
   }
 })
------
-
-
-
-`createNodeAgent`[[config-createNodeAgent]]:: `Function` -- Override the way that the client creates node.js `Agent`[https://nodejs.org/api/http.html#http_class_http_agent] objects. The value of this property will be executed every time a new Node is added to the client (either from the initial seed or from sniffing) and can return any value that node's http(s) module accepts as `agent:` configuration.
-+
-The function is called with two arguments, first an `HttpConnector`[http://github.com/spalger/elasticsearch-js/blob/master/src/lib/connectors/http.js] object and the second the config object initially passed when creating the client.
-
-Default::: `HttpConnector#createAgent()`
-
-Disable Agent creation:::
-+
-[source,js]
------
-var client = new elasticsearch.Client({
-  createNodeAgent: function () {
-    return false;
-  }
-});
 -----

--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -44,7 +44,7 @@ function HttpConnector(host, config) {
     maxSockets: 11
   });
 
-  this.agent = this.createAgent(config);
+  this.agent = config.createNodeAgent ? config.createNodeAgent(this, config) : this.createAgent(config);
 }
 _.inherits(HttpConnector, ConnectionAbstract);
 

--- a/test/unit/specs/http_connector.js
+++ b/test/unit/specs/http_connector.js
@@ -64,6 +64,17 @@ describe('Http Connector', function () {
         var con = new HttpConnection(new Host('thrifty://es.com/stuff'));
       }).to.throwError(/invalid protocol/i);
     });
+
+    it('allows defining a custom agent', function () {
+      var football = {};
+      var con = new HttpConnection(new Host(), { createNodeAgent: _.constant(football) });
+      expect(con.agent).to.be(football);
+    });
+
+    it('allows setting agent to false', function () {
+      var con = new HttpConnection(new Host(), { createNodeAgent: _.constant(false) });
+      expect(con.agent).to.be(false);
+    });
   });
 
   describe('#makeReqParams', function () {


### PR DESCRIPTION
Fixes #327 

Implements a `createNodeAgent()` function for the config ([see docs](https://github.com/spalger/elasticsearch-js/blob/809f545dee261547a0849cba6c83ca8c5e351918/docs/configuration.asciidoc#user-content-config-create-node-agent))