### PR TITLE
clarify AngularJS not Angular in doc

### DIFF
--- a/docs/browser_builds.asciidoc
+++ b/docs/browser_builds.asciidoc
@@ -24,10 +24,10 @@ npm install elasticsearch-browser
 === Download
  * v15.2.0: https://download.elasticsearch.org/elasticsearch/elasticsearch-js/elasticsearch-js-15.2.0.zip[zip], https://download.elasticsearch.org/elasticsearch/elasticsearch-js/elasticsearch-js-15.2.0.tar.gz[tar.gz]
 
-=== Angular Build
+=== AngularJS Build
   * Registers an `esFactory` factory in the `"elasticsearch"` module
-  * Uses Angular's `$http` service
-  * Returns promises using Angular's `$q` service to properly trigger digest cycles within Angular
+  * Uses AngularJS's `$http` service
+  * Returns promises using AngularJS's `$q` service to properly trigger digest cycles within AngularJS
 
 NOTE: Checkout an example that integrates elasticsearch.js with angular https://github.com/spenceralger/elasticsearch-angular-example[on GitHub]
 


### PR DESCRIPTION
It looks like the angular build is for angularjs (old version of angular) not angular 2+. Changing the name to AngularJS makes this clear to angular users reading this.