### PR TITLE
Fix a typo in usage example

### DIFF
--- a/docs/usage.asciidoc
+++ b/docs/usage.asciidoc
@@ -66,7 +66,7 @@ When using the callback style API, the function will also return an object that 
 [source,js]
 ----
 // calback API
-const requesty = client.search({
+const request = client.search({
   index: 'my-index',
   body: { foo: 'bar' }
 }, {


### PR DESCRIPTION
Rename constant `requesty` to `request` which is referred to later in the example.