### PR TITLE
Improve typings

### DIFF
--- a/api/api/data_frame.get_data_frame_transform_stats.js
+++ b/api/api/data_frame.get_data_frame_transform_stats.js
@@ -29,10 +29,13 @@ function buildDataFrameGetDataFrameTransformStats (opts) {
    * Perform a [data_frame.get_data_frame_transform_stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-data-frame-transform-stats.html) request
    *
    * @param {string} transform_id - The id of the transform for which to get stats. '_all' or '*' implies all transforms
+   * @param {number} from - skips a number of transform stats, defaults to 0
+   * @param {number} size - specifies a max number of transform stats to get, defaults to 100
    */
 
   const acceptedQuerystring = [
-
+    'from',
+    'size'
   ]
 
   const snakeCase = {

--- a/api/requestParams.d.ts
+++ b/api/requestParams.d.ts
@@ -27,7 +27,7 @@ export interface Generic {
   source?: string;
 }
 
-export interface Bulk extends Generic {
+export interface Bulk<T = any> extends Generic {
   index?: string;
   type?: string;
   wait_for_active_shards?: string;
@@ -38,7 +38,7 @@ export interface Bulk extends Generic {
   _source_excludes?: string | string[];
   _source_includes?: string | string[];
   pipeline?: string;
-  body: any;
+  body: T;
 }
 
 export interface CatAliases extends Generic {
@@ -258,15 +258,15 @@ export interface CatThreadPool extends Generic {
   v?: boolean;
 }
 
-export interface ClearScroll extends Generic {
+export interface ClearScroll<T = any> extends Generic {
   scroll_id?: string | string[];
-  body?: any;
+  body?: T;
 }
 
-export interface ClusterAllocationExplain extends Generic {
+export interface ClusterAllocationExplain<T = any> extends Generic {
   include_yes_decisions?: boolean;
   include_disk_info?: boolean;
-  body?: any;
+  body?: T;
 }
 
 export interface ClusterGetSettings extends Generic {
@@ -296,24 +296,24 @@ export interface ClusterPendingTasks extends Generic {
   master_timeout?: string;
 }
 
-export interface ClusterPutSettings extends Generic {
+export interface ClusterPutSettings<T = any> extends Generic {
   flat_settings?: boolean;
   master_timeout?: string;
   timeout?: string;
-  body: any;
+  body: T;
 }
 
 export interface ClusterRemoteInfo extends Generic {
 }
 
-export interface ClusterReroute extends Generic {
+export interface ClusterReroute<T = any> extends Generic {
   dry_run?: boolean;
   explain?: boolean;
   retry_failed?: boolean;
   metric?: string | string[];
   master_timeout?: string;
   timeout?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface ClusterState extends Generic {
@@ -335,7 +335,7 @@ export interface ClusterStats extends Generic {
   timeout?: string;
 }
 
-export interface Count extends Generic {
+export interface Count<T = any> extends Generic {
   index?: string | string[];
   type?: string | string[];
   ignore_unavailable?: boolean;
@@ -352,10 +352,10 @@ export interface Count extends Generic {
   df?: string;
   lenient?: boolean;
   terminate_after?: number;
-  body?: any;
+  body?: T;
 }
 
-export interface Create extends Generic {
+export interface Create<T = any> extends Generic {
   id: string;
   index: string;
   type?: string;
@@ -367,7 +367,7 @@ export interface Create extends Generic {
   version?: number;
   version_type?: 'internal' | 'external' | 'external_gte' | 'force';
   pipeline?: string;
-  body: any;
+  body: T;
 }
 
 export interface Delete extends Generic {
@@ -385,7 +385,7 @@ export interface Delete extends Generic {
   version_type?: 'internal' | 'external' | 'external_gte' | 'force';
 }
 
-export interface DeleteByQuery extends Generic {
+export interface DeleteByQuery<T = any> extends Generic {
   index: string | string[];
   type?: string | string[];
   analyzer?: string;
@@ -420,7 +420,7 @@ export interface DeleteByQuery extends Generic {
   wait_for_completion?: boolean;
   requests_per_second?: number;
   slices?: number;
-  body: any;
+  body: T;
 }
 
 export interface DeleteByQueryRethrottle extends Generic {
@@ -467,7 +467,7 @@ export interface ExistsSource extends Generic {
   version_type?: 'internal' | 'external' | 'external_gte' | 'force';
 }
 
-export interface Explain extends Generic {
+export interface Explain<T = any> extends Generic {
   id: string;
   index: string;
   type?: string;
@@ -484,7 +484,7 @@ export interface Explain extends Generic {
   _source?: string | string[];
   _source_excludes?: string | string[];
   _source_includes?: string | string[];
-  body?: any;
+  body?: T;
 }
 
 export interface FieldCaps extends Generic {
@@ -535,7 +535,7 @@ export interface GetSource extends Generic {
   version_type?: 'internal' | 'external' | 'external_gte' | 'force';
 }
 
-export interface Index extends Generic {
+export interface Index<T = any> extends Generic {
   id?: string;
   index: string;
   type?: string;
@@ -550,12 +550,12 @@ export interface Index extends Generic {
   if_seq_no?: number;
   if_primary_term?: number;
   pipeline?: string;
-  body: any;
+  body: T;
 }
 
-export interface IndicesAnalyze extends Generic {
+export interface IndicesAnalyze<T = any> extends Generic {
   index?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface IndicesClearCache extends Generic {
@@ -579,13 +579,13 @@ export interface IndicesClose extends Generic {
   wait_for_active_shards?: string;
 }
 
-export interface IndicesCreate extends Generic {
+export interface IndicesCreate<T = any> extends Generic {
   index: string;
   include_type_name?: boolean;
   wait_for_active_shards?: string;
   timeout?: string;
   master_timeout?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface IndicesDelete extends Generic {
@@ -752,15 +752,15 @@ export interface IndicesOpen extends Generic {
   wait_for_active_shards?: string;
 }
 
-export interface IndicesPutAlias extends Generic {
+export interface IndicesPutAlias<T = any> extends Generic {
   index: string | string[];
   name: string;
   timeout?: string;
   master_timeout?: string;
-  body?: any;
+  body?: T;
 }
 
-export interface IndicesPutMapping extends Generic {
+export interface IndicesPutMapping<T = any> extends Generic {
   index?: string | string[];
   type?: string;
   include_type_name?: boolean;
@@ -769,10 +769,10 @@ export interface IndicesPutMapping extends Generic {
   ignore_unavailable?: boolean;
   allow_no_indices?: boolean;
   expand_wildcards?: 'open' | 'closed' | 'none' | 'all';
-  body: any;
+  body: T;
 }
 
-export interface IndicesPutSettings extends Generic {
+export interface IndicesPutSettings<T = any> extends Generic {
   index?: string | string[];
   master_timeout?: string;
   timeout?: string;
@@ -781,10 +781,10 @@ export interface IndicesPutSettings extends Generic {
   allow_no_indices?: boolean;
   expand_wildcards?: 'open' | 'closed' | 'none' | 'all';
   flat_settings?: boolean;
-  body: any;
+  body: T;
 }
 
-export interface IndicesPutTemplate extends Generic {
+export interface IndicesPutTemplate<T = any> extends Generic {
   name: string;
   include_type_name?: boolean;
   order?: number;
@@ -792,7 +792,7 @@ export interface IndicesPutTemplate extends Generic {
   timeout?: string;
   master_timeout?: string;
   flat_settings?: boolean;
-  body: any;
+  body: T;
 }
 
 export interface IndicesRecovery extends Generic {
@@ -808,7 +808,7 @@ export interface IndicesRefresh extends Generic {
   expand_wildcards?: 'open' | 'closed' | 'none' | 'all';
 }
 
-export interface IndicesRollover extends Generic {
+export interface IndicesRollover<T = any> extends Generic {
   alias: string;
   new_index?: string;
   include_type_name?: boolean;
@@ -816,7 +816,7 @@ export interface IndicesRollover extends Generic {
   dry_run?: boolean;
   master_timeout?: string;
   wait_for_active_shards?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface IndicesSegments extends Generic {
@@ -835,22 +835,22 @@ export interface IndicesShardStores extends Generic {
   expand_wildcards?: 'open' | 'closed' | 'none' | 'all';
 }
 
-export interface IndicesShrink extends Generic {
+export interface IndicesShrink<T = any> extends Generic {
   index: string;
   target: string;
   timeout?: string;
   master_timeout?: string;
   wait_for_active_shards?: string;
-  body?: any;
+  body?: T;
 }
 
-export interface IndicesSplit extends Generic {
+export interface IndicesSplit<T = any> extends Generic {
   index: string;
   target: string;
   timeout?: string;
   master_timeout?: string;
   wait_for_active_shards?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface IndicesStats extends Generic {
@@ -868,10 +868,10 @@ export interface IndicesStats extends Generic {
   forbid_closed_indices?: boolean;
 }
 
-export interface IndicesUpdateAliases extends Generic {
+export interface IndicesUpdateAliases<T = any> extends Generic {
   timeout?: string;
   master_timeout?: string;
-  body: any;
+  body: T;
 }
 
 export interface IndicesUpgrade extends Generic {
@@ -883,7 +883,7 @@ export interface IndicesUpgrade extends Generic {
   only_ancient_segments?: boolean;
 }
 
-export interface IndicesValidateQuery extends Generic {
+export interface IndicesValidateQuery<T = any> extends Generic {
   index?: string | string[];
   type?: string | string[];
   explain?: boolean;
@@ -898,7 +898,7 @@ export interface IndicesValidateQuery extends Generic {
   lenient?: boolean;
   rewrite?: boolean;
   all_shards?: boolean;
-  body?: any;
+  body?: T;
 }
 
 export interface Info extends Generic {
@@ -918,20 +918,20 @@ export interface IngestGetPipeline extends Generic {
 export interface IngestProcessorGrok extends Generic {
 }
 
-export interface IngestPutPipeline extends Generic {
+export interface IngestPutPipeline<T = any> extends Generic {
   id: string;
   master_timeout?: string;
   timeout?: string;
-  body: any;
+  body: T;
 }
 
-export interface IngestSimulate extends Generic {
+export interface IngestSimulate<T = any> extends Generic {
   id?: string;
   verbose?: boolean;
-  body: any;
+  body: T;
 }
 
-export interface Mget extends Generic {
+export interface Mget<T = any> extends Generic {
   index?: string;
   type?: string;
   stored_fields?: string | string[];
@@ -942,10 +942,10 @@ export interface Mget extends Generic {
   _source?: string | string[];
   _source_excludes?: string | string[];
   _source_includes?: string | string[];
-  body: any;
+  body: T;
 }
 
-export interface Msearch extends Generic {
+export interface Msearch<T = any> extends Generic {
   index?: string | string[];
   type?: string | string[];
   search_type?: 'query_then_fetch' | 'query_and_fetch' | 'dfs_query_then_fetch' | 'dfs_query_and_fetch';
@@ -955,10 +955,10 @@ export interface Msearch extends Generic {
   max_concurrent_shard_requests?: number;
   rest_total_hits_as_int?: boolean;
   ccs_minimize_roundtrips?: boolean;
-  body: any;
+  body: T;
 }
 
-export interface MsearchTemplate extends Generic {
+export interface MsearchTemplate<T = any> extends Generic {
   index?: string | string[];
   type?: string | string[];
   search_type?: 'query_then_fetch' | 'query_and_fetch' | 'dfs_query_then_fetch' | 'dfs_query_and_fetch';
@@ -966,10 +966,10 @@ export interface MsearchTemplate extends Generic {
   max_concurrent_searches?: number;
   rest_total_hits_as_int?: boolean;
   ccs_minimize_roundtrips?: boolean;
-  body: any;
+  body: T;
 }
 
-export interface Mtermvectors extends Generic {
+export interface Mtermvectors<T = any> extends Generic {
   index?: string;
   type?: string;
   ids?: string | string[];
@@ -985,7 +985,7 @@ export interface Mtermvectors extends Generic {
   realtime?: boolean;
   version?: number;
   version_type?: 'internal' | 'external' | 'external_gte' | 'force';
-  body?: any;
+  body?: T;
 }
 
 export interface NodesHotThreads extends Generic {
@@ -1033,23 +1033,23 @@ export interface NodesUsage extends Generic {
 export interface Ping extends Generic {
 }
 
-export interface PutScript extends Generic {
+export interface PutScript<T = any> extends Generic {
   id: string;
   context?: string;
   timeout?: string;
   master_timeout?: string;
-  body: any;
+  body: T;
 }
 
-export interface RankEval extends Generic {
+export interface RankEval<T = any> extends Generic {
   index?: string | string[];
   ignore_unavailable?: boolean;
   allow_no_indices?: boolean;
   expand_wildcards?: 'open' | 'closed' | 'none' | 'all';
-  body: any;
+  body: T;
 }
 
-export interface Reindex extends Generic {
+export interface Reindex<T = any> extends Generic {
   refresh?: boolean;
   timeout?: string;
   wait_for_active_shards?: string;
@@ -1057,7 +1057,7 @@ export interface Reindex extends Generic {
   requests_per_second?: number;
   scroll?: string;
   slices?: number;
-  body: any;
+  body: T;
 }
 
 export interface ReindexRethrottle extends Generic {
@@ -1065,27 +1065,27 @@ export interface ReindexRethrottle extends Generic {
   requests_per_second: number;
 }
 
-export interface RenderSearchTemplate extends Generic {
+export interface RenderSearchTemplate<T = any> extends Generic {
   id?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface ScriptsPainlessContext extends Generic {
   context?: string;
 }
 
-export interface ScriptsPainlessExecute extends Generic {
-  body?: any;
+export interface ScriptsPainlessExecute<T = any> extends Generic {
+  body?: T;
 }
 
-export interface Scroll extends Generic {
+export interface Scroll<T = any> extends Generic {
   scroll_id?: string;
   scroll?: string;
   rest_total_hits_as_int?: boolean;
-  body?: any;
+  body?: T;
 }
 
-export interface Search extends Generic {
+export interface Search<T = any> extends Generic {
   index?: string | string[];
   type?: string | string[];
   analyzer?: string;
@@ -1130,7 +1130,7 @@ export interface Search extends Generic {
   max_concurrent_shard_requests?: number;
   pre_filter_shard_size?: number;
   rest_total_hits_as_int?: boolean;
-  body?: any;
+  body?: T;
 }
 
 export interface SearchShards extends Generic {
@@ -1143,7 +1143,7 @@ export interface SearchShards extends Generic {
   expand_wildcards?: 'open' | 'closed' | 'none' | 'all';
 }
 
-export interface SearchTemplate extends Generic {
+export interface SearchTemplate<T = any> extends Generic {
   index?: string | string[];
   type?: string | string[];
   ignore_unavailable?: boolean;
@@ -1159,23 +1159,23 @@ export interface SearchTemplate extends Generic {
   typed_keys?: boolean;
   rest_total_hits_as_int?: boolean;
   ccs_minimize_roundtrips?: boolean;
-  body: any;
+  body: T;
 }
 
-export interface SnapshotCreate extends Generic {
+export interface SnapshotCreate<T = any> extends Generic {
   repository: string;
   snapshot: string;
   master_timeout?: string;
   wait_for_completion?: boolean;
-  body?: any;
+  body?: T;
 }
 
-export interface SnapshotCreateRepository extends Generic {
+export interface SnapshotCreateRepository<T = any> extends Generic {
   repository: string;
   master_timeout?: string;
   timeout?: string;
   verify?: boolean;
-  body: any;
+  body: T;
 }
 
 export interface SnapshotDelete extends Generic {
@@ -1204,12 +1204,12 @@ export interface SnapshotGetRepository extends Generic {
   local?: boolean;
 }
 
-export interface SnapshotRestore extends Generic {
+export interface SnapshotRestore<T = any> extends Generic {
   repository: string;
   snapshot: string;
   master_timeout?: string;
   wait_for_completion?: boolean;
-  body?: any;
+  body?: T;
 }
 
 export interface SnapshotStatus extends Generic {
@@ -1248,7 +1248,7 @@ export interface TasksList extends Generic {
   timeout?: string;
 }
 
-export interface Termvectors extends Generic {
+export interface Termvectors<T = any> extends Generic {
   index: string;
   type?: string;
   id?: string;
@@ -1264,10 +1264,10 @@ export interface Termvectors extends Generic {
   realtime?: boolean;
   version?: number;
   version_type?: 'internal' | 'external' | 'external_gte' | 'force';
-  body?: any;
+  body?: T;
 }
 
-export interface Update extends Generic {
+export interface Update<T = any> extends Generic {
   id: string;
   index: string;
   type?: string;
@@ -1283,10 +1283,10 @@ export interface Update extends Generic {
   timeout?: string;
   if_seq_no?: number;
   if_primary_term?: number;
-  body: any;
+  body: T;
 }
 
-export interface UpdateByQuery extends Generic {
+export interface UpdateByQuery<T = any> extends Generic {
   index: string | string[];
   type?: string | string[];
   analyzer?: string;
@@ -1323,7 +1323,7 @@ export interface UpdateByQuery extends Generic {
   wait_for_completion?: boolean;
   requests_per_second?: number;
   slices?: number;
-  body?: any;
+  body?: T;
 }
 
 export interface UpdateByQueryRethrottle extends Generic {
@@ -1335,10 +1335,10 @@ export interface CcrDeleteAutoFollowPattern extends Generic {
   name: string;
 }
 
-export interface CcrFollow extends Generic {
+export interface CcrFollow<T = any> extends Generic {
   index: string;
   wait_for_active_shards?: string;
-  body: any;
+  body: T;
 }
 
 export interface CcrFollowInfo extends Generic {
@@ -1349,9 +1349,9 @@ export interface CcrFollowStats extends Generic {
   index: string | string[];
 }
 
-export interface CcrForgetFollower extends Generic {
+export interface CcrForgetFollower<T = any> extends Generic {
   index: string;
-  body: any;
+  body: T;
 }
 
 export interface CcrGetAutoFollowPattern extends Generic {
@@ -1362,14 +1362,14 @@ export interface CcrPauseFollow extends Generic {
   index: string;
 }
 
-export interface CcrPutAutoFollowPattern extends Generic {
+export interface CcrPutAutoFollowPattern<T = any> extends Generic {
   name: string;
-  body: any;
+  body: T;
 }
 
-export interface CcrResumeFollow extends Generic {
+export interface CcrResumeFollow<T = any> extends Generic {
   index: string;
-  body?: any;
+  body?: T;
 }
 
 export interface CcrStats extends Generic {
@@ -1391,15 +1391,17 @@ export interface DataFrameGetDataFrameTransform extends Generic {
 
 export interface DataFrameGetDataFrameTransformStats extends Generic {
   transform_id?: string;
+  from?: number;
+  size?: number;
 }
 
-export interface DataFramePreviewDataFrameTransform extends Generic {
-  body: any;
+export interface DataFramePreviewDataFrameTransform<T = any> extends Generic {
+  body: T;
 }
 
-export interface DataFramePutDataFrameTransform extends Generic {
+export interface DataFramePutDataFrameTransform<T = any> extends Generic {
   transform_id: string;
-  body: any;
+  body: T;
 }
 
 export interface DataFrameStartDataFrameTransform extends Generic {
@@ -1413,12 +1415,12 @@ export interface DataFrameStopDataFrameTransform extends Generic {
   timeout?: string;
 }
 
-export interface GraphExplore extends Generic {
+export interface GraphExplore<T = any> extends Generic {
   index?: string | string[];
   type?: string | string[];
   routing?: string;
   timeout?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface IlmDeleteLifecycle extends Generic {
@@ -1436,14 +1438,14 @@ export interface IlmGetLifecycle extends Generic {
 export interface IlmGetStatus extends Generic {
 }
 
-export interface IlmMoveToStep extends Generic {
+export interface IlmMoveToStep<T = any> extends Generic {
   index?: string;
-  body?: any;
+  body?: T;
 }
 
-export interface IlmPutLifecycle extends Generic {
+export interface IlmPutLifecycle<T = any> extends Generic {
   policy?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface IlmRemovePolicy extends Generic {
@@ -1493,9 +1495,9 @@ export interface LicenseGetBasicStatus extends Generic {
 export interface LicenseGetTrialStatus extends Generic {
 }
 
-export interface LicensePost extends Generic {
+export interface LicensePost<T = any> extends Generic {
   acknowledge?: boolean;
-  body?: any;
+  body?: T;
 }
 
 export interface LicensePostStartBasic extends Generic {
@@ -1511,12 +1513,12 @@ export interface MigrationDeprecations extends Generic {
   index?: string;
 }
 
-export interface MlCloseJob extends Generic {
+export interface MlCloseJob<T = any> extends Generic {
   job_id: string;
   allow_no_jobs?: boolean;
   force?: boolean;
   timeout?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface MlDeleteCalendar extends Generic {
@@ -1563,7 +1565,7 @@ export interface MlDeleteModelSnapshot extends Generic {
   snapshot_id: string;
 }
 
-export interface MlFindFileStructure extends Generic {
+export interface MlFindFileStructure<T = any> extends Generic {
   lines_to_sample?: number;
   timeout?: string;
   charset?: string;
@@ -1577,17 +1579,17 @@ export interface MlFindFileStructure extends Generic {
   timestamp_field?: string;
   timestamp_format?: string;
   explain?: boolean;
-  body: any;
+  body: T;
 }
 
-export interface MlFlushJob extends Generic {
+export interface MlFlushJob<T = any> extends Generic {
   job_id: string;
   calc_interim?: boolean;
   start?: string;
   end?: string;
   advance_time?: string;
   skip_time?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface MlForecast extends Generic {
@@ -1596,7 +1598,7 @@ export interface MlForecast extends Generic {
   expires_in?: string;
 }
 
-export interface MlGetBuckets extends Generic {
+export interface MlGetBuckets<T = any> extends Generic {
   job_id: string;
   timestamp?: string;
   expand?: boolean;
@@ -1608,7 +1610,7 @@ export interface MlGetBuckets extends Generic {
   anomaly_score?: number;
   sort?: string;
   desc?: boolean;
-  body?: any;
+  body?: T;
 }
 
 export interface MlGetCalendarEvents extends Generic {
@@ -1620,19 +1622,19 @@ export interface MlGetCalendarEvents extends Generic {
   size?: number;
 }
 
-export interface MlGetCalendars extends Generic {
+export interface MlGetCalendars<T = any> extends Generic {
   calendar_id?: string;
   from?: number;
   size?: number;
-  body?: any;
+  body?: T;
 }
 
-export interface MlGetCategories extends Generic {
+export interface MlGetCategories<T = any> extends Generic {
   job_id: string;
   category_id?: number;
   from?: number;
   size?: number;
-  body?: any;
+  body?: T;
 }
 
 export interface MlGetDatafeedStats extends Generic {
@@ -1651,7 +1653,7 @@ export interface MlGetFilters extends Generic {
   size?: number;
 }
 
-export interface MlGetInfluencers extends Generic {
+export interface MlGetInfluencers<T = any> extends Generic {
   job_id: string;
   exclude_interim?: boolean;
   from?: number;
@@ -1661,7 +1663,7 @@ export interface MlGetInfluencers extends Generic {
   influencer_score?: number;
   sort?: string;
   desc?: boolean;
-  body?: any;
+  body?: T;
 }
 
 export interface MlGetJobStats extends Generic {
@@ -1674,7 +1676,7 @@ export interface MlGetJobs extends Generic {
   allow_no_jobs?: boolean;
 }
 
-export interface MlGetModelSnapshots extends Generic {
+export interface MlGetModelSnapshots<T = any> extends Generic {
   job_id: string;
   snapshot_id?: string;
   from?: number;
@@ -1683,10 +1685,10 @@ export interface MlGetModelSnapshots extends Generic {
   end?: string;
   sort?: string;
   desc?: boolean;
-  body?: any;
+  body?: T;
 }
 
-export interface MlGetOverallBuckets extends Generic {
+export interface MlGetOverallBuckets<T = any> extends Generic {
   job_id: string;
   top_n?: number;
   bucket_span?: string;
@@ -1695,10 +1697,10 @@ export interface MlGetOverallBuckets extends Generic {
   start?: string;
   end?: string;
   allow_no_jobs?: boolean;
-  body?: any;
+  body?: T;
 }
 
-export interface MlGetRecords extends Generic {
+export interface MlGetRecords<T = any> extends Generic {
   job_id: string;
   exclude_interim?: boolean;
   from?: number;
@@ -1708,7 +1710,7 @@ export interface MlGetRecords extends Generic {
   record_score?: number;
   sort?: string;
   desc?: boolean;
-  body?: any;
+  body?: T;
 }
 
 export interface MlInfo extends Generic {
@@ -1720,25 +1722,25 @@ export interface MlOpenJob extends Generic {
   timeout?: string;
 }
 
-export interface MlPostCalendarEvents extends Generic {
+export interface MlPostCalendarEvents<T = any> extends Generic {
   calendar_id: string;
-  body: any;
+  body: T;
 }
 
-export interface MlPostData extends Generic {
+export interface MlPostData<T = any> extends Generic {
   job_id: string;
   reset_start?: string;
   reset_end?: string;
-  body: any;
+  body: T;
 }
 
 export interface MlPreviewDatafeed extends Generic {
   datafeed_id: string;
 }
 
-export interface MlPutCalendar extends Generic {
+export interface MlPutCalendar<T = any> extends Generic {
   calendar_id: string;
-  body?: any;
+  body?: T;
 }
 
 export interface MlPutCalendarJob extends Generic {
@@ -1746,26 +1748,26 @@ export interface MlPutCalendarJob extends Generic {
   job_id: string;
 }
 
-export interface MlPutDatafeed extends Generic {
+export interface MlPutDatafeed<T = any> extends Generic {
   datafeed_id: string;
-  body: any;
+  body: T;
 }
 
-export interface MlPutFilter extends Generic {
+export interface MlPutFilter<T = any> extends Generic {
   filter_id: string;
-  body: any;
+  body: T;
 }
 
-export interface MlPutJob extends Generic {
+export interface MlPutJob<T = any> extends Generic {
   job_id: string;
-  body: any;
+  body: T;
 }
 
-export interface MlRevertModelSnapshot extends Generic {
+export interface MlRevertModelSnapshot<T = any> extends Generic {
   job_id: string;
   snapshot_id: string;
   delete_intervening_results?: boolean;
-  body?: any;
+  body?: T;
 }
 
 export interface MlSetUpgradeMode extends Generic {
@@ -1773,12 +1775,12 @@ export interface MlSetUpgradeMode extends Generic {
   timeout?: string;
 }
 
-export interface MlStartDatafeed extends Generic {
+export interface MlStartDatafeed<T = any> extends Generic {
   datafeed_id: string;
   start?: string;
   end?: string;
   timeout?: string;
-  body?: any;
+  body?: T;
 }
 
 export interface MlStopDatafeed extends Generic {
@@ -1788,41 +1790,41 @@ export interface MlStopDatafeed extends Generic {
   timeout?: string;
 }
 
-export interface MlUpdateDatafeed extends Generic {
+export interface MlUpdateDatafeed<T = any> extends Generic {
   datafeed_id: string;
-  body: any;
+  body: T;
 }
 
-export interface MlUpdateFilter extends Generic {
+export interface MlUpdateFilter<T = any> extends Generic {
   filter_id: string;
-  body: any;
+  body: T;
 }
 
-export interface MlUpdateJob extends Generic {
+export interface MlUpdateJob<T = any> extends Generic {
   job_id: string;
-  body: any;
+  body: T;
 }
 
-export interface MlUpdateModelSnapshot extends Generic {
+export interface MlUpdateModelSnapshot<T = any> extends Generic {
   job_id: string;
   snapshot_id: string;
-  body: any;
+  body: T;
 }
 
-export interface MlValidate extends Generic {
-  body: any;
+export interface MlValidate<T = any> extends Generic {
+  body: T;
 }
 
-export interface MlValidateDetector extends Generic {
-  body: any;
+export interface MlValidateDetector<T = any> extends Generic {
+  body: T;
 }
 
-export interface MonitoringBulk extends Generic {
+export interface MonitoringBulk<T = any> extends Generic {
   type?: string;
   system_id?: string;
   system_api_version?: string;
   interval?: string;
-  body: any;
+  body: T;
 }
 
 export interface RollupDeleteJob extends Generic {
@@ -1841,17 +1843,17 @@ export interface RollupGetRollupIndexCaps extends Generic {
   index: string;
 }
 
-export interface RollupPutJob extends Generic {
+export interface RollupPutJob<T = any> extends Generic {
   id: string;
-  body: any;
+  body: T;
 }
 
-export interface RollupRollupSearch extends Generic {
+export interface RollupRollupSearch<T = any> extends Generic {
   index: string | string[];
   type?: string;
   typed_keys?: boolean;
   rest_total_hits_as_int?: boolean;
-  body: any;
+  body: T;
 }
 
 export interface RollupStartJob extends Generic {
@@ -1867,10 +1869,10 @@ export interface RollupStopJob extends Generic {
 export interface SecurityAuthenticate extends Generic {
 }
 
-export interface SecurityChangePassword extends Generic {
+export interface SecurityChangePassword<T = any> extends Generic {
   username?: string;
   refresh?: 'true' | 'false' | 'wait_for';
-  body: any;
+  body: T;
 }
 
 export interface SecurityClearCachedRealms extends Generic {
@@ -1882,9 +1884,9 @@ export interface SecurityClearCachedRoles extends Generic {
   name: string | string[];
 }
 
-export interface SecurityCreateApiKey extends Generic {
+export interface SecurityCreateApiKey<T = any> extends Generic {
   refresh?: 'true' | 'false' | 'wait_for';
-  body: any;
+  body: T;
 }
 
 export interface SecurityDeletePrivileges extends Generic {
@@ -1938,8 +1940,8 @@ export interface SecurityGetRoleMapping extends Generic {
   name?: string;
 }
 
-export interface SecurityGetToken extends Generic {
-  body: any;
+export interface SecurityGetToken<T = any> extends Generic {
+  body: T;
 }
 
 export interface SecurityGetUser extends Generic {
@@ -1949,53 +1951,53 @@ export interface SecurityGetUser extends Generic {
 export interface SecurityGetUserPrivileges extends Generic {
 }
 
-export interface SecurityHasPrivileges extends Generic {
+export interface SecurityHasPrivileges<T = any> extends Generic {
   user?: string;
-  body: any;
+  body: T;
 }
 
-export interface SecurityInvalidateApiKey extends Generic {
-  body: any;
+export interface SecurityInvalidateApiKey<T = any> extends Generic {
+  body: T;
 }
 
-export interface SecurityInvalidateToken extends Generic {
-  body: any;
+export interface SecurityInvalidateToken<T = any> extends Generic {
+  body: T;
 }
 
-export interface SecurityPutPrivileges extends Generic {
+export interface SecurityPutPrivileges<T = any> extends Generic {
   refresh?: 'true' | 'false' | 'wait_for';
-  body: any;
+  body: T;
 }
 
-export interface SecurityPutRole extends Generic {
+export interface SecurityPutRole<T = any> extends Generic {
   name: string;
   refresh?: 'true' | 'false' | 'wait_for';
-  body: any;
+  body: T;
 }
 
-export interface SecurityPutRoleMapping extends Generic {
+export interface SecurityPutRoleMapping<T = any> extends Generic {
   name: string;
   refresh?: 'true' | 'false' | 'wait_for';
-  body: any;
+  body: T;
 }
 
-export interface SecurityPutUser extends Generic {
+export interface SecurityPutUser<T = any> extends Generic {
   username: string;
   refresh?: 'true' | 'false' | 'wait_for';
-  body: any;
+  body: T;
 }
 
-export interface SqlClearCursor extends Generic {
-  body: any;
+export interface SqlClearCursor<T = any> extends Generic {
+  body: T;
 }
 
-export interface SqlQuery extends Generic {
+export interface SqlQuery<T = any> extends Generic {
   format?: string;
-  body: any;
+  body: T;
 }
 
-export interface SqlTranslate extends Generic {
-  body: any;
+export interface SqlTranslate<T = any> extends Generic {
+  body: T;
 }
 
 export interface SslCertificates extends Generic {
@@ -2018,23 +2020,23 @@ export interface WatcherDeleteWatch extends Generic {
   id: string;
 }
 
-export interface WatcherExecuteWatch extends Generic {
+export interface WatcherExecuteWatch<T = any> extends Generic {
   id?: string;
   debug?: boolean;
-  body?: any;
+  body?: T;
 }
 
 export interface WatcherGetWatch extends Generic {
   id: string;
 }
 
-export interface WatcherPutWatch extends Generic {
+export interface WatcherPutWatch<T = any> extends Generic {
   id: string;
   active?: boolean;
   version?: number;
   if_seq_no?: number;
   if_primary_term?: number;
-  body?: any;
+  body?: T;
 }
 
 export interface WatcherStart extends Generic {

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -4352,6 +4352,12 @@ link:{ref}/get-data-frame-transform-stats.html[Reference]
 |`transform_id` or `transformId`
 |`string` - The id of the transform for which to get stats. '_all' or '*' implies all transforms
 
+|`from`
+|`number` - skips a number of transform stats, defaults to 0
+
+|`size`
+|`number` - specifies a max number of transform stats to get, defaults to 100
+
 |===
 
 === dataFrame.previewDataFrameTransform

--- a/docs/typescript.asciidoc
+++ b/docs/typescript.asciidoc
@@ -3,58 +3,80 @@
 
 The client offers a first-class support for TypeScript, since it ships the type definitions for every exposed API.
 
-While the client offers type definitions for Request parameters, Request bodies and responses are shipped with `any` because there is not an official spec that defines them, so we cannot make guarantees over them (but since they are shipped with `any`, you can easily override them with your own typing definitions).
+While the client offers type definitions for Request parameters, Request bodies and responses are shipped with https://www.typescriptlang.org/docs/handbook/generics.html[generics] (with a default type of `any`) because there is not an official spec that defines them, so we cannot make guarantees over them.
 
 NOTE: If you are using TypeScript you will be required to use _snake_case_ style to define the API parameters instead of _camelCase_. 
 
-=== How to extend the provided typings?
-Extend the provided typings is very straightforward, you should declare a custom `.d.ts` file and then write inside your type extensions, following there is an example of how do it.
+Following you can find an example that uses TypeScript and extends the default API response via generics.
+
 [source,ts]
 ----
-declare module '@elastic/elasticsearch' {
-  export interface ShardsResponse {
-    total: number;
-    successful: number;
-    failed: number;
-    skipped: number;
-  }
+import {
+  Client,
+  // Object that contains the type definitions
+  // of every API method
+  RequestParams,
+  // Interface of the generic API response
+  ApiResponse,
+} from '@elastic/elasticsearch'
 
-   export interface Explanation {
-    value: number;
-    description: string;
-    details: Explanation[];
-  }
+const client = new Client({ node: 'http://localhost:9200' })
 
-   export interface SearchResponse<T> {
-    took: number;
-    timed_out: boolean;
-    _scroll_id?: string;
-    _shards: ShardsResponse;
-    hits: {
-      total: number;
-      max_score: number;
-      hits: Array<{
-        _index: string;
-        _type: string;
-        _id: string;
-        _score: number;
-        _source: T;
-        _version?: number;
-        _explanation?: Explanation;
-        fields?: any;
-        highlight?: any;
-        inner_hits?: any;
-        matched_queries?: string[];
-        sort?: string[];
-      }>;
-    };
-    aggregations?: any;
-  }
-
-   export interface MSearchResponse<T> {
-    responses?: Array<SearchResponse<T>>;
-  }
+interface ShardsResponse {
+  total: number;
+  successful: number;
+  failed: number;
+  skipped: number;
 }
 
-export {};
+interface Explanation {
+  value: number;
+  description: string;
+  details: Explanation[];
+}
+
+interface SearchResponse<T> {
+  took: number;
+  timed_out: boolean;
+  _scroll_id?: string;
+  _shards: ShardsResponse;
+  hits: {
+    total: number;
+    max_score: number;
+    hits: Array<{
+      _index: string;
+      _type: string;
+      _id: string;
+      _score: number;
+      _source: T;
+      _version?: number;
+      _explanation?: Explanation;
+      fields?: any;
+      highlight?: any;
+      inner_hits?: any;
+      matched_queries?: string[];
+      sort?: string[];
+    }>;
+  };
+  aggregations?: any;
+}
+
+async function run (): Promise<void> {
+  // Define the search parameters
+  const searchParams: RequestParams.Search = {
+    index: 'test',
+    q: 'foo:bar'
+  }
+
+  // Define the intefrace of the source object
+  interface Source {
+    foo: string
+  }
+
+  // Craft the final type definition
+  const response: ApiResponse<SearchResponse<Source>> = await client.search(searchParams)
+  console.log(response.body)
+}
+
+run().catch(console.log)
 ----

--- a/docs/typescript.asciidoc
+++ b/docs/typescript.asciidoc
@@ -3,18 +3,72 @@
 
 The client offers a first-class support for TypeScript, since it ships the type definitions for every exposed API.
 
-While the client offers type definitions for Request parameters, Request bodies and responses are shipped with https://www.typescriptlang.org/docs/handbook/generics.html[generics] (with a default type of `any`) because there is not an official spec that defines them, so we cannot make guarantees over them.
-
 NOTE: If you are using TypeScript you will be required to use _snake_case_ style to define the API parameters instead of _camelCase_. 
 
-Following you can find an example that uses TypeScript and extends the default API response via generics.
+Other than the types for the surface API, the client offers the types for every request method, via the `RequestParams`, if you need the types for a search request for instance, you can access them via `RequestParams.Search`.
+Every API that supports a body, accepts a https://www.typescriptlang.org/docs/handbook/generics.html[generics] which represents the type of the request body, if you don't configure anything, it will default to `any`.
+
+For example:
+
+[source,ts]
+----
+import { RequestParams } from '@elastic/elasticsearch'
+
+interface SearchBody {
+  query: {
+    match: { foo: string }
+  }
+}
+
+const searchParams: RequestParams.Search<SearchBody> = {
+  index: 'test',
+  body: {
+    query: {
+      match: { foo: 'bar' }
+    }
+  }
+}
+
+// This is valid as well
+const searchParams: RequestParams.Search = {
+  index: 'test',
+  body: {
+    query: {
+      match: { foo: 'bar' }
+    }
+  }
+}
+----
+
+You can find the type definiton of a response in `ApiResponse`, which accepts a generics as well if you want to specify the body type, otherwise it defaults to `any`.
+
+[source,ts]
+----
+interface SearchResponse<T> {
+  hits: {
+    hits: Array<{
+      _source: T;
+    }>
+  }
+}
+
+// Define the intefrace of the source object
+interface Source {
+  foo: string
+}
+
+client.search(searchParams)
+  .then((response: ApiResponse<SearchResponse<Source>>) => console.log(response))
+  .catch((err: Error) => {})
+----
+
+=== A complete example
 
 [source,ts]
 ----
 import {
   Client,
-  // Object that contains the type definitions
-  // of every API method
+  // Object that contains the type definitions of every API method
   RequestParams,
   // Interface of the generic API response
   ApiResponse,
@@ -22,6 +76,14 @@ import {
 
 const client = new Client({ node: 'http://localhost:9200' })
 
+// Define the type of the body for the Search request
+interface SearchBody {
+  query: {
+    match: { foo: string }
+  }
+}
+
+// Complete definition of the Search response
 interface ShardsResponse {
   total: number;
   successful: number;
@@ -61,16 +123,20 @@ interface SearchResponse<T> {
   aggregations?: any;
 }
 
+// Define the intefrace of the source object
+interface Source {
+  foo: string
+}
+
 async function run (): Promise<void> {
   // Define the search parameters
-  const searchParams: RequestParams.Search = {
+  const searchParams: RequestParams.Search<SearchBody> = {
     index: 'test',
-    q: 'foo:bar'
-  }
-
-  // Define the intefrace of the source object
-  interface Source {
-    foo: string
+    body: {
+      query: {
+        match: { foo: 'bar' }
+      }
+    }
   }
 
   // Craft the final type definition

--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -49,7 +49,7 @@ interface TransportOptions {
   headers?: anyObject;
 }
 
-export interface RequestEvent {
+export interface RequestEvent<T = any> {
   body: any;
   statusCode: number | null;
   headers: anyObject | null;
@@ -71,7 +71,7 @@ export interface RequestEvent {
 
 // ApiResponse and RequestEvent are the same thing
 // we are doing this for have more clear names
-export interface ApiResponse extends RequestEvent {}
+export interface ApiResponse<T = any> extends RequestEvent<T> {}
 
 declare type anyObject = {
   [key: string]: any;

--- a/scripts/utils/generateRequestTypes.js
+++ b/scripts/utils/generateRequestTypes.js
@@ -74,10 +74,10 @@ export interface Generic {
     }
 
     const code = `
-export interface ${name[0].toUpperCase() + name.slice(1)} extends Generic {
+export interface ${name[0].toUpperCase() + name.slice(1)}${body ? '<T = any>' : ''} extends Generic {
   ${partsArr.map(genLine).join('\n  ')}
   ${paramsArr.map(genLine).join('\n  ')}
-  ${body ? `body${body.required ? '' : '?'}: any;` : ''}
+  ${body ? `body${body.required ? '' : '?'}: T;` : ''}
 }
 `
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -22,6 +22,7 @@
 import {
   Client,
   ApiResponse,
+  RequestParams,
   RequestEvent,
   ResurrectEvent,
   events,
@@ -92,6 +93,40 @@ client.index({
   requestTimeout: 2000
 })
   .then((result: ApiResponse) => {})
+  .catch((err: Error) => {})
+
+// --- Use generics ---
+// Define the search parameters
+interface SearchBody {
+  query: {
+    match: { foo: string }
+  }
+}
+const searchParams: RequestParams.Search<SearchBody> = {
+  index: 'test',
+  body: {
+    query: {
+      match: { foo: 'bar' }
+    }
+  }
+}
+
+// Dewfine the interface of the search response
+interface SearchResponse<T> {
+  hits: {
+    hits: Array<{
+      _source: T;
+    }>
+  }
+}
+
+// Define the intefrace of the source object
+interface Source {
+  foo: string
+}
+
+client.search(searchParams)
+  .then((response: ApiResponse<SearchResponse<Source>>) => console.log(response))
   .catch((err: Error) => {})
 
 // extend client


### PR DESCRIPTION
With this change, it's now easier to use TypeScript with the client.
The ApiResponse now accepts a [generics](https://www.typescriptlang.org/docs/handbook/generics.html) that defaults to `any`, same for every API method that might need a body.

The documentation has been updated accordingly.

I would like to thank @fox1t for the suggestions :)