### PR TITLE
Enhance HTTP connector / transport error messages with more detail

### DIFF
--- a/src/lib/transport.js
+++ b/src/lib/transport.js
@@ -226,12 +226,24 @@ Transport.prototype.request = function (params, cb) {
 
     if (err) {
       connection.setStatus('dead');
+
+      var errMsg = err.message || '';
+
+      errMsg =
+        "\n" +
+        params.req.method +
+        ' ' +
+        connection.host.makeUrl(params.req) +
+        (errMsg.length ? ' => ' : '') +
+        errMsg
+      ;
+
       if (remainingRetries) {
         remainingRetries--;
-        self.log.error('Request error, retrying' + (err.message ? ' -- ' + err.message : ''));
+        self.log.error('Request error, retrying' + errMsg);
         self.connectionPool.select(sendReqWithConnection);
       } else {
-        self.log.error('Request complete with error' + (err.message ? ' -- ' + err.message : ''));
+        self.log.error('Request complete with error' + errMsg);
         respond(new errors.ConnectionFault(err));
       }
     } else {


### PR DESCRIPTION
See #226. Another approach would be to construct the request information in `src/lib/transport` and leave `src/lib/connectors/http` untouched, if it's preferable for some reason. I don't have a great understanding of how the connectors / transport interact. Either way, [this](https://github.com/jmm/elasticsearch-js/blob/7bc7d0becbd42255d7d5c0187664f217dbdf28be/src/lib/connectors/http.js#L154-L163) is duplicating code from [`src/lib/log`](https://github.com/elastic/elasticsearch-js/blob/0e3fe1586fd867275fd0e9abb7126724be3d3761/src/lib/log.js#L292-L298) for massaging the request data to be suitable input for `url.format()`. So perhaps that should be extracted and shared.

I'm checking this with something like:

```js
new elasticsearch.Transport({
  host: 'whatever.example:9200',
  log: 'error',
})
.request({
  method: "GET",
  path: "/whatever",
})
```

(That's not the greatest example because the existing error message for that actually includes the hostname, but just imagine it's `... => socket hang up`.)
