### PR TITLE
Use JSON.stringify to log objects

### DIFF
--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -182,7 +182,7 @@ Log.parseLevels = function (input) {
 Log.join = function (arrayish) {
   return _.map(arrayish, function (item) {
     if (_.isPlainObject(item)) {
-      return _.inspect(item) + '\n';
+      return JSON.stringify(item, null, 2) + '\n';
     } else {
       return item.toString();
     }

--- a/test/unit/specs/log.js
+++ b/test/unit/specs/log.js
@@ -97,7 +97,13 @@ describe('Log class', function () {
       expect(Log.join(['foo', 'bar'])).to.eql('foo bar');
     });
     it('stringifies objects', function () {
-      expect(Log.join([{ foo: 'bar' }])).to.eql('{ foo: \'bar\' }\n');
+      expect(Log.join([{ foo: 'bar' }])).to.eql('{\n  "foo": "bar"\n}\n');
+    });
+
+    it('fully stringifies deeply nested objects', function() {
+      var object = { foo: { bar: { baz: 'value' } } };
+      var expected = '{\n  "bar": {\n    "baz": "value"\n  }\n}\n';
+      expect(Log.join(object)).to.eql(expected);
     });
   });
 


### PR DESCRIPTION
There are two major advantages to JSON.stringify over util.inspect:

1.) JSON.stringify defaults to recursively printing deeply nested
objects.

2.) JSON.stringify output is JSON, meaning it can be taken directly from
the output and used wherever JSON is accepted. util.inspect output is
JSON-like, but also includes other annotation such as the types of
various values, as well as functions on objects.

One possible downside is that JSON.stringify cannot print objects with
recursive structure without fore-knowledge of that structure, which is
of course not possible in a logger.

Note: I have a particular use case in mind with this pull request: when
listening to the `debug` log level, the Elasticsearch module prints every
Elasticsearch query, which is excellent. However, due to the nature of
util.inspect, those queries are usually not fully printed (because they
are generally deeply nested), and are not JSON, which means they can't
be easily copied for use with `curl`, Sense, etc.

I'd love this workflow to be supportive natively with the Elasticsearch
module, and I suspect there are _many_ people like us who are frequently
writing our own debug code to print out ES queries to copy to Sense for
further analysis. It would be great if this was supported out of the box
with the Elasticsearch module.

Thanks!