### PR TITLE
Add initial structure for running tests on clients-ci

### DIFF
--- a/.ci/run-tests
+++ b/.ci/run-tests
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#
+# Runs the client tests via Docker with the expectation that the required
+# environment variables have already been exported before running this script.
+#
+# The required environment variables include:
+#
+#   - $ELASTICSEARCH_VERSION
+#   - $NODE_JS_VERSION
+#
+
+# TODO: implement the docker-based testing
+echo docker-compose [...]

--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -1,0 +1,10 @@
+---
+ELASTICSEARCH_VERSION:
+- 6.4.0
+
+NODE_JS_VERSION:
+- 10
+- 8
+- 6
+
+exclude: ~


### PR DESCRIPTION
Per our conversation earlier today, in order to migrate to running tests on https://clients-ci.elastic.co/, we'll need to establish some conventional structure for controlling the Jenkins jobs. The first convention is a build script that Jenkins will execute, and the second will be a definition of the matrix axes values to cover the version combinations that we'd like to test.

Having those two items defined within the repository means that only minimal tweaking of the actual Jenkins job itself will be required in the future.

I tried to match the existing matrix from the [refactor-test-suite branch .travis.yml file](https://github.com/elastic/elasticsearch-js/blob/refactor-test-suite/.travis.yml) for the initial setup. Feel free to suggest different naming for things if they're not what you'd like and I can adjust accordingly.