### PR TITLE
Remove duplicate

### DIFF
--- a/api/api/bulk.js
+++ b/api/api/bulk.js
@@ -34,7 +34,6 @@ function buildBulk (opts) {
    * @param {enum} refresh - If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
    * @param {string} routing - Specific routing value
    * @param {time} timeout - Explicit operation timeout
-   * @param {string} type - Default document type for items which don't provide one
    * @param {list} _source - True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request
    * @param {list} _source_excludes - Default list of fields to exclude from the returned _source field, can be overridden on each sub-request
    * @param {list} _source_includes - Default list of fields to extract and return from the _source field, can be overridden on each sub-request


### PR DESCRIPTION
I don't think a duplicate parameter description is needed for @param type. Correct me if I am wrong.