### PR TITLE
Pass the Client instance to ClientAction namespaceFactory

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -58,7 +58,7 @@ function Client(config) {
 
     _.each(EsApiClient.prototype, _.bind(function (Fn, prop) {
       if (Fn.prototype instanceof clientAction.ApiNamespace) {
-        this[prop] = new Fn(this.transport);
+        this[prop] = new Fn(this.transport, this);
       }
     }, this));
 

--- a/src/lib/client_action.js
+++ b/src/lib/client_action.js
@@ -24,8 +24,9 @@ exports._resolveUrl = resolveUrl;
 
 exports.ApiNamespace = function () {};
 exports.namespaceFactory = function () {
-  function ClientNamespace(transport) {
+  function ClientNamespace(transport, client) {
     this.transport = transport;
+    this.client = client;
   }
 
   ClientNamespace.prototype = new exports.ApiNamespace();


### PR DESCRIPTION
This PR makes the client instance available to namespaced plugins.

I was planning to add tests, but it doesn't look like there are currently any tests for the namespace stuff.