### PR TITLE
[webpack] use babel to ensure legacy browser compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,13 @@
     ]
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0-beta.41",
+    "@babel/preset-env": "^7.0.0-beta.41",
     "@spalger/eslint-config-personal": "^0.4.0",
     "aliasify": "^2.1.0",
     "async": "~0.8.0",
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^8.2.2",
+    "babel-loader": "^8.0.0-beta",
     "blanket": "^1.2.3",
     "bluebird": "^2.9.14",
     "browserify": "^16.1.1",
@@ -76,7 +79,7 @@
     "grunt-prompt": "^1.3.3",
     "grunt-run": "^0.6.0",
     "grunt-saucelabs": "^8.6.2",
-    "grunt-webpack": "^1.0.11",
+    "grunt-webpack": "^3.1.1",
     "jquery": "^3.3.1",
     "js-yaml": "^3.6.0",
     "load-grunt-config": "^0.19.2",
@@ -94,8 +97,8 @@
     "split": "~0.3.2",
     "through2": "~0.6.3",
     "through2-map": "~1.4.0",
-    "webpack": "^1.13.0",
-    "webpack-dev-server": "^1.14.1",
+    "webpack": "^3.10.0",
+    "webpack-dev-server": "^2.11.1",
     "xmlbuilder": "~0.4.3"
   },
   "license": "Apache-2.0",
@@ -106,6 +109,9 @@
     "lodash.get": "^4.4.2",
     "lodash.isempty": "^4.4.0",
     "lodash.trimend": "^4.5.1"
+  },
+  "resolutions": {
+    "grunt-webpack/deep-for-each": "https://github.com/spalger/js-deep-for-each/releases/download/v2.0.2-fix-missing-lodash-dep/deep-for-each-2.0.2.tgz"
   },
   "repository": {
     "type": "git",

--- a/webpack_config/angular.js
+++ b/webpack_config/angular.js
@@ -1,5 +1,5 @@
-const DefinePlugin = require('webpack/lib/DefinePlugin')
-const { ignoreLoader, rel } = require('./lib')
+const webpack = require('webpack')
+const { jsLoader, ignoreLoader, rel } = require('./lib')
 
 module.exports = {
   context: rel('src'),
@@ -9,7 +9,8 @@ module.exports = {
     path: rel('dist'),
   },
   module: {
-    loaders: [
+    rules: [
+      jsLoader(),
       ignoreLoader([
         'src/lib/connectors/jquery.js',
         'src/lib/connectors/xhr.js',
@@ -18,7 +19,7 @@ module.exports = {
     ],
   },
   plugins: [
-    new DefinePlugin({
+    new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"',
     }),
   ],

--- a/webpack_config/browser.js
+++ b/webpack_config/browser.js
@@ -1,5 +1,5 @@
-const DefinePlugin = require('webpack/lib/DefinePlugin')
-const { ignoreLoader, rel } = require('./lib')
+const webpack = require('webpack')
+const { jsLoader, ignoreLoader, rel } = require('./lib')
 
 module.exports = {
   context: rel('src'),
@@ -11,7 +11,8 @@ module.exports = {
     libraryTarget: 'umd'
   },
   module: {
-    loaders: [
+    rules: [
+      jsLoader(),
       ignoreLoader([
         'src/lib/connectors/jquery.js',
         'src/lib/connectors/angular.js'
@@ -19,7 +20,7 @@ module.exports = {
     ],
   },
   plugins: [
-    new DefinePlugin({
+    new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"',
     }),
   ],

--- a/webpack_config/jquery.js
+++ b/webpack_config/jquery.js
@@ -1,5 +1,5 @@
-const DefinePlugin = require('webpack/lib/DefinePlugin')
-const { ignoreLoader, rel } = require('./lib')
+const webpack = require('webpack')
+const { jsLoader, ignoreLoader, rel } = require('./lib')
 
 module.exports = {
   context: rel('src'),
@@ -9,7 +9,8 @@ module.exports = {
     path: rel('dist'),
   },
   module: {
-    loaders: [
+    rules: [
+      jsLoader(),
       ignoreLoader([
         'src/lib/connectors/angular.js',
         'src/lib/connectors/xhr.js',
@@ -18,7 +19,7 @@ module.exports = {
     ],
   },
   plugins: [
-    new DefinePlugin({
+    new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"',
     }),
   ],

--- a/webpack_config/lib.js
+++ b/webpack_config/lib.js
@@ -12,9 +12,23 @@ function ignoreLoader(ignores) {
 
 function jsLoader() {
   return {
-    loader: 'babel-loader',
     test: /\.js$/,
     include: rel('src'),
+    loader: 'babel-loader',
+    options: {
+      babelrc: false,
+      presets: [
+        ['@babel/preset-env', {
+          targets: {
+            browsers: [
+              'last 2 versions',
+              '> 5%',
+              'Safari 7', // for PhantomJS support
+            ]
+          }
+        }]
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
Inspired by @dominykas question in #630 I decided to look into browser version support and realized that there wasn't any transpiling happening to make sure that browser client is compatible with legacy browsers like IE 11. This fixes that by transpiling the bundles with the `@babel/preset-env` targeting `last 2 versions, > 5%, Safari 7, // for PhantomJS support`, which currently translates to:

http://browserl.ist/?q=last+2+versions%2C+%3E+5%25%2C+Safari+7

![image](https://user-images.githubusercontent.com/1329312/37491758-11dd549e-285c-11e8-9bef-406a1a7d266b.png)
