### PR TITLE
Update host.js => window.location is not defined

### DIFF
--- a/src/lib/host.js
+++ b/src/lib/host.js
@@ -12,7 +12,7 @@ var startsWithProtocolRE = /^([a-z]+:)?\/\//;
 var defaultProto = 'http:';
 var btoa;
 
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' && typeof window.location !== 'undefined') {
   defaultProto = window.location.protocol;
   btoa = window.btoa;
 }


### PR DESCRIPTION
window can be defined and yet window.location can be undefined: both "window" and  "window.location" must be defined to access to "protocol" information.

I encountered this problem where "window" was defined but not "window.location". This append when transpiling js file in a express-react-browserify env.

Regards