### PR TITLE
Inspect Connection

### DIFF
--- a/lib/Connection.d.ts
+++ b/lib/Connection.d.ts
@@ -20,6 +20,7 @@
 /// <reference types="node" />
 
 import { URL } from 'url';
+import { inspect, InspectOptions } from 'util';
 import * as http from 'http';
 import { SecureContextOptions } from 'tls';
 
@@ -73,6 +74,7 @@ export default class Connection {
   setRole(role: string, enabled: boolean): Connection;
   status: string;
   buildRequestObject(params: any): http.ClientRequestArgs;
+  [inspect.custom](object: any, options: InspectOptions): string;
 }
 
 export {};

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -20,6 +20,7 @@
 'use strict'
 
 const assert = require('assert')
+const { inspect } = require('util')
 const http = require('http')
 const https = require('https')
 const debug = require('debug')('elasticsearch')
@@ -54,7 +55,7 @@ class Connection {
       maxSockets: keepAliveFalse ? Infinity : 256,
       maxFreeSockets: 256
     }, opts.agent)
-    this._agent = this.url.protocol === 'http:'
+    this.agent = this.url.protocol === 'http:'
       ? new http.Agent(agentOptions)
       : new https.Agent(Object.assign({}, agentOptions, this.ssl))
 
@@ -146,7 +147,7 @@ class Connection {
     if (this._openRequests > 0) {
       setTimeout(() => this.close(callback), 1000)
     } else {
-      this._agent.destroy()
+      this.agent.destroy()
       callback()
     }
   }
@@ -193,7 +194,7 @@ class Connection {
       auth: !!url.username === true || !!url.password === true
         ? `${url.username}:${url.password}`
         : undefined,
-      agent: this._agent
+      agent: this.agent
     }
 
     const paramsKeys = Object.keys(params)
@@ -217,6 +218,23 @@ class Connection {
     request.path = request.pathname + request.search
 
     return request
+  }
+
+  // Handles console.log and utils.inspect invocations.
+  // We want to hide `agent` and `ssl` since they made
+  // the logs very hard to read. The user can still
+  // access them with `instance.agent` and `instance.ssl`.
+  [inspect.custom] (depth, options) {
+    return {
+      url: this.url,
+      id: this.id,
+      headers: this.headers,
+      deadCount: this.deadCount,
+      resurrectTimeout: this.resurrectTimeout,
+      _openRequests: this._openRequests,
+      status: this.status,
+      roles: this.roles
+    }
   }
 }
 

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -681,7 +681,16 @@ test('Util.inspect Connection class should hide agent and ssl', t => {
     headers: { foo: 'bar' }
   })
 
-  t.strictEqual(inspect(connection), `{ url:
+  // Removes spaces and new lines because
+  // utils.inspect is handled differently
+  // between major versions of Node.js
+  function cleanStr (str) {
+    return str
+      .replace(/\s/g, '')
+      .replace(/(\r\n|\n|\r)/gm, '')
+  }
+
+  t.strictEqual(cleanStr(inspect(connection)), cleanStr(`{ url:
    URL {
      href: 'http://localhost:9200/',
      origin: 'http://localhost:9200',
@@ -701,6 +710,6 @@ test('Util.inspect Connection class should hide agent and ssl', t => {
   resurrectTimeout: 0,
   _openRequests: 0,
   status: 'alive',
-  roles: { master: true, data: true, ingest: true, ml: false } }`
+  roles: { master: true, data: true, ingest: true, ml: false } }`)
   )
 })

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -20,6 +20,7 @@
 'use strict'
 
 const { test } = require('tap')
+const { inspect } = require('util')
 const { createGzip, createDeflate } = require('zlib')
 const { URL } = require('url')
 const intoStream = require('into-stream')
@@ -669,4 +670,37 @@ test('setRole', t => {
   })
 
   t.end()
+})
+
+test('Util.inspect Connection class should hide agent and ssl', t => {
+  t.plan(1)
+
+  const connection = new Connection({
+    url: new URL('http://localhost:9200'),
+    id: 'node-id',
+    headers: { foo: 'bar' }
+  })
+
+  t.strictEqual(inspect(connection), `{ url:
+   URL {
+     href: 'http://localhost:9200/',
+     origin: 'http://localhost:9200',
+     protocol: 'http:',
+     username: '',
+     password: '',
+     host: 'localhost:9200',
+     hostname: 'localhost',
+     port: '9200',
+     pathname: '/',
+     search: '',
+     searchParams: URLSearchParams {},
+     hash: '' },
+  id: 'node-id',
+  headers: { foo: 'bar' },
+  deadCount: 0,
+  resurrectTimeout: 0,
+  _openRequests: 0,
+  status: 'alive',
+  roles: { master: true, data: true, ingest: true, ml: false } }`
+  )
 })


### PR DESCRIPTION
Handles `console.log` and `utils.inspect` invocations for a better debugging experience.

`agent` and `ssl` are hidden since they made the logs very hard to read.
The user can still access them with `instance.agent` and `instance.ssl`.