### PR TITLE
fixes typo in quick start doc

### DIFF
--- a/docs/quick_start.asciidoc
+++ b/docs/quick_start.asciidoc
@@ -127,7 +127,7 @@ var searchParams = {
       filtered: {
         query: {
           match: {
-            // match the query agains all of
+            // match the query against all of
             // the fields in the posts index
             _all: userQuery
           }


### PR DESCRIPTION
there was a missing t for the word against on line 130 of the quick start document

line use to read:
// match the query agains all of