### PR TITLE
feat: add support for querystring in options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ The supported *request specific options* are:
   requestTimeout: number, // client default
   maxRetries: number, // default `5`
   asStream: boolean, // default `false`
-  headers: object // default `null`
+  compression: string, // default `false`
+  headers: object, // default `null`
+  querystring: object // default `null`
 }
 ```
 

--- a/api/api/bulk.js
+++ b/api/api/bulk.js
@@ -149,6 +149,7 @@ function buildBulk (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.aliases.js
+++ b/api/api/cat.aliases.js
@@ -131,6 +131,7 @@ function buildCatAliases (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.allocation.js
+++ b/api/api/cat.allocation.js
@@ -133,6 +133,7 @@ function buildCatAllocation (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.count.js
+++ b/api/api/cat.count.js
@@ -131,6 +131,7 @@ function buildCatCount (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.fielddata.js
+++ b/api/api/cat.fielddata.js
@@ -135,6 +135,7 @@ function buildCatFielddata (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.health.js
+++ b/api/api/cat.health.js
@@ -128,6 +128,7 @@ function buildCatHealth (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.help.js
+++ b/api/api/cat.help.js
@@ -115,6 +115,7 @@ function buildCatHelp (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.indices.js
+++ b/api/api/cat.indices.js
@@ -137,6 +137,7 @@ function buildCatIndices (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.master.js
+++ b/api/api/cat.master.js
@@ -126,6 +126,7 @@ function buildCatMaster (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.nodeattrs.js
+++ b/api/api/cat.nodeattrs.js
@@ -126,6 +126,7 @@ function buildCatNodeattrs (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.nodes.js
+++ b/api/api/cat.nodes.js
@@ -129,6 +129,7 @@ function buildCatNodes (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.pending_tasks.js
+++ b/api/api/cat.pending_tasks.js
@@ -126,6 +126,7 @@ function buildCatPendingTasks (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.plugins.js
+++ b/api/api/cat.plugins.js
@@ -126,6 +126,7 @@ function buildCatPlugins (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.recovery.js
+++ b/api/api/cat.recovery.js
@@ -131,6 +131,7 @@ function buildCatRecovery (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.repositories.js
+++ b/api/api/cat.repositories.js
@@ -126,6 +126,7 @@ function buildCatRepositories (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.segments.js
+++ b/api/api/cat.segments.js
@@ -128,6 +128,7 @@ function buildCatSegments (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.shards.js
+++ b/api/api/cat.shards.js
@@ -133,6 +133,7 @@ function buildCatShards (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.snapshots.js
+++ b/api/api/cat.snapshots.js
@@ -132,6 +132,7 @@ function buildCatSnapshots (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.tasks.js
+++ b/api/api/cat.tasks.js
@@ -131,6 +131,7 @@ function buildCatTasks (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.templates.js
+++ b/api/api/cat.templates.js
@@ -131,6 +131,7 @@ function buildCatTemplates (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cat.thread_pool.js
+++ b/api/api/cat.thread_pool.js
@@ -133,6 +133,7 @@ function buildCatThreadPool (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ccr.delete_auto_follow_pattern.js
+++ b/api/api/ccr.delete_auto_follow_pattern.js
@@ -107,6 +107,7 @@ function buildCcrDeleteAutoFollowPattern (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ccr.follow.js
+++ b/api/api/ccr.follow.js
@@ -115,6 +115,7 @@ function buildCcrFollow (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ccr.follow_info.js
+++ b/api/api/ccr.follow_info.js
@@ -99,6 +99,7 @@ function buildCcrFollowInfo (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ccr.follow_stats.js
+++ b/api/api/ccr.follow_stats.js
@@ -99,6 +99,7 @@ function buildCcrFollowStats (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ccr.get_auto_follow_pattern.js
+++ b/api/api/ccr.get_auto_follow_pattern.js
@@ -103,6 +103,7 @@ function buildCcrGetAutoFollowPattern (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ccr.pause_follow.js
+++ b/api/api/ccr.pause_follow.js
@@ -107,6 +107,7 @@ function buildCcrPauseFollow (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ccr.put_auto_follow_pattern.js
+++ b/api/api/ccr.put_auto_follow_pattern.js
@@ -114,6 +114,7 @@ function buildCcrPutAutoFollowPattern (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ccr.resume_follow.js
+++ b/api/api/ccr.resume_follow.js
@@ -108,6 +108,7 @@ function buildCcrResumeFollow (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ccr.stats.js
+++ b/api/api/ccr.stats.js
@@ -98,6 +98,7 @@ function buildCcrStats (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ccr.unfollow.js
+++ b/api/api/ccr.unfollow.js
@@ -107,6 +107,7 @@ function buildCcrUnfollow (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/clear_scroll.js
+++ b/api/api/clear_scroll.js
@@ -109,6 +109,7 @@ function buildClearScroll (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cluster.allocation_explain.js
+++ b/api/api/cluster.allocation_explain.js
@@ -110,6 +110,7 @@ function buildClusterAllocationExplain (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cluster.get_settings.js
+++ b/api/api/cluster.get_settings.js
@@ -122,6 +122,7 @@ function buildClusterGetSettings (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cluster.health.js
+++ b/api/api/cluster.health.js
@@ -143,6 +143,7 @@ function buildClusterHealth (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cluster.pending_tasks.js
+++ b/api/api/cluster.pending_tasks.js
@@ -116,6 +116,7 @@ function buildClusterPendingTasks (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cluster.put_settings.js
+++ b/api/api/cluster.put_settings.js
@@ -120,6 +120,7 @@ function buildClusterPutSettings (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cluster.remote_info.js
+++ b/api/api/cluster.remote_info.js
@@ -111,6 +111,7 @@ function buildClusterRemoteInfo (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cluster.reroute.js
+++ b/api/api/cluster.reroute.js
@@ -119,6 +119,7 @@ function buildClusterReroute (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cluster.state.js
+++ b/api/api/cluster.state.js
@@ -150,6 +150,7 @@ function buildClusterState (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/cluster.stats.js
+++ b/api/api/cluster.stats.js
@@ -121,6 +121,7 @@ function buildClusterStats (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/count.js
+++ b/api/api/count.js
@@ -156,6 +156,7 @@ function buildCount (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/create.js
+++ b/api/api/create.js
@@ -149,6 +149,7 @@ function buildCreate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/delete.js
+++ b/api/api/delete.js
@@ -160,6 +160,7 @@ function buildDelete (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/delete_by_query.js
+++ b/api/api/delete_by_query.js
@@ -211,6 +211,7 @@ function buildDeleteByQuery (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/delete_by_query_rethrottle.js
+++ b/api/api/delete_by_query_rethrottle.js
@@ -127,6 +127,7 @@ function buildDeleteByQueryRethrottle (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/delete_script.js
+++ b/api/api/delete_script.js
@@ -123,6 +123,7 @@ function buildDeleteScript (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/exists.js
+++ b/api/api/exists.js
@@ -156,6 +156,7 @@ function buildExists (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/exists_source.js
+++ b/api/api/exists_source.js
@@ -166,6 +166,7 @@ function buildExistsSource (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/explain.js
+++ b/api/api/explain.js
@@ -156,6 +156,7 @@ function buildExplain (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/field_caps.js
+++ b/api/api/field_caps.js
@@ -127,6 +127,7 @@ function buildFieldCaps (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/get.js
+++ b/api/api/get.js
@@ -162,6 +162,7 @@ function buildGet (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/get_script.js
+++ b/api/api/get_script.js
@@ -121,6 +121,7 @@ function buildGetScript (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/get_source.js
+++ b/api/api/get_source.js
@@ -153,6 +153,7 @@ function buildGetSource (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ilm.delete_lifecycle.js
+++ b/api/api/ilm.delete_lifecycle.js
@@ -107,6 +107,7 @@ function buildIlmDeleteLifecycle (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ilm.explain_lifecycle.js
+++ b/api/api/ilm.explain_lifecycle.js
@@ -108,6 +108,7 @@ function buildIlmExplainLifecycle (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ilm.get_lifecycle.js
+++ b/api/api/ilm.get_lifecycle.js
@@ -111,6 +111,7 @@ function buildIlmGetLifecycle (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ilm.get_status.js
+++ b/api/api/ilm.get_status.js
@@ -106,6 +106,7 @@ function buildIlmGetStatus (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ilm.move_to_step.js
+++ b/api/api/ilm.move_to_step.js
@@ -100,6 +100,7 @@ function buildIlmMoveToStep (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ilm.put_lifecycle.js
+++ b/api/api/ilm.put_lifecycle.js
@@ -100,6 +100,7 @@ function buildIlmPutLifecycle (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ilm.remove_policy.js
+++ b/api/api/ilm.remove_policy.js
@@ -107,6 +107,7 @@ function buildIlmRemovePolicy (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ilm.retry.js
+++ b/api/api/ilm.retry.js
@@ -107,6 +107,7 @@ function buildIlmRetry (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ilm.start.js
+++ b/api/api/ilm.start.js
@@ -106,6 +106,7 @@ function buildIlmStart (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ilm.stop.js
+++ b/api/api/ilm.stop.js
@@ -106,6 +106,7 @@ function buildIlmStop (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/index.js
+++ b/api/api/index.js
@@ -164,6 +164,7 @@ function buildIndex (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.analyze.js
+++ b/api/api/indices.analyze.js
@@ -111,6 +111,7 @@ function buildIndicesAnalyze (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.clear_cache.js
+++ b/api/api/indices.clear_cache.js
@@ -135,6 +135,7 @@ function buildIndicesClearCache (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.close.js
+++ b/api/api/indices.close.js
@@ -132,6 +132,7 @@ function buildIndicesClose (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.create.js
+++ b/api/api/indices.create.js
@@ -124,6 +124,7 @@ function buildIndicesCreate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.delete.js
+++ b/api/api/indices.delete.js
@@ -132,6 +132,7 @@ function buildIndicesDelete (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.delete_alias.js
+++ b/api/api/indices.delete_alias.js
@@ -142,6 +142,7 @@ function buildIndicesDeleteAlias (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.delete_template.js
+++ b/api/api/indices.delete_template.js
@@ -123,6 +123,7 @@ function buildIndicesDeleteTemplate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.exists.js
+++ b/api/api/indices.exists.js
@@ -135,6 +135,7 @@ function buildIndicesExists (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.exists_alias.js
+++ b/api/api/indices.exists_alias.js
@@ -134,6 +134,7 @@ function buildIndicesExistsAlias (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.exists_template.js
+++ b/api/api/indices.exists_template.js
@@ -126,6 +126,7 @@ function buildIndicesExistsTemplate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.exists_type.js
+++ b/api/api/indices.exists_type.js
@@ -144,6 +144,7 @@ function buildIndicesExistsType (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.flush.js
+++ b/api/api/indices.flush.js
@@ -130,6 +130,7 @@ function buildIndicesFlush (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.flush_synced.js
+++ b/api/api/indices.flush_synced.js
@@ -125,6 +125,7 @@ function buildIndicesFlushSynced (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.forcemerge.js
+++ b/api/api/indices.forcemerge.js
@@ -133,6 +133,7 @@ function buildIndicesForcemerge (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.freeze.js
+++ b/api/api/indices.freeze.js
@@ -128,6 +128,7 @@ function buildIndicesFreeze (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.get.js
+++ b/api/api/indices.get.js
@@ -141,6 +141,7 @@ function buildIndicesGet (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.get_alias.js
+++ b/api/api/indices.get_alias.js
@@ -132,6 +132,7 @@ function buildIndicesGetAlias (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.get_field_mapping.js
+++ b/api/api/indices.get_field_mapping.js
@@ -145,6 +145,7 @@ function buildIndicesGetFieldMapping (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.get_mapping.js
+++ b/api/api/indices.get_mapping.js
@@ -138,6 +138,7 @@ function buildIndicesGetMapping (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.get_settings.js
+++ b/api/api/indices.get_settings.js
@@ -141,6 +141,7 @@ function buildIndicesGetSettings (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.get_template.js
+++ b/api/api/indices.get_template.js
@@ -127,6 +127,7 @@ function buildIndicesGetTemplate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.get_upgrade.js
+++ b/api/api/indices.get_upgrade.js
@@ -125,6 +125,7 @@ function buildIndicesGetUpgrade (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.open.js
+++ b/api/api/indices.open.js
@@ -135,6 +135,7 @@ function buildIndicesOpen (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.put_alias.js
+++ b/api/api/indices.put_alias.js
@@ -137,6 +137,7 @@ function buildIndicesPutAlias (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.put_mapping.js
+++ b/api/api/indices.put_mapping.js
@@ -147,6 +147,7 @@ function buildIndicesPutMapping (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.put_settings.js
+++ b/api/api/indices.put_settings.js
@@ -137,6 +137,7 @@ function buildIndicesPutSettings (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.put_template.js
+++ b/api/api/indices.put_template.js
@@ -134,6 +134,7 @@ function buildIndicesPutTemplate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.recovery.js
+++ b/api/api/indices.recovery.js
@@ -121,6 +121,7 @@ function buildIndicesRecovery (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.refresh.js
+++ b/api/api/indices.refresh.js
@@ -125,6 +125,7 @@ function buildIndicesRefresh (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.rollover.js
+++ b/api/api/indices.rollover.js
@@ -140,6 +140,7 @@ function buildIndicesRollover (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.segments.js
+++ b/api/api/indices.segments.js
@@ -127,6 +127,7 @@ function buildIndicesSegments (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.shard_stores.js
+++ b/api/api/indices.shard_stores.js
@@ -127,6 +127,7 @@ function buildIndicesShardStores (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.shrink.js
+++ b/api/api/indices.shrink.js
@@ -139,6 +139,7 @@ function buildIndicesShrink (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.split.js
+++ b/api/api/indices.split.js
@@ -139,6 +139,7 @@ function buildIndicesSplit (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.stats.js
+++ b/api/api/indices.stats.js
@@ -138,6 +138,7 @@ function buildIndicesStats (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.unfreeze.js
+++ b/api/api/indices.unfreeze.js
@@ -128,6 +128,7 @@ function buildIndicesUnfreeze (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.update_aliases.js
+++ b/api/api/indices.update_aliases.js
@@ -117,6 +117,7 @@ function buildIndicesUpdateAliases (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.upgrade.js
+++ b/api/api/indices.upgrade.js
@@ -131,6 +131,7 @@ function buildIndicesUpgrade (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/indices.validate_query.js
+++ b/api/api/indices.validate_query.js
@@ -150,6 +150,7 @@ function buildIndicesValidateQuery (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/info.js
+++ b/api/api/info.js
@@ -111,6 +111,7 @@ function buildInfo (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ingest.delete_pipeline.js
+++ b/api/api/ingest.delete_pipeline.js
@@ -123,6 +123,7 @@ function buildIngestDeletePipeline (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ingest.get_pipeline.js
+++ b/api/api/ingest.get_pipeline.js
@@ -119,6 +119,7 @@ function buildIngestGetPipeline (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ingest.processor_grok.js
+++ b/api/api/ingest.processor_grok.js
@@ -111,6 +111,7 @@ function buildIngestProcessorGrok (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ingest.put_pipeline.js
+++ b/api/api/ingest.put_pipeline.js
@@ -124,6 +124,7 @@ function buildIngestPutPipeline (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ingest.simulate.js
+++ b/api/api/ingest.simulate.js
@@ -119,6 +119,7 @@ function buildIngestSimulate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/mget.js
+++ b/api/api/mget.js
@@ -147,6 +147,7 @@ function buildMget (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.close_job.js
+++ b/api/api/ml.close_job.js
@@ -114,6 +114,7 @@ function buildMlCloseJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.delete_calendar.js
+++ b/api/api/ml.delete_calendar.js
@@ -113,6 +113,7 @@ function buildMlDeleteCalendar (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.delete_calendar_event.js
+++ b/api/api/ml.delete_calendar_event.js
@@ -128,6 +128,7 @@ function buildMlDeleteCalendarEvent (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.delete_calendar_job.js
+++ b/api/api/ml.delete_calendar_job.js
@@ -128,6 +128,7 @@ function buildMlDeleteCalendarJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.delete_datafeed.js
+++ b/api/api/ml.delete_datafeed.js
@@ -114,6 +114,7 @@ function buildMlDeleteDatafeed (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.delete_expired_data.js
+++ b/api/api/ml.delete_expired_data.js
@@ -106,6 +106,7 @@ function buildMlDeleteExpiredData (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.delete_filter.js
+++ b/api/api/ml.delete_filter.js
@@ -113,6 +113,7 @@ function buildMlDeleteFilter (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.delete_forecast.js
+++ b/api/api/ml.delete_forecast.js
@@ -130,6 +130,7 @@ function buildMlDeleteForecast (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.delete_job.js
+++ b/api/api/ml.delete_job.js
@@ -116,6 +116,7 @@ function buildMlDeleteJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.delete_model_snapshot.js
+++ b/api/api/ml.delete_model_snapshot.js
@@ -128,6 +128,7 @@ function buildMlDeleteModelSnapshot (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.find_file_structure.js
+++ b/api/api/ml.find_file_structure.js
@@ -139,6 +139,7 @@ function buildMlFindFileStructure (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.flush_job.js
+++ b/api/api/ml.flush_job.js
@@ -119,6 +119,7 @@ function buildMlFlushJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.forecast.js
+++ b/api/api/ml.forecast.js
@@ -116,6 +116,7 @@ function buildMlForecast (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_buckets.js
+++ b/api/api/ml.get_buckets.js
@@ -140,6 +140,7 @@ function buildMlGetBuckets (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_calendar_events.js
+++ b/api/api/ml.get_calendar_events.js
@@ -123,6 +123,7 @@ function buildMlGetCalendarEvents (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_calendars.js
+++ b/api/api/ml.get_calendars.js
@@ -114,6 +114,7 @@ function buildMlGetCalendars (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_categories.js
+++ b/api/api/ml.get_categories.js
@@ -116,6 +116,7 @@ function buildMlGetCategories (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_datafeed_stats.js
+++ b/api/api/ml.get_datafeed_stats.js
@@ -112,6 +112,7 @@ function buildMlGetDatafeedStats (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_datafeeds.js
+++ b/api/api/ml.get_datafeeds.js
@@ -112,6 +112,7 @@ function buildMlGetDatafeeds (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_filters.js
+++ b/api/api/ml.get_filters.js
@@ -114,6 +114,7 @@ function buildMlGetFilters (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_influencers.js
+++ b/api/api/ml.get_influencers.js
@@ -125,6 +125,7 @@ function buildMlGetInfluencers (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_job_stats.js
+++ b/api/api/ml.get_job_stats.js
@@ -112,6 +112,7 @@ function buildMlGetJobStats (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_jobs.js
+++ b/api/api/ml.get_jobs.js
@@ -112,6 +112,7 @@ function buildMlGetJobs (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_model_snapshots.js
+++ b/api/api/ml.get_model_snapshots.js
@@ -132,6 +132,7 @@ function buildMlGetModelSnapshots (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_overall_buckets.js
+++ b/api/api/ml.get_overall_buckets.js
@@ -125,6 +125,7 @@ function buildMlGetOverallBuckets (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.get_records.js
+++ b/api/api/ml.get_records.js
@@ -125,6 +125,7 @@ function buildMlGetRecords (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.info.js
+++ b/api/api/ml.info.js
@@ -98,6 +98,7 @@ function buildMlInfo (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.open_job.js
+++ b/api/api/ml.open_job.js
@@ -115,6 +115,7 @@ function buildMlOpenJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.post_calendar_events.js
+++ b/api/api/ml.post_calendar_events.js
@@ -114,6 +114,7 @@ function buildMlPostCalendarEvents (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.post_data.js
+++ b/api/api/ml.post_data.js
@@ -118,6 +118,7 @@ function buildMlPostData (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.preview_datafeed.js
+++ b/api/api/ml.preview_datafeed.js
@@ -113,6 +113,7 @@ function buildMlPreviewDatafeed (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.put_calendar.js
+++ b/api/api/ml.put_calendar.js
@@ -108,6 +108,7 @@ function buildMlPutCalendar (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.put_calendar_job.js
+++ b/api/api/ml.put_calendar_job.js
@@ -128,6 +128,7 @@ function buildMlPutCalendarJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.put_datafeed.js
+++ b/api/api/ml.put_datafeed.js
@@ -114,6 +114,7 @@ function buildMlPutDatafeed (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.put_filter.js
+++ b/api/api/ml.put_filter.js
@@ -114,6 +114,7 @@ function buildMlPutFilter (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.put_job.js
+++ b/api/api/ml.put_job.js
@@ -114,6 +114,7 @@ function buildMlPutJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.revert_model_snapshot.js
+++ b/api/api/ml.revert_model_snapshot.js
@@ -124,6 +124,7 @@ function buildMlRevertModelSnapshot (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.set_upgrade_mode.js
+++ b/api/api/ml.set_upgrade_mode.js
@@ -109,6 +109,7 @@ function buildMlSetUpgradeMode (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.start_datafeed.js
+++ b/api/api/ml.start_datafeed.js
@@ -113,6 +113,7 @@ function buildMlStartDatafeed (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.stop_datafeed.js
+++ b/api/api/ml.stop_datafeed.js
@@ -113,6 +113,7 @@ function buildMlStopDatafeed (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.update_datafeed.js
+++ b/api/api/ml.update_datafeed.js
@@ -114,6 +114,7 @@ function buildMlUpdateDatafeed (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.update_filter.js
+++ b/api/api/ml.update_filter.js
@@ -114,6 +114,7 @@ function buildMlUpdateFilter (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.update_job.js
+++ b/api/api/ml.update_job.js
@@ -114,6 +114,7 @@ function buildMlUpdateJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.update_model_snapshot.js
+++ b/api/api/ml.update_model_snapshot.js
@@ -129,6 +129,7 @@ function buildMlUpdateModelSnapshot (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.validate.js
+++ b/api/api/ml.validate.js
@@ -107,6 +107,7 @@ function buildMlValidate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ml.validate_detector.js
+++ b/api/api/ml.validate_detector.js
@@ -107,6 +107,7 @@ function buildMlValidateDetector (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/monitoring.bulk.js
+++ b/api/api/monitoring.bulk.js
@@ -119,6 +119,7 @@ function buildMonitoringBulk (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/msearch.js
+++ b/api/api/msearch.js
@@ -149,6 +149,7 @@ function buildMsearch (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/msearch_template.js
+++ b/api/api/msearch_template.js
@@ -143,6 +143,7 @@ function buildMsearchTemplate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/mtermvectors.js
+++ b/api/api/mtermvectors.js
@@ -149,6 +149,7 @@ function buildMtermvectors (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/nodes.hot_threads.js
+++ b/api/api/nodes.hot_threads.js
@@ -135,6 +135,7 @@ function buildNodesHotThreads (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/nodes.info.js
+++ b/api/api/nodes.info.js
@@ -126,6 +126,7 @@ function buildNodesInfo (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/nodes.reload_secure_settings.js
+++ b/api/api/nodes.reload_secure_settings.js
@@ -118,6 +118,7 @@ function buildNodesReloadSecureSettings (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/nodes.stats.js
+++ b/api/api/nodes.stats.js
@@ -145,6 +145,7 @@ function buildNodesStats (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/nodes.usage.js
+++ b/api/api/nodes.usage.js
@@ -123,6 +123,7 @@ function buildNodesUsage (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ping.js
+++ b/api/api/ping.js
@@ -111,6 +111,7 @@ function buildPing (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/put_script.js
+++ b/api/api/put_script.js
@@ -139,6 +139,7 @@ function buildPutScript (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/rank_eval.js
+++ b/api/api/rank_eval.js
@@ -126,6 +126,7 @@ function buildRankEval (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/reindex.js
+++ b/api/api/reindex.js
@@ -127,6 +127,7 @@ function buildReindex (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/reindex_rethrottle.js
+++ b/api/api/reindex_rethrottle.js
@@ -127,6 +127,7 @@ function buildReindexRethrottle (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/render_search_template.js
+++ b/api/api/render_search_template.js
@@ -109,6 +109,7 @@ function buildRenderSearchTemplate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/scripts_painless_execute.js
+++ b/api/api/scripts_painless_execute.js
@@ -104,6 +104,7 @@ function buildScriptsPainlessExecute (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/scroll.js
+++ b/api/api/scroll.js
@@ -117,6 +117,7 @@ function buildScroll (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/search.js
+++ b/api/api/search.js
@@ -231,6 +231,7 @@ function buildSearch (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/search_shards.js
+++ b/api/api/search_shards.js
@@ -131,6 +131,7 @@ function buildSearchShards (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/search_template.js
+++ b/api/api/search_template.js
@@ -162,6 +162,7 @@ function buildSearchTemplate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.authenticate.js
+++ b/api/api/security.authenticate.js
@@ -106,6 +106,7 @@ function buildSecurityAuthenticate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.change_password.js
+++ b/api/api/security.change_password.js
@@ -113,6 +113,7 @@ function buildSecurityChangePassword (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.clear_cached_realms.js
+++ b/api/api/security.clear_cached_realms.js
@@ -114,6 +114,7 @@ function buildSecurityClearCachedRealms (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.clear_cached_roles.js
+++ b/api/api/security.clear_cached_roles.js
@@ -113,6 +113,7 @@ function buildSecurityClearCachedRoles (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.create_api_key.js
+++ b/api/api/security.create_api_key.js
@@ -108,6 +108,7 @@ function buildSecurityCreateApiKey (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.delete_privileges.js
+++ b/api/api/security.delete_privileges.js
@@ -129,6 +129,7 @@ function buildSecurityDeletePrivileges (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.delete_role.js
+++ b/api/api/security.delete_role.js
@@ -114,6 +114,7 @@ function buildSecurityDeleteRole (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.delete_role_mapping.js
+++ b/api/api/security.delete_role_mapping.js
@@ -114,6 +114,7 @@ function buildSecurityDeleteRoleMapping (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.delete_user.js
+++ b/api/api/security.delete_user.js
@@ -114,6 +114,7 @@ function buildSecurityDeleteUser (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.disable_user.js
+++ b/api/api/security.disable_user.js
@@ -108,6 +108,7 @@ function buildSecurityDisableUser (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.enable_user.js
+++ b/api/api/security.enable_user.js
@@ -108,6 +108,7 @@ function buildSecurityEnableUser (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.get_api_key.js
+++ b/api/api/security.get_api_key.js
@@ -113,6 +113,7 @@ function buildSecurityGetApiKey (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.get_privileges.js
+++ b/api/api/security.get_privileges.js
@@ -122,6 +122,7 @@ function buildSecurityGetPrivileges (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.get_role.js
+++ b/api/api/security.get_role.js
@@ -111,6 +111,7 @@ function buildSecurityGetRole (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.get_role_mapping.js
+++ b/api/api/security.get_role_mapping.js
@@ -111,6 +111,7 @@ function buildSecurityGetRoleMapping (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.get_token.js
+++ b/api/api/security.get_token.js
@@ -107,6 +107,7 @@ function buildSecurityGetToken (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.get_user.js
+++ b/api/api/security.get_user.js
@@ -111,6 +111,7 @@ function buildSecurityGetUser (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.get_user_privileges.js
+++ b/api/api/security.get_user_privileges.js
@@ -106,6 +106,7 @@ function buildSecurityGetUserPrivileges (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.has_privileges.js
+++ b/api/api/security.has_privileges.js
@@ -112,6 +112,7 @@ function buildSecurityHasPrivileges (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.invalidate_api_key.js
+++ b/api/api/security.invalidate_api_key.js
@@ -107,6 +107,7 @@ function buildSecurityInvalidateApiKey (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.invalidate_token.js
+++ b/api/api/security.invalidate_token.js
@@ -107,6 +107,7 @@ function buildSecurityInvalidateToken (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.put_privileges.js
+++ b/api/api/security.put_privileges.js
@@ -108,6 +108,7 @@ function buildSecurityPutPrivileges (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.put_role.js
+++ b/api/api/security.put_role.js
@@ -115,6 +115,7 @@ function buildSecurityPutRole (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.put_role_mapping.js
+++ b/api/api/security.put_role_mapping.js
@@ -115,6 +115,7 @@ function buildSecurityPutRoleMapping (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/security.put_user.js
+++ b/api/api/security.put_user.js
@@ -115,6 +115,7 @@ function buildSecurityPutUser (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/snapshot.create.js
+++ b/api/api/snapshot.create.js
@@ -134,6 +134,7 @@ function buildSnapshotCreate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/snapshot.create_repository.js
+++ b/api/api/snapshot.create_repository.js
@@ -126,6 +126,7 @@ function buildSnapshotCreateRepository (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/snapshot.delete.js
+++ b/api/api/snapshot.delete.js
@@ -136,6 +136,7 @@ function buildSnapshotDelete (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/snapshot.delete_repository.js
+++ b/api/api/snapshot.delete_repository.js
@@ -123,6 +123,7 @@ function buildSnapshotDeleteRepository (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/snapshot.get.js
+++ b/api/api/snapshot.get.js
@@ -141,6 +141,7 @@ function buildSnapshotGet (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/snapshot.get_repository.js
+++ b/api/api/snapshot.get_repository.js
@@ -121,6 +121,7 @@ function buildSnapshotGetRepository (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/snapshot.restore.js
+++ b/api/api/snapshot.restore.js
@@ -134,6 +134,7 @@ function buildSnapshotRestore (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/snapshot.status.js
+++ b/api/api/snapshot.status.js
@@ -133,6 +133,7 @@ function buildSnapshotStatus (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/snapshot.verify_repository.js
+++ b/api/api/snapshot.verify_repository.js
@@ -123,6 +123,7 @@ function buildSnapshotVerifyRepository (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/ssl.certificates.js
+++ b/api/api/ssl.certificates.js
@@ -106,6 +106,7 @@ function buildSslCertificates (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/tasks.cancel.js
+++ b/api/api/tasks.cancel.js
@@ -123,6 +123,7 @@ function buildTasksCancel (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/tasks.get.js
+++ b/api/api/tasks.get.js
@@ -123,6 +123,7 @@ function buildTasksGet (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/tasks.list.js
+++ b/api/api/tasks.list.js
@@ -128,6 +128,7 @@ function buildTasksList (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/termvectors.js
+++ b/api/api/termvectors.js
@@ -150,6 +150,7 @@ function buildTermvectors (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/update.js
+++ b/api/api/update.js
@@ -161,6 +161,7 @@ function buildUpdate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/update_by_query.js
+++ b/api/api/update_by_query.js
@@ -210,6 +210,7 @@ function buildUpdateByQuery (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/update_by_query_rethrottle.js
+++ b/api/api/update_by_query_rethrottle.js
@@ -127,6 +127,7 @@ function buildUpdateByQueryRethrottle (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.graph.explore.js
+++ b/api/api/xpack.graph.explore.js
@@ -116,6 +116,7 @@ function buildXpackGraphExplore (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.info.js
+++ b/api/api/xpack.info.js
@@ -107,6 +107,7 @@ function buildXpackInfo (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.license.delete.js
+++ b/api/api/xpack.license.delete.js
@@ -106,6 +106,7 @@ function buildXpackLicenseDelete (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.license.get.js
+++ b/api/api/xpack.license.get.js
@@ -107,6 +107,7 @@ function buildXpackLicenseGet (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.license.get_basic_status.js
+++ b/api/api/xpack.license.get_basic_status.js
@@ -106,6 +106,7 @@ function buildXpackLicenseGetBasicStatus (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.license.get_trial_status.js
+++ b/api/api/xpack.license.get_trial_status.js
@@ -106,6 +106,7 @@ function buildXpackLicenseGetTrialStatus (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.license.post.js
+++ b/api/api/xpack.license.post.js
@@ -100,6 +100,7 @@ function buildXpackLicensePost (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.license.post_start_basic.js
+++ b/api/api/xpack.license.post_start_basic.js
@@ -107,6 +107,7 @@ function buildXpackLicensePostStartBasic (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.license.post_start_trial.js
+++ b/api/api/xpack.license.post_start_trial.js
@@ -109,6 +109,7 @@ function buildXpackLicensePostStartTrial (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.migration.deprecations.js
+++ b/api/api/xpack.migration.deprecations.js
@@ -111,6 +111,7 @@ function buildXpackMigrationDeprecations (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.migration.get_assistance.js
+++ b/api/api/xpack.migration.get_assistance.js
@@ -110,6 +110,7 @@ function buildXpackMigrationGetAssistance (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.migration.upgrade.js
+++ b/api/api/xpack.migration.upgrade.js
@@ -108,6 +108,7 @@ function buildXpackMigrationUpgrade (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.rollup.delete_job.js
+++ b/api/api/xpack.rollup.delete_job.js
@@ -107,6 +107,7 @@ function buildXpackRollupDeleteJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.rollup.get_jobs.js
+++ b/api/api/xpack.rollup.get_jobs.js
@@ -103,6 +103,7 @@ function buildXpackRollupGetJobs (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.rollup.get_rollup_caps.js
+++ b/api/api/xpack.rollup.get_rollup_caps.js
@@ -103,6 +103,7 @@ function buildXpackRollupGetRollupCaps (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.rollup.get_rollup_index_caps.js
+++ b/api/api/xpack.rollup.get_rollup_index_caps.js
@@ -107,6 +107,7 @@ function buildXpackRollupGetRollupIndexCaps (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.rollup.put_job.js
+++ b/api/api/xpack.rollup.put_job.js
@@ -114,6 +114,7 @@ function buildXpackRollupPutJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.rollup.rollup_search.js
+++ b/api/api/xpack.rollup.rollup_search.js
@@ -131,6 +131,7 @@ function buildXpackRollupRollupSearch (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.rollup.start_job.js
+++ b/api/api/xpack.rollup.start_job.js
@@ -107,6 +107,7 @@ function buildXpackRollupStartJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.rollup.stop_job.js
+++ b/api/api/xpack.rollup.stop_job.js
@@ -111,6 +111,7 @@ function buildXpackRollupStopJob (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.sql.clear_cursor.js
+++ b/api/api/xpack.sql.clear_cursor.js
@@ -107,6 +107,7 @@ function buildXpackSqlClearCursor (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.sql.query.js
+++ b/api/api/xpack.sql.query.js
@@ -108,6 +108,7 @@ function buildXpackSqlQuery (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.sql.translate.js
+++ b/api/api/xpack.sql.translate.js
@@ -107,6 +107,7 @@ function buildXpackSqlTranslate (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.usage.js
+++ b/api/api/xpack.usage.js
@@ -107,6 +107,7 @@ function buildXpackUsage (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.watcher.ack_watch.js
+++ b/api/api/xpack.watcher.ack_watch.js
@@ -126,6 +126,7 @@ function buildXpackWatcherAckWatch (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.watcher.activate_watch.js
+++ b/api/api/xpack.watcher.activate_watch.js
@@ -113,6 +113,7 @@ function buildXpackWatcherActivateWatch (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.watcher.deactivate_watch.js
+++ b/api/api/xpack.watcher.deactivate_watch.js
@@ -113,6 +113,7 @@ function buildXpackWatcherDeactivateWatch (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.watcher.delete_watch.js
+++ b/api/api/xpack.watcher.delete_watch.js
@@ -113,6 +113,7 @@ function buildXpackWatcherDeleteWatch (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.watcher.execute_watch.js
+++ b/api/api/xpack.watcher.execute_watch.js
@@ -105,6 +105,7 @@ function buildXpackWatcherExecuteWatch (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.watcher.get_watch.js
+++ b/api/api/xpack.watcher.get_watch.js
@@ -113,6 +113,7 @@ function buildXpackWatcherGetWatch (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.watcher.put_watch.js
+++ b/api/api/xpack.watcher.put_watch.js
@@ -116,6 +116,7 @@ function buildXpackWatcherPutWatch (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.watcher.start.js
+++ b/api/api/xpack.watcher.start.js
@@ -106,6 +106,7 @@ function buildXpackWatcherStart (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.watcher.stats.js
+++ b/api/api/xpack.watcher.stats.js
@@ -114,6 +114,7 @@ function buildXpackWatcherStats (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/api/api/xpack.watcher.stop.js
+++ b/api/api/xpack.watcher.stop.js
@@ -106,6 +106,7 @@ function buildXpackWatcherStop (opts) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/docs/usage.asciidoc
+++ b/docs/usage.asciidoc
@@ -159,6 +159,10 @@ _Default:_ `false`
 |`headers`
 |`object` - Custom headers for the request. +
 _Default:_ `null`
+
+|`querystring`
+|`object` - Custom querystring for the request. +
+_Default:_ `null`
 |===
 
 === Error handling

--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -80,9 +80,9 @@ declare type anyObject = {
 export interface TransportRequestParams {
   method: string;
   path: string;
-  body?: anyObject,
-  bulkBody?: anyObject,
-  querystring: anyObject
+  body?: anyObject;
+  bulkBody?: anyObject;
+  querystring?: anyObject;
 }
 
 export interface TransportRequestOptions {
@@ -91,6 +91,7 @@ export interface TransportRequestOptions {
   maxRetries?: number;
   asStream?: boolean;
   headers?: anyObject;
+  querystring?: anyObject;
   compression?: string;
   warnings?: [string];
 }

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -166,7 +166,13 @@ class Transport {
 
       params.headers = headers
       // serializes the querystring
-      params.querystring = this.serializer.qserialize(params.querystring)
+      if (options.querystring == null) {
+        params.querystring = this.serializer.qserialize(params.querystring)
+      } else {
+        params.querystring = this.serializer.qserialize(
+          Object.assign({}, params.querystring, options.querystring)
+        )
+      }
 
       meta.request.params = params
       meta.request.options = options

--- a/scripts/utils/generate.js
+++ b/scripts/utils/generate.js
@@ -160,6 +160,7 @@ function generate (spec, common) {
       maxRetries: options.maxRetries || null,
       asStream: options.asStream || false,
       headers: options.headers || null,
+      querystring: options.querystring || null,
       compression: options.compression || false,
       warnings
     }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -59,7 +59,11 @@ client.index({
 }, {
   maxRetries: 2,
   ignore: [404],
-  requestTimeout: 2000
+  requestTimeout: 2000,
+  headers: { foo: 'bar' },
+  querystring: { baz: 'faz' },
+  compression: 'gzip',
+  asStream: false
 }, (err: Error | null, result: ApiResponse) => {})
 
 // Promises

--- a/test/unit/api.test.js
+++ b/test/unit/api.test.js
@@ -269,6 +269,32 @@ test('Pass unknown parameters as query parameters (and get a warning)', t => {
   })
 })
 
+test('If the API uses the same key for both url and query parameter, the url should win', t => {
+  t.plan(2)
+
+  function handler (req, res) {
+    t.strictEqual(req.url, '/index/type/_bulk')
+    res.setHeader('Content-Type', 'application/json;utf=8')
+    res.end(JSON.stringify({ hello: 'world' }))
+  }
+
+  buildServer(handler, ({ port }, server) => {
+    const client = new Client({
+      node: `http://localhost:${port}`
+    })
+
+    // bulk has two `type` parameters
+    client.bulk({
+      index: 'index',
+      type: 'type',
+      body: []
+    }, (err, { body, warnings }) => {
+      t.error(err)
+      server.stop()
+    })
+  })
+})
+
 if (Number(process.version.split('.')[0].slice(1)) >= 8) {
   require('./api-async')(test)
 }

--- a/test/unit/transport.test.js
+++ b/test/unit/transport.test.js
@@ -2030,3 +2030,80 @@ test('nodeFilter and nodeSelector', t => {
     t.deepEqual(body, { hello: 'world' })
   })
 })
+
+test('Should accept custom querystring in the optons object', t => {
+  t.test('Options object', t => {
+    t.plan(3)
+
+    function handler (req, res) {
+      t.strictEqual(req.url, '/hello?foo=bar')
+      res.setHeader('Content-Type', 'application/json;utf=8')
+      res.end(JSON.stringify({ hello: 'world' }))
+    }
+
+    buildServer(handler, ({ port }, server) => {
+      const pool = new ConnectionPool({ Connection })
+      pool.addConnection(`http://localhost:${port}`)
+
+      const transport = new Transport({
+        emit: () => {},
+        connectionPool: pool,
+        serializer: new Serializer(),
+        maxRetries: 3,
+        requestTimeout: 30000,
+        sniffInterval: false,
+        sniffOnStart: false
+      })
+
+      transport.request({
+        method: 'GET',
+        path: '/hello'
+      }, {
+        querystring: { foo: 'bar' }
+      }, (err, { body }) => {
+        t.error(err)
+        t.deepEqual(body, { hello: 'world' })
+        server.stop()
+      })
+    })
+  })
+
+  t.test('Options object and params', t => {
+    t.plan(3)
+
+    function handler (req, res) {
+      t.strictEqual(req.url, '/hello?baz=faz&foo=bar')
+      res.setHeader('Content-Type', 'application/json;utf=8')
+      res.end(JSON.stringify({ hello: 'world' }))
+    }
+
+    buildServer(handler, ({ port }, server) => {
+      const pool = new ConnectionPool({ Connection })
+      pool.addConnection(`http://localhost:${port}`)
+
+      const transport = new Transport({
+        emit: () => {},
+        connectionPool: pool,
+        serializer: new Serializer(),
+        maxRetries: 3,
+        requestTimeout: 30000,
+        sniffInterval: false,
+        sniffOnStart: false
+      })
+
+      transport.request({
+        method: 'GET',
+        path: '/hello',
+        querystring: { baz: 'faz' }
+      }, {
+        querystring: { foo: 'bar' }
+      }, (err, { body }) => {
+        t.error(err)
+        t.deepEqual(body, { hello: 'world' })
+        server.stop()
+      })
+    })
+  })
+
+  t.end()
+})


### PR DESCRIPTION
In very few cases, some API uses the same key for both url and query params, such as the bulk method.
The client is not designed to handle such cases since accepts both url and query keys in the same object, and the url parameter will always take precedence.
This pr fixes this edge case by adding a `querystring` key in the options object.

Fixes: https://github.com/elastic/elasticsearch-js/pull/778

```js
client.bulk({
  index: 'index',
  type: '_doc',
  body: [...]
}, {
  querystring: {
    type: '_doc'
  }
}, console.log)
```