### PR TITLE
Update chalk 1.0.0 to stable 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "agentkeepalive": "^3.4.1",
-    "chalk": "^1.0.0",
+    "chalk": "^2.4.1",
     "lodash": "^4.17.10"
   },
   "resolutions": {


### PR DESCRIPTION
Chalk 1.0.0 is outdated.
https://david-dm.org/elastic/elasticsearch-js