### PR TITLE
Updating bulk JSON content type

### DIFF
--- a/src/lib/serializers/json.js
+++ b/src/lib/serializers/json.js
@@ -60,4 +60,4 @@ Json.prototype.bulkBody = function (val) {
   return body;
 };
 
-Json.prototype.bulkBody.contentType = 'application/x-ldjson';
+Json.prototype.bulkBody.contentType = 'application/x-ndjson';

--- a/test/unit/specs/transport.js
+++ b/test/unit/specs/transport.js
@@ -505,7 +505,7 @@ describe('Transport Class', function () {
         ];
 
         stub(conn, 'request', function (params) {
-          expect(params.headers).to.have.property('content-type', 'application/x-ldjson');
+          expect(params.headers).to.have.property('content-type', 'application/x-ndjson');
           expect(params.body).to.eql(
             '{"_id":"simple body"}\n' +
             '{"name":"ഢധയമബ"}\n'


### PR DESCRIPTION
Per https://github.com/elastic/elasticsearch/pull/23049 the `application/x-ldjson` content type for bulk requests is being removed in favor of the `application/x-ndjson` content type. This PR updates the Elasticsearch JS client to comply with the Elasticsearch change.