### PR TITLE
Make sure null is sent as the body of a request when the body is empty

### DIFF
--- a/src/lib/connectors/xhr.js
+++ b/src/lib/connectors/xhr.js
@@ -79,7 +79,7 @@ XhrConnector.prototype.request = function (params, cb) {
     }
   };
 
-  xhr.send(params.body || void 0);
+  xhr.send(params.body || null);
 
   return function () {
     xhr.abort();


### PR DESCRIPTION
Currently the xhr request is sending undefined when the body is empty, however this causes IE11 to put the string "undefined" in the request body, triggering ElasticSearch to error out on a document search with `Failed to derive xcontent from org.elasticsearch.common.bytes.ChannelBufferBytesReference`
