### PR TITLE
Update docs to use async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,18 +70,19 @@ client.ping({
 
 Skip the callback to get a promise back
 ```js
-client.search({
-  q: 'pants'
-}).then(function (body) {
-  var hits = body.hits.hits;
-}, function (error) {
-  console.trace(error.message);
-});
+try {
+  const response = await client.search({
+    q: 'pants'
+  });
+  console.log(response.hits.hits)
+} catch (error) {
+  console.trace(error.message)
+}
 ```
 
 Find tweets that have "elasticsearch" in their body field
 ```js
-client.search({
+const response = await client.search({
   index: 'twitter',
   type: 'tweets',
   body: {
@@ -91,11 +92,11 @@ client.search({
       }
     }
   }
-}).then(function (resp) {
-    var hits = resp.hits.hits;
-}, function (err) {
-    console.trace(err.message);
-});
+})
+
+for (const tweet of response.hits.hits) {
+  console.log('tweet:', tweet);
+}
 ```
 
 More examples and detailed information about each method are available [here](http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html)

--- a/docs/_examples/cluster.nodeInfo.asciidoc
+++ b/docs/_examples/cluster.nodeInfo.asciidoc
@@ -1,10 +1,7 @@
 .Return information about JVM
 [source,js]
 ---------
-client.cluster.nodeInfo({ jvm: true })
-  .then(function (response) {
-    // enjoy your sweet info!
-  }, function (error) {
-    // scream!
-  })
+const response = await client.cluster.nodeInfo({
+  jvm: true
+});
 ---------

--- a/docs/_examples/count.asciidoc
+++ b/docs/_examples/count.asciidoc
@@ -1,26 +1,21 @@
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -33,7 +28,5 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------

--- a/docs/_examples/create.asciidoc
+++ b/docs/_examples/create.asciidoc
@@ -1,7 +1,7 @@
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -12,7 +12,5 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------

--- a/docs/_examples/delete.asciidoc
+++ b/docs/_examples/delete.asciidoc
@@ -1,11 +1,9 @@
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------

--- a/docs/_examples/deleteByQuery.asciidoc
+++ b/docs/_examples/deleteByQuery.asciidoc
@@ -1,25 +1,21 @@
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------

--- a/docs/_examples/exists.asciidoc
+++ b/docs/_examples/exists.asciidoc
@@ -1,15 +1,9 @@
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------

--- a/docs/_examples/explain.asciidoc
+++ b/docs/_examples/explain.asciidoc
@@ -1,7 +1,7 @@
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -9,15 +9,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -26,7 +24,5 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------

--- a/docs/_examples/get.asciidoc
+++ b/docs/_examples/get.asciidoc
@@ -1,11 +1,9 @@
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------

--- a/docs/_examples/index.asciidoc
+++ b/docs/_examples/index.asciidoc
@@ -1,7 +1,7 @@
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -10,7 +10,5 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------

--- a/docs/_examples/indices.updateAliases.asciidoc
+++ b/docs/_examples/indices.updateAliases.asciidoc
@@ -1,14 +1,12 @@
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------

--- a/docs/_examples/mget.asciidoc
+++ b/docs/_examples/mget.asciidoc
@@ -1,7 +1,7 @@
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -9,21 +9,17 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------

--- a/docs/_examples/mlt.asciidoc
+++ b/docs/_examples/mlt.asciidoc
@@ -1,12 +1,10 @@
 .Search for similar documents using the `title` property of document `myindex/mytype/1`
 [source,js]
 ---------
-client.mlt({
+const response = await client.mlt({
   index: 'myindex',
   type: 'mytype',
   id: 1,
   mlt_fields: 'title'
-}, function (errors, response) {
-  // ...
 });
 ---------

--- a/docs/_examples/msearch.asciidoc
+++ b/docs/_examples/msearch.asciidoc
@@ -1,7 +1,7 @@
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},

--- a/docs/_examples/percolate.asciidoc
+++ b/docs/_examples/percolate.asciidoc
@@ -1,43 +1,41 @@
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -45,15 +43,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -61,14 +59,14 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------

--- a/docs/_examples/scroll.asciidoc
+++ b/docs/_examples/scroll.asciidoc
@@ -1,28 +1,38 @@
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------

--- a/docs/_examples/search.asciidoc
+++ b/docs/_examples/search.asciidoc
@@ -1,18 +1,16 @@
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -28,7 +26,5 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------

--- a/docs/_examples/suggest.asciidoc
+++ b/docs/_examples/suggest.asciidoc
@@ -1,17 +1,18 @@
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -30,5 +31,5 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------

--- a/docs/_examples/update.asciidoc
+++ b/docs/_examples/update.asciidoc
@@ -1,7 +1,7 @@
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -11,15 +11,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -27,15 +25,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -45,15 +41,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -63,7 +57,5 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------

--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -116,26 +116,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -148,8 +143,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -218,7 +211,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -229,10 +222,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -292,14 +284,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -357,28 +348,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -519,18 +507,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -645,7 +628,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -653,15 +636,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -670,10 +651,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -774,14 +754,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -921,7 +900,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -930,10 +909,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1015,7 +993,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1023,24 +1001,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1086,7 +1061,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1401,30 +1376,40 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------
 
 
@@ -1460,18 +1445,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1487,10 +1470,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1777,7 +1759,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1787,15 +1769,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1803,15 +1783,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -1821,15 +1799,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1839,10 +1815,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4419,17 +4394,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_0_90.asciidoc
+++ b/docs/api_methods_0_90.asciidoc
@@ -109,26 +109,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -141,8 +136,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -189,7 +182,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -200,10 +193,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -270,14 +262,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -338,28 +329,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -426,18 +414,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -479,7 +462,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -487,15 +470,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -504,10 +485,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -573,14 +553,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -685,7 +664,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -694,10 +673,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -786,7 +764,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -794,24 +772,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -855,15 +830,14 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search for similar documents using the `title` property of document `myindex/mytype/1`
 [source,js]
 ---------
-client.mlt({
+const response = await client.mlt({
   index: 'myindex',
   type: 'mytype',
   id: 1,
   mlt_fields: 'title'
-}, function (errors, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -933,7 +907,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -985,43 +959,41 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1029,15 +1001,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1045,17 +1017,18 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------
+
 
 
 *Params*
@@ -1163,18 +1136,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1190,10 +1161,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1302,17 +1272,18 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -1331,8 +1302,9 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------
+
 
 
 *Params*
@@ -1375,7 +1347,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1385,15 +1357,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1401,15 +1371,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -1419,15 +1387,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1437,10 +1403,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1628,13 +1593,11 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return information about JVM
 [source,js]
 ---------
-client.cluster.nodeInfo({ jvm: true })
-  .then(function (response) {
-    // enjoy your sweet info!
-  }, function (error) {
-    // scream!
-  })
+const response = await client.cluster.nodeInfo({
+  jvm: true
+});
 ---------
+
 
 
 *Params*
@@ -2952,17 +2915,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_1_7.asciidoc
+++ b/docs/api_methods_1_7.asciidoc
@@ -111,26 +111,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -143,8 +138,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -272,7 +265,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -283,10 +276,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -353,14 +345,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -423,28 +414,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -587,18 +575,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -640,7 +623,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -648,15 +631,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -665,10 +646,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -777,14 +757,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -969,7 +948,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -978,10 +957,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1070,7 +1048,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1078,24 +1056,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1139,15 +1114,14 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search for similar documents using the `title` property of document `myindex/mytype/1`
 [source,js]
 ---------
-client.mlt({
+const response = await client.mlt({
   index: 'myindex',
   type: 'mytype',
   id: 1,
   mlt_fields: 'title'
-}, function (errors, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1254,7 +1228,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1355,43 +1329,41 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1399,15 +1371,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1415,17 +1387,18 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------
+
 
 
 *Params*
@@ -1656,18 +1629,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1683,10 +1654,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1966,17 +1936,18 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -1995,8 +1966,9 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------
+
 
 
 *Params*
@@ -2092,7 +2064,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2102,15 +2074,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2118,15 +2088,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -2136,15 +2104,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2154,10 +2120,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4340,17 +4305,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_2_4.asciidoc
+++ b/docs/api_methods_2_4.asciidoc
@@ -107,26 +107,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -139,8 +134,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -268,7 +261,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -279,10 +272,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -343,14 +335,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -479,18 +470,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -532,7 +518,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -540,15 +526,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -557,10 +541,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -669,14 +652,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -861,7 +843,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -870,10 +852,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -956,7 +937,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -964,24 +945,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1066,7 +1044,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1177,43 +1155,41 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1221,15 +1197,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1237,17 +1213,18 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------
+
 
 
 *Params*
@@ -1568,18 +1545,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1595,10 +1570,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1878,17 +1852,18 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -1907,8 +1882,9 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------
+
 
 
 *Params*
@@ -2016,7 +1992,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2026,15 +2002,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2042,15 +2016,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -2060,15 +2032,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2078,10 +2048,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4514,17 +4483,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_5_0.asciidoc
+++ b/docs/api_methods_5_0.asciidoc
@@ -116,26 +116,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -148,8 +143,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -277,7 +270,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -288,10 +281,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -355,14 +347,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -420,28 +411,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -605,18 +593,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -658,7 +641,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -666,15 +649,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -683,10 +664,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -795,14 +775,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -967,7 +946,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -976,10 +955,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1065,7 +1043,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1073,24 +1051,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1175,7 +1150,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1321,43 +1296,41 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1365,15 +1338,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1381,17 +1354,18 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------
+
 
 
 *Params*
@@ -1615,30 +1589,40 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------
 
 
@@ -1674,18 +1658,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1701,10 +1683,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1919,17 +1900,18 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -1948,8 +1930,9 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------
+
 
 
 *Params*
@@ -2055,7 +2038,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2065,15 +2048,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2081,15 +2062,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -2099,15 +2078,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2117,10 +2094,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4561,17 +4537,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_5_1.asciidoc
+++ b/docs/api_methods_5_1.asciidoc
@@ -116,26 +116,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -148,8 +143,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -275,7 +268,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -286,10 +279,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -353,14 +345,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -418,28 +409,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -603,18 +591,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -656,7 +639,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -664,15 +647,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -681,10 +662,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -791,14 +771,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -963,7 +942,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -972,10 +951,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1061,7 +1039,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1069,24 +1047,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1171,7 +1146,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1317,43 +1292,41 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1361,15 +1334,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1377,17 +1350,18 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------
+
 
 
 *Params*
@@ -1613,30 +1587,40 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------
 
 
@@ -1672,18 +1656,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1699,10 +1681,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1919,17 +1900,18 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -1948,8 +1930,9 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------
+
 
 
 *Params*
@@ -2055,7 +2038,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2065,15 +2048,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2081,15 +2062,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -2099,15 +2078,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2117,10 +2094,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4638,17 +4614,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_5_2.asciidoc
+++ b/docs/api_methods_5_2.asciidoc
@@ -116,26 +116,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -148,8 +143,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -275,7 +268,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -286,10 +279,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -353,14 +345,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -418,28 +409,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -603,18 +591,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -656,7 +639,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -664,15 +647,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -681,10 +662,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -791,14 +771,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -963,7 +942,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -972,10 +951,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1061,7 +1039,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1069,24 +1047,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1171,7 +1146,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1317,43 +1292,41 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1361,15 +1334,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1377,17 +1350,18 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------
+
 
 
 *Params*
@@ -1613,30 +1587,40 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------
 
 
@@ -1672,18 +1656,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1699,10 +1681,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1919,17 +1900,18 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -1948,8 +1930,9 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------
+
 
 
 *Params*
@@ -2055,7 +2038,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2065,15 +2048,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2081,15 +2062,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -2099,15 +2078,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2117,10 +2094,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4638,17 +4614,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_5_3.asciidoc
+++ b/docs/api_methods_5_3.asciidoc
@@ -116,26 +116,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -148,8 +143,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -275,7 +268,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -286,10 +279,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -353,14 +345,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -418,28 +409,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -603,18 +591,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -656,7 +639,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -664,15 +647,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -681,10 +662,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -791,14 +771,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -963,7 +942,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -972,10 +951,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1061,7 +1039,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1069,24 +1047,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1171,7 +1146,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1317,43 +1292,41 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1361,15 +1334,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1377,17 +1350,18 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------
+
 
 
 *Params*
@@ -1613,30 +1587,40 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------
 
 
@@ -1672,18 +1656,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1699,10 +1681,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1919,17 +1900,18 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -1948,8 +1930,9 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------
+
 
 
 *Params*
@@ -2055,7 +2038,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2065,15 +2048,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2081,15 +2062,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -2099,15 +2078,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2117,10 +2094,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4624,17 +4600,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_5_4.asciidoc
+++ b/docs/api_methods_5_4.asciidoc
@@ -116,26 +116,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -148,8 +143,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -275,7 +268,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -286,10 +279,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -353,14 +345,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -418,28 +409,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -603,18 +591,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -729,7 +712,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -737,15 +720,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -754,10 +735,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -903,14 +883,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1075,7 +1054,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1084,10 +1063,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1173,7 +1151,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1181,24 +1159,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1283,7 +1258,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1433,43 +1408,41 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1477,15 +1450,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1493,17 +1466,18 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------
+
 
 
 *Params*
@@ -1729,30 +1703,40 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------
 
 
@@ -1788,18 +1772,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1815,10 +1797,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -2041,17 +2022,18 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -2070,8 +2052,9 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------
+
 
 
 *Params*
@@ -2177,7 +2160,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2187,15 +2170,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2203,15 +2184,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -2221,15 +2200,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2239,10 +2216,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4754,17 +4730,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_5_5.asciidoc
+++ b/docs/api_methods_5_5.asciidoc
@@ -116,26 +116,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -148,8 +143,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -275,7 +268,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -286,10 +279,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -353,14 +345,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -418,28 +409,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -603,18 +591,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -729,7 +712,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -737,15 +720,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -754,10 +735,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -903,14 +883,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1075,7 +1054,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1084,10 +1063,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1173,7 +1151,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1181,24 +1159,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1283,7 +1258,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1435,43 +1410,41 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1479,15 +1452,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1495,17 +1468,18 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------
+
 
 
 *Params*
@@ -1731,30 +1705,40 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------
 
 
@@ -1790,18 +1774,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1817,10 +1799,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -2043,17 +2024,18 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -2072,8 +2054,9 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------
+
 
 
 *Params*
@@ -2179,7 +2162,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2189,15 +2172,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2205,15 +2186,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -2223,15 +2202,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2241,10 +2218,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4756,17 +4732,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_5_6.asciidoc
+++ b/docs/api_methods_5_6.asciidoc
@@ -116,26 +116,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -148,8 +143,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -277,7 +270,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -288,10 +281,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -355,14 +347,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -420,28 +411,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -609,18 +597,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -735,7 +718,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -743,15 +726,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -760,10 +741,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -909,14 +889,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1081,7 +1060,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1090,10 +1069,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1179,7 +1157,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1187,24 +1165,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1289,7 +1264,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1443,43 +1418,41 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .First, Register queries named “alert-1” and “alert-2” for the “myindex” index
 [source,js]
 ---------
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-1',
-  body: {
-    // This query will be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'foo'
+await Promise.all([
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-1',
+    body: {
+      // This query will be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'foo'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  }),
 
-client.index({
-  index: 'myindex',
-  type: '.percolator',
-  id: 'alert-2',
-  body: {
-    // This query will also be run against documents sent to percolate
-    query: {
-      query_string: {
-        query: 'bar'
+  client.index({
+    index: 'myindex',
+    type: '.percolator',
+    id: 'alert-2',
+    body: {
+      // This query will also be run against documents sent to percolate
+      query: {
+        query_string: {
+          query: 'bar'
+        }
       }
     }
-  }
-}, function (error, response) {
-  // ...
-});
+  })
+]);
 ---------
 
 .Then you can send documents to learn which query `_percolator` queries they match
 [source,js]
 ---------
-client.percolate({
+const response1 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1487,15 +1460,15 @@ client.percolate({
       title: "Foo"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 1,
-  //   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
-  // }
 });
 
-client.percolate({
+// response1 should look something like
+// {
+//   total: 1,
+//   matches: [ { _index: 'myindex', _id: 'alert-1' } ]
+// }
+
+const response2 = await client.percolate({
   index: 'myindex',
   type: 'mytype',
   body: {
@@ -1503,17 +1476,18 @@ client.percolate({
       title: "Foo Bar"
     }
   }
-}, function (error, response) {
-  // response would equal
-  // {
-  //   total: 2,
-  //   matches: [
-  //     { _index: 'myindex', _id: 'alert-1' },
-  //     { _index: 'myindex', _id: 'alert-2' }
-  //   ]
-  // }
 });
+
+// response2 should look something like
+// {
+//   total: 2,
+//   matches: [
+//     { _index: 'myindex', _id: 'alert-1' },
+//     { _index: 'myindex', _id: 'alert-2' }
+//   ]
+// }
 ---------
+
 
 
 *Params*
@@ -1743,30 +1717,40 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------
 
 
@@ -1802,18 +1786,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1829,10 +1811,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -2059,17 +2040,18 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Return query terms suggestions (“auto-correction”)
 [source,js]
 ---------
-client.suggest({
-index: 'myindex',
-body: {
-  mysuggester: {
-    text: 'tset',
-    term: {
-      field: 'title'
+const response = await client.suggest({
+  index: 'myindex',
+  body: {
+    mysuggester: {
+      text: 'tset',
+      term: {
+        field: 'title'
+      }
     }
   }
-}
-}, function (error, response) {
+});
+
 // response will be formatted like so:
 //
 // {
@@ -2088,8 +2070,9 @@ body: {
 //     }
 //   ]
 // }
-});
+
 ---------
+
 
 
 *Params*
@@ -2195,7 +2178,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2205,15 +2188,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2221,15 +2202,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -2239,15 +2218,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -2257,10 +2234,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4818,17 +4794,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_6_0.asciidoc
+++ b/docs/api_methods_6_0.asciidoc
@@ -116,26 +116,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -148,8 +143,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -218,7 +211,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -229,10 +222,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -292,14 +284,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -357,28 +348,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -519,18 +507,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -645,7 +628,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -653,15 +636,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -670,10 +651,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -774,14 +754,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -921,7 +900,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -930,10 +909,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1015,7 +993,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1023,24 +1001,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1086,7 +1061,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1374,30 +1349,40 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------
 
 
@@ -1433,18 +1418,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1460,10 +1443,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1750,7 +1732,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1760,15 +1742,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1776,15 +1756,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -1794,15 +1772,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1812,10 +1788,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4363,17 +4338,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/docs/api_methods_6_1.asciidoc
+++ b/docs/api_methods_6_1.asciidoc
@@ -116,26 +116,21 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get the number of all documents in the cluster
 [source,js]
 ---------
-client.count(function (error, response, status) {
-  // check for and handle error
-  var count = response.count;
-});
+const { count } = await client.count();
 ---------
 
 .Get the number of documents in an index
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Get the number of documents matching a query
 [source,js]
 ---------
-client.count({
+const { count } = await client.count({
   index: 'index_name',
   body: {
     query: {
@@ -148,8 +143,6 @@ client.count({
       }
     }
   }
-}, function (err, response) {
-  // ...
 });
 ---------
 
@@ -218,7 +211,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create a document
 [source,js]
 ---------
-client.create({
+await client.create({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -229,10 +222,9 @@ client.create({
     published_at: '2013-01-01',
     counter: 1
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -292,14 +284,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Delete the document `/myindex/mytype/1`
 [source,js]
 ---------
-client.delete({
+await client.delete({
   index: 'myindex',
   type: 'mytype',
   id: '1'
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -357,28 +348,25 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Deleting documents with a simple query
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'myindex',
   q: 'test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Deleting documents using the Query DSL
 [source,js]
 ---------
-client.deleteByQuery({
+await client.deleteByQuery({
   index: 'posts',
   body: {
     query: {
       term: { published: false }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -519,18 +507,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Check that the document `/myindex/mytype/1` exist
 [source,js]
 ---------
-client.exists({
+const exists = await client.exists({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, exists) {
-  if (exists === true) {
-    // ...
-  } else {
-    // ...
-  }
 });
 ---------
+
 
 
 *Params*
@@ -645,7 +628,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .See how a document is scored against a simple query
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   // the document to test
   index: 'myindex',
   type: 'mytype',
@@ -653,15 +636,13 @@ client.explain({
 
   // the query to score it against
   q: 'field:value'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .See how a document is scored against a query written in the Query DSL
 [source,js]
 ---------
-client.explain({
+const response = await client.explain({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -670,10 +651,9 @@ client.explain({
       match: { title: 'test' }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -774,14 +754,13 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Get `/myindex/mytype/1`
 [source,js]
 ---------
-client.get({
+const response = await client.get({
   index: 'myindex',
   type: 'mytype',
   id: 1
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -921,7 +900,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Create or update a document
 [source,js]
 ---------
-client.index({
+const response = await client.index({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -930,10 +909,9 @@ client.index({
     tags: ['y', 'z'],
     published: true,
   }
-}, function (error, response) {
-
 });
 ---------
+
 
 
 *Params*
@@ -1015,7 +993,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .An array of doc locations. Useful for getting documents from different indices.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   body: {
     docs: [
       { _index: 'indexA', _type: 'typeA', _id: '1' },
@@ -1023,24 +1001,21 @@ client.mget({
       { _index: 'indexC', _type: 'typeC', _id: '1' }
     ]
   }
-}, function(error, response){
-  // ...
 });
 ---------
 
 .An array of ids. You must also specify the `index` and `type` that apply to all of the ids.
 [source,js]
 ---------
-client.mget({
+const response = await client.mget({
   index: 'myindex',
   type: 'mytype',
   body: {
     ids: [1, 2, 3]
   }
-}, function(error, response){
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1086,7 +1061,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform multiple different searches, the body is made up of meta/data pairs
 [source,js]
 ---------
-client.msearch({
+const response = await client.msearch({
   body: [
     // match all query, on all indices and types
     {},
@@ -1374,30 +1349,40 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Collect every title in the index that contains the word "test"
 [source,js]
 ---------
-var allTitles = [];
+const allTitles = [];
+const responseQueue = [];
 
-// first we do a search, and specify a scroll timeout
-client.search({
+// start things off by searching, setting a scroll timeout, and pushing
+// our first response into the queue to be processed
+await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
   source: ['title'], // filter the source to only include the title field
   q: 'title:test'
-}, function getMoreUntilDone(error, response) {
-  // collect the title from each response
+})
+
+while (responseQueue.length) {
+  const response = responseQueue.shift();
+
+  // collect the titles from this response
   response.hits.hits.forEach(function (hit) {
-    allTitles.push(hit._source.title);
+    allTitles.push(hit.fields.title);
   });
 
-  if (response.hits.total > allTitles.length) {
-    // ask elasticsearch for the next set of hits from this search
-    client.scroll({
+  // check to see if we have collected all of the titles
+  if (response.hits.total === allTitles.length) {
+    console.log('every "test" title', allTitles);
+    break
+  }
+
+  // get the next response if there are more titles to fetch
+  responseQueue.push(
+    await client.scroll({
       scrollId: response._scroll_id,
       scroll: '30s'
-    }, getMoreUntilDone);
-  } else {
-    console.log('every "test" title', allTitles);
-  }
-});
+    })
+  );
+}
 ---------
 
 
@@ -1433,18 +1418,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Search with a simple query string query
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   q: 'title:test'
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Passing a full request definition in the Elasticsearch's Query DSL as a `Hash`
 [source,js]
 ---------
-client.search({
+const response = await client.search({
   index: 'myindex',
   body: {
     query: {
@@ -1460,10 +1443,9 @@ client.search({
       }
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -1750,7 +1732,7 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Update document title using partial document
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1760,15 +1742,13 @@ client.update({
       title: 'Updated'
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Add a tag to document `tags` property using a `script`
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1776,15 +1756,13 @@ client.update({
     script: 'ctx._source.tags += tag',
     params: { tag: 'some new tag' }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
 
 .Increment a document counter by 1 or initialize it, when the document does not exist
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '777',
@@ -1794,15 +1772,13 @@ client.update({
       counter: 1
     }
   }
-}, function (error, response) {
-  // ...
 })
 ---------
 
 .Delete a document if it's tagged “to-delete”
 [source,js]
 ---------
-client.update({
+const response = await client.update({
   index: 'myindex',
   type: 'mytype',
   id: '1',
@@ -1812,10 +1788,9 @@ client.update({
       tag: 'to-delete'
     }
   }
-}, function (error, response) {
-  // ...
 });
 ---------
+
 
 
 *Params*
@@ -4398,17 +4373,16 @@ Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearc
 .Perform an atomic alias swap, for a rotating index
 [source,js]
 ---------
-client.indices.updateAliases({
+const response = await client.indices.updateAliases({
   body: {
     actions: [
       { remove: { index: 'logstash-2014.04', alias: 'logstash-current' } },
       { add:    { index: 'logstash-2014.05', alias: 'logstash-current' } }
     ]
   }
-}).then(function (response) {
-  // ...
-}, errorHandler);
+});
 ---------
+
 
 
 *Params*

--- a/src/lib/apis/6_x.js
+++ b/src/lib/apis/6_x.js
@@ -3664,6 +3664,7 @@ api.indices.prototype.getMapping = ca({
  * Perform a [indices.getSettings](https://www.elastic.co/guide/en/elasticsearch/reference/6.x/indices-get-settings.html) request
  *
  * @param {Object} params - An object with parameters used to carry out this action
+ * @param {<<api-param-type-duration-string,`DurationString`>>} params.masterTimeout - Specify timeout for connection to master
  * @param {<<api-param-type-boolean,`Boolean`>>} params.ignoreUnavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
  * @param {<<api-param-type-boolean,`Boolean`>>} params.allowNoIndices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
  * @param {<<api-param-type-string,`String`>>} [params.expandWildcards=open,closed] - Whether to expand wildcard expression to concrete indices that are open, closed or both.
@@ -3675,6 +3676,10 @@ api.indices.prototype.getMapping = ca({
  */
 api.indices.prototype.getSettings = ca({
   params: {
+    masterTimeout: {
+      type: 'time',
+      name: 'master_timeout'
+    },
     ignoreUnavailable: {
       type: 'boolean',
       name: 'ignore_unavailable'


### PR DESCRIPTION
Inspired by #666, this updates nearly all examples except the first one in README.md to use `async`/`await` syntax. 