### PR TITLE
Fix  #324

### DIFF
--- a/src/lib/connection.js
+++ b/src/lib/connection.js
@@ -22,6 +22,8 @@ function ConnectionAbstract(host, config) {
     throw new TypeError('Missing host');
   } else if (host instanceof Host) {
     this.host = host;
+  } else if (typeof host === "string"){
+    this.host = new Host(host);
   } else {
     throw new TypeError('Invalid host');
   }

--- a/test/unit/specs/connection_abstract.js
+++ b/test/unit/specs/connection_abstract.js
@@ -15,6 +15,15 @@ describe('Connection Abstract', function () {
     expect(conn.host).to.be(host);
   });
 
+  it('constructs with string host using Host constructor', function(){
+    var host = 'localhost';
+    var port = 9200;
+    var hostUrl = host+':'+port;
+    var conn = new ConnectionAbstract(hostUrl);
+    expect(conn.host.host).to.be(host);
+    expect(conn.host.port).to.be(port);
+  });
+
   it('requires a valid host', function () {
     expect(function () {
       new ConnectionAbstract();


### PR DESCRIPTION
Added support for string hosts in ConnectionAbstract constructor.
Host constructor is used with supplied host string to create host object for ConnectionAbstract.
With this fix it will be possible again to configure ES connection dynamically as was described in #137