### PR TITLE
Rollback lodash

### DIFF
--- a/grunt/config/esvm.js
+++ b/grunt/config/esvm.js
@@ -1,11 +1,11 @@
-var _ = require('lodash');
+var get = require('lodash.get');
 var utils = require('../utils');
 var fromRoot = require('path').join.bind(null, __dirname, '..', '..');
 
 var release = process.env.ES_RELEASE;
 var ref = process.env.ES_REF;
-var port = parseFloat(_.get(process.env, 'ES_PORT', 9400));
-var host = _.get(process.env, 'ES_HOST', 'localhost');
+var port = parseFloat(get(process.env, 'ES_PORT', 9400));
+var host = get(process.env, 'ES_HOST', 'localhost');
 
 var Version = require('../../scripts/Version');
 var versionedOpts = [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
   "main": "src/elasticsearch.js",
   "homepage": "http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html",
   "version": "13.0.0-alpha1",
-  "keywords" : ["elasticsearch", "mapping", "REST"],
+  "keywords": [
+    "elasticsearch",
+    "mapping",
+    "REST"
+  ],
   "browser": {
     "./src/lib/connectors/index.js": "./src/lib/connectors/browser_index.js",
     "./src/lib/loggers/index.js": "./src/lib/loggers/browser_index.js",
@@ -91,7 +95,8 @@
     "agentkeepalive": "^2.2.0",
     "chalk": "^1.0.0",
     "lodash-node": "~2.4",
-    "lodash.get": "^4.4.2"
+    "lodash.get": "^4.4.2",
+    "lodash.isempty": "^4.4.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
   "dependencies": {
     "agentkeepalive": "^2.2.0",
     "chalk": "^1.0.0",
-    "lodash": "^4.12.0"
+    "lodash-node": "~2.4",
+    "lodash.get": "^4.4.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -94,9 +94,10 @@
   "dependencies": {
     "agentkeepalive": "^2.2.0",
     "chalk": "^1.0.0",
-    "lodash-node": "~2.4",
+    "lodash": "2.4.2",
     "lodash.get": "^4.4.2",
-    "lodash.isempty": "^4.4.0"
+    "lodash.isempty": "^4.4.0",
+    "lodash.trimend": "^4.5.1"
   },
   "repository": {
     "type": "git",

--- a/scripts/Version.js
+++ b/scripts/Version.js
@@ -41,16 +41,14 @@ Version.prototype.satisfies = function (range) {
 // merge a list of option objects, each of which has a "version" key dictating
 // the range of versions those options should be included in. Options are merged
 // in the order of the array
-Version.prototype.mergeOpts = function (opts) {
-  var self = this;
+Version.prototype.mergeOpts = function (versioned, overrides) {
 
-  return opts.filter(function (rule) {
-    return self.satisfies(rule.version);
-  })
-  .map(_.ary(_.partialRight(_.omit, 'version'), 1))
-  .concat(_.tail(arguments))
-  .reverse()
-  .reduce(_.merge, {});
+  const candidates = versioned
+    .filter(o => this.satisfies(o.version))
+    .map(o => _.omit(o, 'version'))
+    .reverse()
+
+  return _.merge({}, overrides || {}, ...candidates)
 };
 
 module.exports = Version;

--- a/scripts/generate/index.js
+++ b/scripts/generate/index.js
@@ -98,7 +98,7 @@ function dirRegex(dir, regexp) {
 function dirOpts(dir, opts) {
   opts = _.isArray(opts) ? opts : [opts];
   return dirFilter(dir, function (name) {
-    return _.includes(opts, name);
+    return _.include(opts, name);
   });
 }
 
@@ -174,7 +174,7 @@ function clearGeneratedFiles() {
   generatedFiles.push(dirRegex(paths.src, esArchives));
 
   var rmSteps = _.chain(generatedFiles)
-  .flattenDeep()
+  .flatten()
   .uniq()
   .map(function (path) {
     return spawnStep('rm', ['-rf', path]);
@@ -202,7 +202,7 @@ function createArchive(branch) {
     var dir = paths.getArchiveDir(branch);
     var tarball = paths.getArchiveTarball(branch);
     var specPathInRepo = paths.getSpecPathInRepo(branch);
-    var subDirCount = _.countBy(specPathInRepo, _.partial(_.eq, '/')).true || 0;
+    var subDirCount = _.countBy(specPathInRepo, p => p === '/').true || 0;
 
     if (isDirectory(dir)) {
       console.log(branch + ' archive already exists');

--- a/scripts/generate/js_api.js
+++ b/scripts/generate/js_api.js
@@ -207,7 +207,7 @@ module.exports = function (branch, done) {
       _.forOwn(allParams, (paramSpec, paramName) => {
         const toMerge = _.get(overrides, ['mergeConcatParams', name, paramName])
         if (toMerge) {
-          _.mergeWith(paramSpec, toMerge, (dest, src) => {
+          _.merge(paramSpec, toMerge, (dest, src) => {
             if (_.isArray(dest) && _.isArray(src)) {
               return dest.concat(src)
             }
@@ -263,7 +263,7 @@ module.exports = function (branch, done) {
 
         urlSignatures.push(_.union(_.keys(optionalVars), _.keys(requiredVars)).sort().join(':'));
 
-        return _.omitBy({
+        return _.omit({
           fmt: url.replace(urlParamRE, function (full, match) {
             return '<%=' + _.camelCase(match) + '%>';
           }),

--- a/scripts/generate/templates/api_file.tmpl
+++ b/scripts/generate/templates/api_file.tmpl
@@ -11,7 +11,7 @@ api._namespaces = <%= stringify(namespaces) %>;<%
 
 _.each(actions, function (action) {
   var namespace = action.location.split('.').shift();
-  if (_.includes(namespaces, namespace)) {
+  if (_.include(namespaces, namespace)) {
     _.pull(namespaces, namespace);
 %>
 

--- a/scripts/generate/templates/index.js
+++ b/scripts/generate/templates/index.js
@@ -112,6 +112,7 @@ fs.readdirSync(path.resolve(__dirname)).forEach(function (filename) {
   if (name !== 'index') {
     templates[name] = _.template(
       fs.readFileSync(path.resolve(__dirname, filename), 'utf8'),
+      null,
       {
         imports: templateGlobals
       }

--- a/src/lib/transport/find_common_protocol.js
+++ b/src/lib/transport/find_common_protocol.js
@@ -1,4 +1,4 @@
-var isEmpty = require('lodash').isEmpty;
+var isEmpty = require('lodash.isempty');
 
 module.exports = function (hosts) {
   if (isEmpty(hosts)) return false;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var nodeUtils = require('util');
+var lodash = require('lodash-node/modern');
 
 /**
  * Custom utils library, basically a modified version of [lodash](http://lodash.com/docs) +
@@ -9,7 +10,7 @@ var nodeUtils = require('util');
  * @class utils
  * @static
  */
-var _ = require('lodash').assign({}, require('lodash'), nodeUtils);
+var _ = lodash.assign({}, lodash, nodeUtils);
 
 /**
  * Link to [path.join](http://nodejs.org/api/path.html#path_path_join_path1_path2)
@@ -18,6 +19,8 @@ var _ = require('lodash').assign({}, require('lodash'), nodeUtils);
  * @type {function}
  */
 _.joinPath = path.join;
+
+_.get = require('lodash.get');
 
 /**
  * Recursively merge two objects, walking into each object and concating arrays. If both to and from have a value at a

--- a/test/fixtures/keepalive.js
+++ b/test/fixtures/keepalive.js
@@ -24,7 +24,7 @@ process.once('message', function (port) {
       .transform(function (sockets, conn) {
         sockets.push(_.values(conn.agent.sockets), _.values(conn.agent.freeSockets));
       }, [])
-      .flattenDeep()
+      .flatten()
       .value();
 
     es.close();


### PR DESCRIPTION
I'm doing some memory tests and from the looks of it lodash 4 is the number one cause for memory-thrashing in esjs version 4+. This reverts to version 2.x temporarily until we can find a better solution.