### PR TITLE
Fix delete vs update by query typo, make consistent

### DIFF
--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -407,7 +407,7 @@ Options:::
 `allowNoIndices`::
 <<api-param-type-boolean,`Boolean`>> -- Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
 `[conflicts=abort]`::
-<<api-param-type-string,`String`>> -- What to do when the delete-by-query hits version conflicts?
+<<api-param-type-string,`String`>> -- What to do when the delete by query hits version conflicts?
 Options:::
  * `"abort"`
  * `"proceed"`
@@ -463,9 +463,9 @@ Options:::
 `waitForActiveShards`::
 <<api-param-type-string,`String`>> -- Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 `scrollSize`::
-<<api-param-type-number,`Number`>> -- Size on the scroll request powering the update_by_query
+<<api-param-type-number,`Number`>> -- Size on the scroll request powering the delete by query
 `[waitForCompletion=true]`::
-<<api-param-type-boolean,`Boolean`>> -- Should the request should block until the delete-by-query is complete.
+<<api-param-type-boolean,`Boolean`>> -- Should the request should block until the delete by query is complete.
 `requestsPerSecond`::
 <<api-param-type-number,`Number`>> -- The throttle for this request in sub-requests per second. -1 means no throttle.
 `[slices=1]`::
@@ -1977,7 +1977,7 @@ Options:::
 `waitForActiveShards`::
 <<api-param-type-string,`String`>> -- Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 `scrollSize`::
-<<api-param-type-number,`Number`>> -- Size on the scroll request powering the update_by_query
+<<api-param-type-number,`Number`>> -- Size on the scroll request powering the update by query
 `[waitForCompletion=true]`::
 <<api-param-type-boolean,`Boolean`>> -- Should the request should block until the update by query operation is complete.
 `requestsPerSecond`::

--- a/docs/api_methods_5_6.asciidoc
+++ b/docs/api_methods_5_6.asciidoc
@@ -522,9 +522,9 @@ Options:::
 `waitForActiveShards`::
 <<api-param-type-string,`String`>> -- Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 `scrollSize`::
-<<api-param-type-number,`Number`>> -- Size on the scroll request powering the update_by_query
+<<api-param-type-number,`Number`>> -- Size on the scroll request powering the delete by query
 `[waitForCompletion=true]`::
-<<api-param-type-boolean,`Boolean`>> -- Should the request should block until the delete-by-query is complete.
+<<api-param-type-boolean,`Boolean`>> -- Should the request should block until the delete by query is complete.
 `requestsPerSecond`::
 <<api-param-type-number,`Number`>> -- The throttle for this request in sub-requests per second. -1 means no throttle.
 `[slices=1]`::
@@ -2414,7 +2414,7 @@ Options:::
 `waitForActiveShards`::
 <<api-param-type-string,`String`>> -- Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 `scrollSize`::
-<<api-param-type-number,`Number`>> -- Size on the scroll request powering the update_by_query
+<<api-param-type-number,`Number`>> -- Size on the scroll request powering the update by query
 `[waitForCompletion=true]`::
 <<api-param-type-boolean,`Boolean`>> -- Should the request should block until the update by query operation is complete.
 `requestsPerSecond`::


### PR DESCRIPTION
In latest and 5.6 API method docs,
- Fixed "update by query" typo that should be "delete by query"
- Attempted to make a little more consistent with `_` vs `-` vs ` `