### PR TITLE
Docs: Fix link in changelog

### DIFF
--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -205,7 +205,7 @@ const client = new elasticsearch.Client({
 
 === 1.5 (Feb 6 2014)
   * Switched out `keepaliveagent` dependency with `forever-agent`, which is used in the ever popular `request` module, and is much simpler
-  * The option to use keep-alive is now all or nothing. `maxKeepAliveTime` and `maxKeepAliveRequests` config parameters have been replaced by `keepAlive`, which will keeps at least `minSockets` connections open forever. See: http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html
+  * The option to use keep-alive is now all or nothing. `maxKeepAliveTime` and `maxKeepAliveRequests` config parameters have been replaced by `keepAlive`, which will keeps at least `minSockets` connections open forever. See: <<configuration>>
   * Closing the client with `keepAlive` turned on will allow the process to exit. https://github.com/elastic/elasticsearch-js/issues/40
   * Fixed a bug that caused invalid param/type errors to not be reported properly, in the browser builds that use promises
   * added the cat.threadPool to the master/1.0/1.x apis


### PR DESCRIPTION
The changelog had a link to `/current/configuration.html` which isn't in
the current version of the docs anymore. This changes the link from a
fully qualified link to an in-book link.
