### PR TITLE
fix _source parameter in scroll() api

### DIFF
--- a/docs/api_methods_6_6.asciidoc
+++ b/docs/api_methods_6_6.asciidoc
@@ -1460,7 +1460,7 @@ const responseQueue = [];
 await client.search({
   index: 'myindex',
   scroll: '30s', // keep the search results "scrollable" for 30 seconds
-  source: ['title'], // filter the source to only include the title field
+  _source: ['title'], // filter the source to only include the title field
   q: 'title:test'
 })
 


### PR DESCRIPTION
In the documentation, `source: ['title']` is provided as parameter to scroll(). This doesn't work, and correct parameter would be `_source`