### PR TITLE
[npm] upgrade agentkeepalive from 2.2.0 to 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "agentkeepalive": "^2.2.0",
+    "agentkeepalive": "^3.4.1",
     "chalk": "^1.0.0",
     "lodash": "2.4.2",
     "lodash.get": "^4.4.2",

--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -94,7 +94,6 @@ HttpConnector.prototype.makeAgentConfig = function (config) {
     maxSockets: config.maxSockets,
     maxFreeSockets: config.keepAliveMaxFreeSockets,
     freeSocketKeepAliveTimeout: config.keepAliveFreeSocketTimeout,
-    keepAliveTimeout: config.keepAliveFreeSocketTimeout // support agentkeepalive 2.x
   };
 
   if (this.useSsl) {


### PR DESCRIPTION
Fixes #640 

Unit tests pass, my limited testing in Kibana didn't bring up any issues, and as far as @mattiasholmlund and I can tell this should work.