### PR TITLE
2017-11-29 added exception handling logic during jQuery.ajax() fail p…

### DIFF
--- a/src/lib/connectors/jquery.js
+++ b/src/lib/connectors/jquery.js
@@ -33,7 +33,14 @@ JqueryConnector.prototype.request = function (params, cb) {
       });
     })
     .fail(function (a, b, err) {
-      cb(new ConnectionFault(err && err.message));
+      // if response is available, execute cb. Else throw ConnectionFault
+      if (a && a.responseText) {
+        cb(null, a.responseText, a.statusCode(), {
+          'content-type': a.getResponseHeader('content-type')
+        });
+      } else {
+        cb(new ConnectionFault(err && err.message));
+      }
     });
 
   return function () {


### PR DESCRIPTION

added logics during jQuery.ajax().fail() promise

if there were any "responseText" available, return this "content" instead of throwing a ConnectionFault exception.

<img width="1267" alt="screen shot 2017-11-29 at 10 57 22 am" src="https://user-images.githubusercontent.com/22022577/33363005-6a9227f4-d519-11e7-86ae-9e934a337369.png">
<img width="800" alt="screen shot 2017-11-29 at 11 05 36 am" src="https://user-images.githubusercontent.com/22022577/33363006-6d854cde-d519-11e7-9427-dbb86b740835.png">

