### PR TITLE
[ping()] determine ping timeout at runtime

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -136,7 +136,7 @@ Default::: `30000`
 Default::: `60000`
 
 
-`pingTimeout`[[config-ping-timeout]]:: `Number` -- Milliseconds that a ping request can take before timing out.
+`pingTimeout`[[config-ping-timeout]]:: `Number` -- Milliseconds that a ping request can take before timing out.  Takes precedence over `requestTimeout` for ping requests.
 
 Default::: `3000`
 

--- a/scripts/generate/js_api.js
+++ b/scripts/generate/js_api.js
@@ -253,10 +253,6 @@ module.exports = function (branch, done) {
         spec.bulkBody = true;
       }
 
-      if (name === 'ping') {
-        spec.requestTimeout = 3000;
-      }
-
       var urls = _.difference(def.url.paths, overrides.aliases[name]);
       var urlSignatures = [];
       urls = _.map(urls, function (url) {

--- a/src/lib/apis/0_90.js
+++ b/src/lib/apis/0_90.js
@@ -2890,7 +2890,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/1_7.js
+++ b/src/lib/apis/1_7.js
@@ -5193,7 +5193,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/2_4.js
+++ b/src/lib/apis/2_4.js
@@ -5133,7 +5133,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/5_0.js
+++ b/src/lib/apis/5_0.js
@@ -5563,7 +5563,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/5_1.js
+++ b/src/lib/apis/5_1.js
@@ -5691,7 +5691,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/5_2.js
+++ b/src/lib/apis/5_2.js
@@ -5692,7 +5692,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/5_3.js
+++ b/src/lib/apis/5_3.js
@@ -5667,7 +5667,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/5_4.js
+++ b/src/lib/apis/5_4.js
@@ -5854,7 +5854,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/5_5.js
+++ b/src/lib/apis/5_5.js
@@ -5858,7 +5858,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/5_6.js
+++ b/src/lib/apis/5_6.js
@@ -5936,7 +5936,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/6_0.js
+++ b/src/lib/apis/6_0.js
@@ -5553,7 +5553,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/6_1.js
+++ b/src/lib/apis/6_1.js
@@ -5597,7 +5597,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/6_2.js
+++ b/src/lib/apis/6_2.js
@@ -5581,7 +5581,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/6_3.js
+++ b/src/lib/apis/6_3.js
@@ -5571,7 +5571,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/6_x.js
+++ b/src/lib/apis/6_x.js
@@ -2700,25 +2700,11 @@ api.indices = namespace();
  *
  * @param {Object} params - An object with parameters used to carry out this action
  * @param {<<api-param-type-string,`String`>>} params.index - The name of the index to scope the operation
- * @param {<<api-param-type-boolean,`Boolean`>>} params.preferLocal - With `true`, specify that a local shard should be used if available, with `false`, use a random shard (default: true)
- * @param {<<api-param-type-string,`String`>>} [params.format=detailed] - Format of the output
  */
 api.indices.prototype.analyze = ca({
   params: {
     index: {
       type: 'string'
-    },
-    preferLocal: {
-      type: 'boolean',
-      name: 'prefer_local'
-    },
-    format: {
-      type: 'enum',
-      'default': 'detailed',
-      options: [
-        'detailed',
-        'text'
-      ]
     }
   },
   urls: [
@@ -3391,6 +3377,7 @@ api.indices.prototype.forcemerge = ca({
  * @param {<<api-param-type-string,`String`>>} [params.expandWildcards=open] - Whether wildcard expressions should get expanded to open or closed indices (default: open)
  * @param {<<api-param-type-boolean,`Boolean`>>} params.flatSettings - Return settings in flat format (default: false)
  * @param {<<api-param-type-boolean,`Boolean`>>} params.includeDefaults - Whether to return all default setting for each of the indices.
+ * @param {<<api-param-type-duration-string,`DurationString`>>} params.masterTimeout - Specify timeout for connection to master
  * @param {<<api-param-type-string,`String`>>, <<api-param-type-string-array,`String[]`>>, <<api-param-type-boolean,`Boolean`>>} params.index - A comma-separated list of index names
  */
 api.indices.prototype.get = ca({
@@ -3425,6 +3412,10 @@ api.indices.prototype.get = ca({
       type: 'boolean',
       'default': false,
       name: 'include_defaults'
+    },
+    masterTimeout: {
+      type: 'time',
+      name: 'master_timeout'
     }
   },
   url: {
@@ -5598,7 +5589,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/apis/master.js
+++ b/src/lib/apis/master.js
@@ -2761,25 +2761,11 @@ api.indices = namespace();
  *
  * @param {Object} params - An object with parameters used to carry out this action
  * @param {<<api-param-type-string,`String`>>} params.index - The name of the index to scope the operation
- * @param {<<api-param-type-boolean,`Boolean`>>} params.preferLocal - With `true`, specify that a local shard should be used if available, with `false`, use a random shard (default: true)
- * @param {<<api-param-type-string,`String`>>} [params.format=detailed] - Format of the output
  */
 api.indices.prototype.analyze = ca({
   params: {
     index: {
       type: 'string'
-    },
-    preferLocal: {
-      type: 'boolean',
-      name: 'prefer_local'
-    },
-    format: {
-      type: 'enum',
-      'default': 'detailed',
-      options: [
-        'detailed',
-        'text'
-      ]
     }
   },
   urls: [
@@ -3442,6 +3428,7 @@ api.indices.prototype.forcemerge = ca({
  * @param {<<api-param-type-string,`String`>>} [params.expandWildcards=open] - Whether wildcard expressions should get expanded to open or closed indices (default: open)
  * @param {<<api-param-type-boolean,`Boolean`>>} params.flatSettings - Return settings in flat format (default: false)
  * @param {<<api-param-type-boolean,`Boolean`>>} params.includeDefaults - Whether to return all default setting for each of the indices.
+ * @param {<<api-param-type-duration-string,`DurationString`>>} params.masterTimeout - Specify timeout for connection to master
  * @param {<<api-param-type-string,`String`>>, <<api-param-type-string-array,`String[]`>>, <<api-param-type-boolean,`Boolean`>>} params.index - A comma-separated list of index names
  */
 api.indices.prototype.get = ca({
@@ -3476,6 +3463,10 @@ api.indices.prototype.get = ca({
       type: 'boolean',
       'default': false,
       name: 'include_defaults'
+    },
+    masterTimeout: {
+      type: 'time',
+      name: 'master_timeout'
     }
   },
   url: {
@@ -5662,7 +5653,6 @@ api.ping = ca({
   url: {
     fmt: '/'
   },
-  requestTimeout: 3000,
   method: 'HEAD'
 });
 

--- a/src/lib/transport.js
+++ b/src/lib/transport.js
@@ -206,9 +206,8 @@ Transport.prototype.request = function (params, cb) {
 
   const pingRequest = params.path === '/' && params.method === 'HEAD';
   if (pingRequest) {
-    const pingParam = params.hasOwnProperty('pingTimeout') && params.pingTimeout;
     const requestParam = params.hasOwnProperty('requestTimeout') && params.requestTimeout;
-    requestTimeout = pingParam || requestParam || this.pingTimeout || requestTimeout;
+    requestTimeout = requestParam || this.pingTimeout;
   }
 
   params.req = {

--- a/src/lib/transport.js
+++ b/src/lib/transport.js
@@ -37,6 +37,7 @@ function Transport(config) {
 
   // setup requestTimeout default
   self.requestTimeout = config.hasOwnProperty('requestTimeout') ? config.requestTimeout : 30000;
+  self.pingTimeout = config.hasOwnProperty('pingTimeout') ? config.pingTimeout : 3000;
 
   if (config.hasOwnProperty('defer')) {
     self.defer = config.defer;
@@ -201,6 +202,15 @@ Transport.prototype.request = function (params, cb) {
 
   if (params.hasOwnProperty('requestTimeout')) {
     requestTimeout = params.requestTimeout;
+  }
+
+  const pingRequest = params.path === '/' && params.method === 'HEAD';
+  if (pingRequest) {
+    const pingParam =
+      params.hasOwnProperty('pingTimeout') && params.pingTimeout;
+    const requestParam =
+      params.hasOwnProperty('requestTimeout') && params.requestTimeout;
+    requestTimeout = pingParam || requestParam || this.pingTimeout || requestTimeout;
   }
 
   params.req = {

--- a/src/lib/transport.js
+++ b/src/lib/transport.js
@@ -206,10 +206,8 @@ Transport.prototype.request = function (params, cb) {
 
   const pingRequest = params.path === '/' && params.method === 'HEAD';
   if (pingRequest) {
-    const pingParam =
-      params.hasOwnProperty('pingTimeout') && params.pingTimeout;
-    const requestParam =
-      params.hasOwnProperty('requestTimeout') && params.requestTimeout;
+    const pingParam = params.hasOwnProperty('pingTimeout') && params.pingTimeout;
+    const requestParam = params.hasOwnProperty('requestTimeout') && params.requestTimeout;
     requestTimeout = pingParam || requestParam || this.pingTimeout || requestTimeout;
   }
 

--- a/test/unit/specs/client.js
+++ b/test/unit/specs/client.js
@@ -81,13 +81,4 @@ describe('Client instances creation', function () {
       client.transport.log.error(new Error());
     });
   });
-
-  describe('#ping', function () {
-    it('sets the default requestTimeout to 3000', function () {
-      stub(client.transport, 'request');
-      client.ping();
-      expect(client.transport.request.callCount).to.be(1);
-      expect(client.transport.request.lastCall.args[0].requestTimeout).to.be(3000);
-    });
-  });
 });

--- a/test/unit/specs/transport.js
+++ b/test/unit/specs/transport.js
@@ -788,6 +788,28 @@ describe('Transport Class', function () {
         });
       });
 
+      it('inherits the pingTimeout from the transport', function () {
+        var clock = sinon.useFakeTimers('setTimeout', 'clearTimeout');
+        stub.autoRelease(clock);
+        var tran = new Transport({
+          requestTimeout: 4000,
+          pingTimeout: 5000
+        });
+
+        var prom = tran.request({
+          path: '/',
+          method: 'HEAD'
+        });
+        // disregard promise, prevent bluebird's warnings
+        prom.then(_.noop, _.noop);
+
+        expect(_.size(clock.timers)).to.eql(1);
+        _.each(clock.timers, function (timer, id) {
+          expect(timer.callAt).to.eql(5000);
+          clearTimeout(id);
+        });
+      });
+
 
       _.each([false, 0, null], function (falsy) {
         it('skips the timeout when it is ' + falsy, function () {


### PR DESCRIPTION
Currently ping does not respect defaults set on client instantiation.   The only way to override is by setting request parameters. 

This sets the ordering from:
1) requestTimeout param
2) 3000

to:
1) pingTimeout param
1) requestTimeout param
1) instantiated pingTimeout
1) default pingTimeout

Closes https://github.com/elastic/elasticsearch-js/issues/547