### PR TITLE
fix _source parameter

### DIFF
--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -1442,7 +1442,7 @@ const responseQueue = [];
 await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
-  source: ['title'], // filter the source to only include the title field
+  _source: ['title'], // filter the source to only include the title field
   q: 'title:test'
 })
 


### PR DESCRIPTION
the example of suing Scroll API supplies `source` parameter, and this doesn't work. it should be `_source`