### PR TITLE
Fix memory leaks when making requests and logging

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -57,11 +57,11 @@ function Client(config) {
 
     this.transport = new Transport(config);
 
-    _.each(EsApiClient.prototype, _.bind(function (Fn, prop) {
+    _.each(EsApiClient.prototype, (Fn, prop) => {
       if (Fn.prototype instanceof clientAction.ApiNamespace) {
         this[prop] = new Fn(this.transport, this);
       }
-    }, this));
+    });
 
     delete this._namespaces;
   }

--- a/src/lib/client_action.js
+++ b/src/lib/client_action.js
@@ -62,7 +62,7 @@ function makeFactoryWithModifier(modifier) {
         return exec(this.transport, spec, _.clone(params), cb);
       } catch (e) {
         if (typeof cb === 'function') {
-          utils.nextTick(cb, e);
+          process.nextTick(cb, e);
         } else {
           var def = this.transport.defer();
           def.reject(e);

--- a/src/lib/connection_pool.js
+++ b/src/lib/connection_pool.js
@@ -87,7 +87,7 @@ ConnectionPool.prototype.select = function (cb) {
       this.selector(this._conns.alive, cb);
     } else {
       try {
-        utils.nextTick(cb, void 0, this.selector(this._conns.alive));
+        process.nextTick(cb, void 0, this.selector(this._conns.alive));
       } catch (e) {
         cb(e);
       }
@@ -95,7 +95,7 @@ ConnectionPool.prototype.select = function (cb) {
   } else if (this._timeouts.length) {
     this._selectDeadConnection(cb);
   } else {
-    utils.nextTick(cb, void 0);
+    process.nextTick(cb, void 0);
   }
 };
 

--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -134,14 +134,17 @@ HttpConnector.prototype.request = function (params, _cb) {
   var request;
   var status = 0;
   var headers = {};
-  var log = this.log;
-
   var reqParams = this.makeReqParams(params);
+
+  var logRequest = (response) => {
+    this.log.trace(params.method, reqParams, params.body, response, status);
+  }
 
   // general clean-up procedure to run after the request
   // completes, has an error, or is aborted.
   function cleanUp(err, response) {
     if (request) {
+      request.removeListener('error', cleanUp);
       request = null;
     }
 
@@ -149,7 +152,7 @@ HttpConnector.prototype.request = function (params, _cb) {
       err = void 0;
     }
 
-    log.trace(params.method, reqParams, params.body, response, status);
+    logRequest(request);
     if (err) {
       cb(err);
     } else {

--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -150,7 +150,7 @@ HttpConnector.prototype.request = function (params, _cb) {
     }
 
     if (incoming) {
-      incoming.removeListener('data', cleanUp);
+      incoming.removeListener('data', onData);
       incoming.removeListener('error', cleanUp);
       incoming.removeListener('end', cleanUp);
       incoming = null;

--- a/src/lib/host.js
+++ b/src/lib/host.js
@@ -111,9 +111,9 @@ function Host(config, globalConfig) {
     delete config.auth;
   }
 
-  _.forOwn(config, _.bind(function (val, prop) {
+  _.forOwn(config, (val, prop) => {
     if (val != null) this[prop] = _.clone(val);
-  }, this));
+  });
 
   // make sure the query string is parsed
   if (this.query === null) {

--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -251,7 +251,7 @@ Log.prototype.warning = function (...args) {
  */
 Log.prototype.info = function (...args) {
   if (this.listenerCount('info')) {
-    return this.emit('info', Log.join(...args));
+    return this.emit('info', Log.join(args));
   }
 };
 

--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -66,7 +66,7 @@ Log.prototype.close = function () {
 if (EventEmitter.prototype.listenerCount) {
   // If the event emitter implements it's own listenerCount method
   // we don't need to (newer nodes do this).
-  Log.prototype.listenerCount = EventEmitter.prototype.listenerCount;
+  // Log.prototype.listenerCount = EventEmitter.prototype.listenerCount;
 }
 else if (EventEmitter.listenerCount) {
   // some versions of node expose EventEmitter::listenerCount

--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -235,9 +235,9 @@ Log.prototype.error = function (e) {
  * @param  {*} msg* - Any amount of messages that will be joined before logged
  * @return {Boolean} - True if any outputs accepted the message
  */
-Log.prototype.warning = function (/* ...msg */) {
+Log.prototype.warning = function (...args) {
   if (this.listenerCount('warning')) {
-    return this.emit('warning', Log.join(arguments));
+    return this.emit('warning', Log.join(args));
   }
 };
 
@@ -249,9 +249,9 @@ Log.prototype.warning = function (/* ...msg */) {
  * @param  {*} msg* - Any amount of messages that will be joined before logged
  * @return {Boolean} - True if any outputs accepted the message
  */
-Log.prototype.info = function (/* ...msg */) {
+Log.prototype.info = function (...args) {
   if (this.listenerCount('info')) {
-    return this.emit('info', Log.join(arguments));
+    return this.emit('info', Log.join(...args));
   }
 };
 
@@ -262,9 +262,9 @@ Log.prototype.info = function (/* ...msg */) {
  * @param  {*} msg* - Any amount of messages that will be joined before logged
  * @return {Boolean} - True if any outputs accepted the message
  */
-Log.prototype.debug = function (/* ...msg */) {
+Log.prototype.debug = function (...args) {
   if (this.listenerCount('debug')) {
-    return this.emit('debug', Log.join(arguments));
+    return this.emit('debug', Log.join(args));
   }
 };
 

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -65,7 +65,7 @@ LoggerAbstract.prototype.setupListeners = function (levels) {
 
   this.listeningLevels = [];
 
-  _.each(levels, _.bind(function (level) {
+  _.each(levels, (level) => {
     var fnName = 'on' + utils.ucfirst(level);
     if (this.bound[fnName]) {
       this.listeningLevels.push(level);
@@ -73,7 +73,7 @@ LoggerAbstract.prototype.setupListeners = function (levels) {
     } else {
       throw new Error('Unable to listen for level "' + level + '"');
     }
-  }, this));
+  });
 };
 
 /**
@@ -84,9 +84,9 @@ LoggerAbstract.prototype.setupListeners = function (levels) {
  * @return {undefined}
  */
 LoggerAbstract.prototype.cleanUpListeners = utils.handler(function () {
-  _.each(this.listeningLevels, _.bind(function (level) {
+  _.each(this.listeningLevels, (level) => {
     this.log.removeListener(level, this.bound['on' + utils.ucfirst(level)]);
-  }, this));
+  });
 });
 
 /**

--- a/src/lib/transport.js
+++ b/src/lib/transport.js
@@ -181,7 +181,7 @@ Transport.prototype.request = function (params, cb) {
   }
 
   if (body && params.method === 'GET') {
-    utils.nextTick(respond, new TypeError('Body can not be sent with method "GET"'));
+    process.nextTick(respond, new TypeError('Body can not be sent with method "GET"'));
     return ret;
   }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -247,7 +247,7 @@ utils.makeBoundMethods = function (obj) {
   for (var prop in obj) {
     // dearest maintainer, we want to look through the prototype
     if (typeof obj[prop] === 'function' && obj[prop]._provideBound === true) {
-      obj.bound[prop] = _.bind(obj[prop], obj);
+      obj.bound[prop] = obj[prop].bind(obj);
     }
   }
 };


### PR DESCRIPTION
I created a test [repo](https://github.com/peterdemartini/elasticsearch-js-leak) that shows there are memory leaks in `elasticsearch-js`. After taking a few heap snapshots and finding the leaks, I fixed a few of the problems. Most of the leaks were caused by the use of `_.bind`, holding on references longer than needed, and creating sparse arrays by continually mutating them.

I used a couple of es6 features in my changes, like the arrow functions, but this doesn't seem to be used elsewhere in within project, let me know if I should change this.

After applying my changes to the test project, I saw **10x** decrease in memory gain, see the [results](https://github.com/peterdemartini/elasticsearch-js-leak/blob/master/RESULTS.md).

Resolves #707.