### PR TITLE
added putMapping functionality when index is not present at the initial stage

### DIFF
--- a/src/lib/apis/2_0.js
+++ b/src/lib/apis/2_0.js
@@ -3483,6 +3483,14 @@ api.indices.prototype.putMapping = ca({
           type: 'string'
         }
       }
+    },
+    {
+      fmt: '/<%=index%>',
+      req: {
+        index: {
+          type: 'list'
+        }
+      }
     }
   ],
   needBody: true,

--- a/src/lib/apis/2_1.js
+++ b/src/lib/apis/2_1.js
@@ -3628,6 +3628,14 @@ api.indices.prototype.putMapping = ca({
           type: 'string'
         }
       }
+    },
+    {
+      fmt: '/<%=index%>',
+      req: {
+        index: {
+          type: 'list'
+        }
+      }
     }
   ],
   needBody: true,

--- a/src/lib/apis/2_2.js
+++ b/src/lib/apis/2_2.js
@@ -3642,6 +3642,14 @@ api.indices.prototype.putMapping = ca({
           type: 'string'
         }
       }
+    },
+    {
+      fmt: '/<%=index%>',
+      req: {
+        index: {
+          type: 'list'
+        }
+      }
     }
   ],
   needBody: true,

--- a/src/lib/apis/2_3.js
+++ b/src/lib/apis/2_3.js
@@ -3651,6 +3651,14 @@ api.indices.prototype.putMapping = ca({
           type: 'string'
         }
       }
+    },
+    {
+      fmt: '/<%=index%>',
+      req: {
+        index: {
+          type: 'list'
+        }
+      }
     }
   ],
   needBody: true,

--- a/src/lib/apis/2_4.js
+++ b/src/lib/apis/2_4.js
@@ -3651,6 +3651,14 @@ api.indices.prototype.putMapping = ca({
           type: 'string'
         }
       }
+    },
+    {
+      fmt: '/<%=index%>',
+      req: {
+        index: {
+          type: 'list'
+        }
+      }
     }
   ],
   needBody: true,


### PR DESCRIPTION
**Issue** : The putMapping API was throwing exceptions, when we try to put a mapping related to an index and there is no such index present.

**Expected result** : It should have created the index and then have saved the respective mapping.

According to the [putMapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html) documentation, ES supports the above scenario.

Hence I went ahead to find that the mapping was only happening for 2 cases, both of which required an index to be present.

**After this change** : Now users can use putMapping function, and pass only index and the body.
If an user wants to put the mapping at the beginning when the index is not created, this change will let them create a new index and then put the mapping provided.

```
eSClient.indices.putMapping({
  index: index,    // index is the indexName to be created
  body: mapping,   // mapping to be saved
}, (error, response) => {
  if (error) {
    console.error('error while mapping ', error);
  } else {
    console.log('mapping stored for ', index, ' ', response);
  }
});
```

What users have to provide is the json format that the actual document suggest:

```
{
  "mappings" : {
    "indexName" : {
      "properties" : {
        ........
      }
    }
  }
}
```

**Things to take care** : User should handle the cases, when mapping is already present, this will thrown an exception with status code 400 (Mapping exists).

**Suggestions** : Use getMapping before creating the mapping.
If index is not present handle the error status code of 404 to create mapping, and status code of 400 to skip creating the mapping.

**PS** : The changes are only done for 2.x APIs.
