### PR TITLE
export console logger in non browser environments

### DIFF
--- a/src/lib/loggers/index.js
+++ b/src/lib/loggers/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  console: require('./console'),
   file: require('./file'),
   stream: require('./stream'),
   stdio: require('./stdio'),


### PR DESCRIPTION
When using this library in eg. AWS Lambda environment the console logger
is a lot more usefull than stdio.