### PR TITLE
Add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ env:
 before_install:
   - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
   - tar -xzf elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
-  - ./elasticsearch-${ELASTICSEARCH_VERSION}/bin/elasticsearch -Enode.attr.testattr=test -Epath.repo=/tmp -Erepositories.url.allowed_urls='http://snapshot.*' &
+  - ./elasticsearch-${ELASTICSEARCH_VERSION}/bin/elasticsearch -Enode.attr.testattr=test -Epath.repo=/tmp -Erepositories.url.allowed_urls='http://snapshot.*' &> /dev/null &
   - sleep 10
-  - curl http://localhost:9200/_cluster/health?wait_for_status=green&timeout=50s
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+dist: trusty
+
+sudo: required
+
+language: node_js
+
+node_js:
+  - "10"
+  - "8"
+  - "6"
+
+env:
+  global:
+    - ELASTICSEARCH_VERSION=6.3.0
+    - QUIET=true
+
+before_install:
+  - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
+  - tar -xzf elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
+  - ./elasticsearch-${ELASTICSEARCH_VERSION}/bin/elasticsearch -Enode.attr.testattr=test -Epath.repo=/tmp -Erepositories.url.allowed_urls='http://snapshot.*' &
+  - sleep 10
+  - curl http://localhost:9200/_cluster/health?wait_for_status=green&timeout=50s
+
+install:
+  - npm install
+
+script:
+  - npm run test:unit && npm run test:integration
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "async": "~0.8.0",
     "babel-eslint": "^8.2.2",
     "babel-loader": "^8.0.0-beta",
-    "backport": "^3.0.2",
     "blanket": "^1.2.3",
     "bluebird": "^2.9.14",
     "browserify": "^16.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "test": "grunt test",
-    "test:unit": "tap test/unit/tap/*.test.js",
+    "test:unit": "tap test/unit/tap/*.test.js -J -T",
     "test:integration": "tap test/integration/tap/index.js -T",
     "generate": "node scripts/generate",
     "grunt": "grunt",


### PR DESCRIPTION
Adds Travis support.
The test are still failing on Node v6 because some regex are not valid on Node ≤ 8, I will fix the test runner in the `refactor-test-suite` branch.