### PR TITLE
Add elastic-builder to list of query building libraries.

### DIFF
--- a/docs/_descriptions/search.asciidoc
+++ b/docs/_descriptions/search.asciidoc
@@ -1,4 +1,4 @@
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
+TIP: https://github.com/danpaz/bodybuilder[bodybuilder], https://github.com/holidayextras/esq[esq], https://github.com/sudo-suhas/elastic-builder[elastic-builder] or https://github.com/fullscale/elastic.js[elastic.js] can be used to make building query bodies easier.
 

--- a/docs/api_conventions.asciidoc
+++ b/docs/api_conventions.asciidoc
@@ -11,7 +11,7 @@ By default, all api methods accept the following parameters. They are omitted fr
 `body`::
 `String, Anything` -- The body to send along with this request. If the body is a string it will be passed along as is, otherwise it is passed to the serializer and converted to either JSON or a newline separated list of JSON objects based on the API method.
 +
-NOTE: the https://github.com/fullscale/elastic.js[elastic.js] or https://github.com/danpaz/bodybuilder[bodybuilder] libraries can be used to make building request bodies simpler.
+NOTE: the https://github.com/danpaz/bodybuilder[bodybuilder], https://github.com/sudo-suhas/elastic-builder[elastic-builder] or https://github.com/fullscale/elastic.js[elastic.js] libraries can be used to make building request bodies simpler.
 
 `ignore`::
 +

--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -1663,7 +1663,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
+TIP: https://github.com/danpaz/bodybuilder[bodybuilder], https://github.com/holidayextras/esq[esq], or https://github.com/sudo-suhas/elastic-builder[elastic-builder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_2_4.asciidoc
+++ b/docs/api_methods_2_4.asciidoc
@@ -1560,7 +1560,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
+TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], https://github.com/danpaz/bodybuilder[bodybuilder], or https://github.com/sudo-suhas/elastic-builder[elastic-builder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_5_0.asciidoc
+++ b/docs/api_methods_5_0.asciidoc
@@ -1665,7 +1665,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
+TIP: https://github.com/danpaz/bodybuilder[bodybuilder], https://github.com/holidayextras/esq[esq], or https://github.com/sudo-suhas/elastic-builder[elastic-builder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_5_1.asciidoc
+++ b/docs/api_methods_5_1.asciidoc
@@ -1663,7 +1663,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
+TIP: https://github.com/danpaz/bodybuilder[bodybuilder], https://github.com/holidayextras/esq[esq], or https://github.com/sudo-suhas/elastic-builder[elastic-builder] can be used to make building query bodies easier.
 
 
 

--- a/docs/api_methods_5_2.asciidoc
+++ b/docs/api_methods_5_2.asciidoc
@@ -1663,7 +1663,7 @@ client.search([params, [callback]])
 
 Return documents matching a query, aggregations/facets, highlighted snippets, suggestions, and more. Write your queries as either http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html[simple query strings] in the `q` parameter, or by specifying a http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html[full request definition] using the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch Query DSL] in the `body` parameter.
 
-TIP: https://github.com/fullscale/elastic.js[elastic.js], https://github.com/holidayextras/esq[esq], or https://github.com/danpaz/bodybuilder[bodybuilder] can be used to make building query bodies easier.
+TIP: https://github.com/danpaz/bodybuilder[bodybuilder], https://github.com/holidayextras/esq[esq], or https://github.com/sudo-suhas/elastic-builder[elastic-builder] can be used to make building query bodies easier.
 
 
 


### PR DESCRIPTION
Adding [elastic-builder](/sudo-suhas/elastic-builder) to the list of query builders(5.x, 2.4). The library aims for 100% support for the 5.x query/aggregations DSL.

### Code example:
```js
const bob = require('elastic-builder'); // the builder

const requestBody = bob.requestBodySearch()
    .query(
        bob.boolQuery()
            .must(bob.matchQuery('last_name', 'smith'))
            .filter(bob.rangeQuery('age').gt(30))
    );

requestBody.toJSON() 
{ 
    "query" : { 
        "bool" : { 
            "must" : { 
                "match" : { "last_name" : "smith" } 
            }, 
            "filter" : { 
                "range" : { "age" : { "gt" : 30 } } 
            } 
        } 
    } 
} 
```

The library also has 100% test coverage. The docs, which are hosted [here](https://elastic-builder.js.org/docs/), are next on the roadmap for improvement with examples and better presentation.

I have also removed the link(in 5.x docs) to the now defunkt library, [elastic.js](/fullscale/elastic.js) which has not been updated in over 3 years.

Any feedback or suggestions for elastic-builder are welcome.

I have signed the CLA.