### PR TITLE
handle node 3+ Eventlistener prototype

### DIFF
--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -63,12 +63,17 @@ Log.prototype.close = function () {
 };
 
 Log.prototype.listenerCount = function (event) {
+  // node >= 3.0 supports EE#listenerCount()
+  if (EventEmitter.prototype.listenerCount) {
+    return EventEmitter.prototype.listenerCount.call(this, event);
+  }
+
   // compatability for node < 0.10
   if (EventEmitter.listenerCount) {
     return EventEmitter.listenerCount(this, event);
-  } else {
-    return this.listeners(event).length;
   }
+
+  return this.listeners(event).length;
 };
 
 /**


### PR DESCRIPTION
This patches the 3.1 branch to allow it to work in nodejs 3.x + environments. Note: I have only tested our use case. I have not run thorough tests of all ES methods. 

Suggest releasing as 3.1.4.

See #310.