### PR TITLE
[15.x] Fix: Serialization does not handle non-enumerable properties in Node versions < 5.x (#677)

### DIFF
--- a/src/lib/serializers/json.js
+++ b/src/lib/serializers/json.js
@@ -20,7 +20,11 @@ Json.prototype.serialize = function (val, replacer, spaces) {
       return val;
     case 'object':
       if (val) {
-        return JSON.stringify(val, replacer, spaces);
+        if (replacer || spaces) {
+          return JSON.stringify(val, replacer, spaces);
+        } else {
+          return JSON.stringify(val);
+        }
       }
     /* falls through */
     default:

--- a/test/unit/specs/json_serializer.js
+++ b/test/unit/specs/json_serializer.js
@@ -39,6 +39,24 @@ describe('JSON serializer', function () {
         ser.serialize(thing);
       }).to.throwError();
     });
+
+    it('utilizes replacer or spaces if passed', function () {
+      sinon.spy(JSON, 'stringify');
+      var ser = makeSerializer();
+      var thing = { name: 'thing' };
+      ser.serialize(thing, null, 2);
+      expect(JSON.stringify.withArgs(thing, null, 2).calledOnce).to.be(true);
+      JSON.stringify.restore();
+    });
+
+    it('should call JSON.stringify with value only', function () {
+      sinon.spy(JSON, 'stringify');
+      var ser = makeSerializer();
+      var thing = { name: 'thing' };
+      ser.serialize(thing);
+      expect(JSON.stringify.withArgs(thing).calledOnce).to.be(true);
+      JSON.stringify.restore();
+    });
   });
 
   describe('#deserialize', function () {


### PR DESCRIPTION
Backports the following commits to 15.x:
 - Fix: Serialization does not handle non-enumerable properties in Node versions < 5.x  (#677)