### PR TITLE
Custom http agent support

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -90,8 +90,20 @@ _Default:_ `false`
 _Default:_ `null`
 
 |`agent`
-|`http.AgentOptions` - http agent https://nodejs.org/api/http.html#http_new_agent_options[options], or an actual http agent instance. +
+a|`http.AgentOptions, function` - http agent https://nodejs.org/api/http.html#http_new_agent_options[options], or a function that returns an actual http agent instance. +
 _Default:_ `null`
+[source,js]
+----
+const client = new Client({
+  node: 'http://localhost:9200',
+  agent: { agent: 'options' }
+})
+
+const client = new Client({
+  node: 'http://localhost:9200',
+  agent: () => new CustomAgent()
+})
+----
 
 |`nodeFilter`
 a|`function` - Filters which node not to use for a request. +

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -90,7 +90,7 @@ _Default:_ `false`
 _Default:_ `null`
 
 |`agent`
-|`http.AgentOptions` - http agent https://nodejs.org/api/http.html#http_new_agent_options[options]. +
+|`http.AgentOptions` - http agent https://nodejs.org/api/http.html#http_new_agent_options[options], or an actual http agent instance. +
 _Default:_ `null`
 
 |`nodeFilter`

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,8 @@
 
 import { EventEmitter } from 'events';
 import { SecureContextOptions } from 'tls';
+import * as http from 'http';
+import * as https from 'https';
 import Transport, {
   ApiResponse,
   RequestEvent,
@@ -82,7 +84,7 @@ interface ClientOptions {
   suggestCompression?: boolean;
   compression?: 'gzip';
   ssl?: SecureContextOptions;
-  agent?: AgentOptions;
+  agent?: AgentOptions | http.Agent | https.Agent;
   nodeFilter?: nodeFilterFn;
   nodeSelector?: nodeSelectorFn | string;
   headers?: anyObject;

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,8 +21,6 @@
 
 import { EventEmitter } from 'events';
 import { SecureContextOptions } from 'tls';
-import * as http from 'http';
-import * as https from 'https';
 import Transport, {
   ApiResponse,
   RequestEvent,
@@ -31,7 +29,7 @@ import Transport, {
   nodeFilterFn,
   nodeSelectorFn
 } from './lib/Transport';
-import Connection, { AgentOptions } from './lib/Connection';
+import Connection, { AgentOptions, agentFn } from './lib/Connection';
 import ConnectionPool, { ResurrectEvent } from './lib/ConnectionPool';
 import Serializer from './lib/Serializer';
 import * as RequestParams from './api/requestParams';
@@ -84,7 +82,7 @@ interface ClientOptions {
   suggestCompression?: boolean;
   compression?: 'gzip';
   ssl?: SecureContextOptions;
-  agent?: AgentOptions | http.Agent | https.Agent;
+  agent?: AgentOptions | agentFn;
   nodeFilter?: nodeFilterFn;
   nodeSelector?: nodeSelectorFn | string;
   headers?: anyObject;

--- a/lib/Connection.d.ts
+++ b/lib/Connection.d.ts
@@ -22,6 +22,7 @@
 import { URL } from 'url';
 import { inspect, InspectOptions } from 'util';
 import * as http from 'http';
+import * as https from 'http';
 import { SecureContextOptions } from 'tls';
 
 interface ConnectionOptions {
@@ -29,7 +30,7 @@ interface ConnectionOptions {
   ssl?: SecureContextOptions;
   id?: string;
   headers?: any;
-  agent?: AgentOptions;
+  agent?: AgentOptions | http.Agent | https.Agent;
   status?: string;
   roles?: any;
 }

--- a/lib/Connection.d.ts
+++ b/lib/Connection.d.ts
@@ -22,15 +22,16 @@
 import { URL } from 'url';
 import { inspect, InspectOptions } from 'util';
 import * as http from 'http';
-import * as https from 'http';
 import { SecureContextOptions } from 'tls';
+
+export declare type agentFn = () => any;
 
 interface ConnectionOptions {
   url: URL;
   ssl?: SecureContextOptions;
   id?: string;
   headers?: any;
-  agent?: AgentOptions | http.Agent | https.Agent;
+  agent?: AgentOptions | agentFn;
   status?: string;
   roles?: any;
 }

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -46,18 +46,20 @@ class Connection {
       throw new ConfigurationError(`Invalid protocol: '${this.url.protocol}'`)
     }
 
-    // Probably there is a bug in Node Core
-    // see https://github.com/nodejs/node/issues/26357
-    const keepAliveFalse = opts.agent && opts.agent.keepAlive === false
-    const agentOptions = Object.assign({}, {
-      keepAlive: true,
-      keepAliveMsecs: 1000,
-      maxSockets: keepAliveFalse ? Infinity : 256,
-      maxFreeSockets: 256
-    }, opts.agent)
-    this.agent = this.url.protocol === 'http:'
-      ? new http.Agent(agentOptions)
-      : new https.Agent(Object.assign({}, agentOptions, this.ssl))
+    if (opts.agent instanceof http.Agent || opts.agent instanceof https.Agent) {
+      this.agent = opts.agent
+    } else {
+      const keepAliveFalse = opts.agent && opts.agent.keepAlive === false
+      const agentOptions = Object.assign({}, {
+        keepAlive: true,
+        keepAliveMsecs: 1000,
+        maxSockets: keepAliveFalse ? Infinity : 256,
+        maxFreeSockets: 256
+      }, opts.agent)
+      this.agent = this.url.protocol === 'http:'
+        ? new http.Agent(agentOptions)
+        : new https.Agent(Object.assign({}, agentOptions, this.ssl))
+    }
 
     this.makeRequest = this.url.protocol === 'http:'
       ? http.request

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -46,8 +46,8 @@ class Connection {
       throw new ConfigurationError(`Invalid protocol: '${this.url.protocol}'`)
     }
 
-    if (opts.agent instanceof http.Agent || opts.agent instanceof https.Agent) {
-      this.agent = opts.agent
+    if (typeof opts.agent === 'function') {
+      this.agent = opts.agent()
     } else {
       const keepAliveFalse = opts.agent && opts.agent.keepAlive === false
       const agentOptions = Object.assign({}, {

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -171,7 +171,7 @@ test('Custom http agent', t => {
     agent.custom = true
     const connection = new Connection({
       url: new URL(`http://localhost:${port}`),
-      agent
+      agent: () => agent
     })
     t.true(connection.agent.custom)
     connection.request({

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -23,6 +23,7 @@ const { test } = require('tap')
 const { inspect } = require('util')
 const { createGzip, createDeflate } = require('zlib')
 const { URL } = require('url')
+const { Agent } = require('http')
 const intoStream = require('into-stream')
 const { buildServer } = require('../utils')
 const Connection = require('../../lib/Connection')
@@ -124,6 +125,55 @@ test('Basic (https with ssl agent)', t => {
       url: new URL(`https://localhost:${port}`),
       ssl: { key, cert }
     })
+    connection.request({
+      path: '/hello',
+      method: 'GET',
+      headers: {
+        'X-Custom-Test': true
+      }
+    }, (err, res) => {
+      t.error(err)
+
+      t.match(res.headers, {
+        connection: 'keep-alive'
+      })
+
+      var payload = ''
+      res.setEncoding('utf8')
+      res.on('data', chunk => { payload += chunk })
+      res.on('error', err => t.fail(err))
+      res.on('end', () => {
+        t.strictEqual(payload, 'ok')
+        server.stop()
+      })
+    })
+  })
+})
+
+test('Custom http agent', t => {
+  t.plan(5)
+
+  function handler (req, res) {
+    t.match(req.headers, {
+      'x-custom-test': 'true',
+      connection: 'keep-alive'
+    })
+    res.end('ok')
+  }
+
+  buildServer(handler, ({ port }, server) => {
+    const agent = new Agent({
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+      maxSockets: 256,
+      maxFreeSockets: 256
+    })
+    agent.custom = true
+    const connection = new Connection({
+      url: new URL(`http://localhost:${port}`),
+      agent
+    })
+    t.true(connection.agent.custom)
     connection.request({
       path: '/hello',
       method: 'GET',


### PR DESCRIPTION
With this pr we add the support for a custom http(s) agent passed as a parameter instead of the http agent options.
In any case, you will use the same `agent` configuration option.

```js
const { Agent } = require('http')
const { Client } = require('@elastic/elasticsearch')

const client = new Client({
  node: 'http://localhost:9200',
  agent: new Agent({ ... })
})

client.info(console.log)
```

Related: https://github.com/elastic/elasticsearch-js/issues/808 https://github.com/elastic/elasticsearch-js/issues/809