### PR TITLE
[15.x] 📖 fix badly-formatted link in logging docs

### DIFF
--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -165,7 +165,7 @@ Options:
 `String` --  Default is `9200`.
 
 `"stream"`::
-Send log messages to a <a href="http://nodejs.org/api/stream.html#stream_class_stream_writable">WriteableStream</a>
+Send log messages to a http://nodejs.org/api/stream.html#stream_class_stream_writable[WriteableStream]
 +
 Options:
 


### PR DESCRIPTION
Backports the following commits to 15.x:
 - 📖 fix badly-formatted link in logging docs (9c98262)