### PR TITLE
Drop Node.js v6 support

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -6,6 +6,5 @@ NODE_JS_VERSION:
 - 11
 - 10
 - 8
-- 6
 
 exclude: ~

--- a/.npmignore
+++ b/.npmignore
@@ -67,3 +67,6 @@ scripts
 .ci
 .travis.yml
 certs
+.github
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ sudo: required
 language: node_js
 
 node_js:
+  - "11"
   - "10"
   - "8"
-  - "6"
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm install @elastic/elasticsearch
 
 ### Compatibility
 
+The minimum supported version of Node.js is `v8`.
+
 The library is compatible with all Elasticsearch versions since 5.x, but you should use the same major version of the Elasticsearch instance that you are using.
 ```
 # Elasticsearch 7.x
@@ -40,7 +42,9 @@ The library is compatible with all Elasticsearch versions since 5.x, but you sho
 ```
 
 ## Usage
-You can find the full documentation in the [docs](https://github.com/elastic/elasticsearch-js/tree/master/docs) folder.
+
+You can find the full documentation in our [docs](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html) website.
+
 ```js
 const { Client } = require('@elastic/elasticsearch')
 const client = new Client({ node: 'http://localhost:9200' })
@@ -70,7 +74,9 @@ The returned value of **every** API call is formed as follows:
 }
 ```
 ### Client options
+
 The client is designed to be easily configured as you see fit for your needs, following you can see all the possible options that you can use to configure it.
+
 ```ts
 {
   // the Elasticsearch endpoint to use

--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -9,7 +9,7 @@ Every breaking change was carefully weighed, and each is justified. Furthermore,
 
 === Breaking changes
 
-*  Minimum supported version of Node.js is `v6`.
+*  Minimum supported version of Node.js is `v8`.
 
 * Everything has been rewritten using ES6 classes to help users extend the defaults more easily.
 

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -18,6 +18,7 @@ npm install @elastic/elasticsearch
 ----
 
 === Compatibility
+The minimum supported version of Node.js is `v8`.
 
 The library is compatible with all Elasticsearch versions since 5.x, but you should use the same major version of the Elasticsearch instance that you are using.
 ----

--- a/package.json
+++ b/package.json
@@ -36,33 +36,33 @@
     "company": "Elasticsearch BV"
   },
   "devDependencies": {
-    "@types/node": "^10.12.24",
-    "codecov": "^3.2.0",
-    "convert-hrtime": "^2.0.0",
+    "@types/node": "^11.13.4",
+    "codecov": "^3.3.0",
+    "convert-hrtime": "^3.0.0",
     "dedent": "^0.7.0",
-    "deepmerge": "^3.1.0",
+    "deepmerge": "^3.2.0",
     "dezalgo": "^1.0.3",
-    "js-yaml": "^3.12.1",
+    "js-yaml": "^3.13.1",
     "license-checker": "^25.0.1",
     "lolex": "^3.1.0",
     "minimist": "^1.2.0",
-    "ora": "^3.2.0",
+    "ora": "^3.4.0",
     "pretty-hrtime": "^1.0.3",
     "rimraf": "^2.6.3",
-    "semver": "^5.6.0",
-    "simple-git": "^1.107.0",
+    "semver": "^6.0.0",
+    "simple-git": "^1.110.0",
     "simple-statistics": "^7.0.2",
-    "split2": "^3.1.0",
+    "split2": "^3.1.1",
     "standard": "^12.0.1",
     "stoppable": "^1.1.0",
-    "tap": "^12.6.0",
-    "typescript": "^3.3.3",
+    "tap": "^12.6.1",
+    "typescript": "^3.4.3",
     "workq": "^2.1.0"
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "decompress-response": "^4.0.0",
-    "into-stream": "^4.0.0",
+    "decompress-response": "^4.2.0",
+    "into-stream": "^5.1.0",
     "ms": "^2.1.1",
     "once": "^1.4.0",
     "pump": "^3.0.0"
@@ -76,6 +76,6 @@
     "url": "https://github.com/elastic/elasticsearch-js/issues"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   }
 }


### PR DESCRIPTION
Node.js v6 will go EOL at the end of April 2019, and already two of the production dependencies of the client have already dropped support for it, and soon others will do *(as well as development dependencies)*.

Furthermore, since Node.js will go in EOL it will never get security patches, plus, also OpenSSL-1.0.2 will go EOL [this year](https://github.com/nodejs/Release#release-schedule); to avoid risks for the client users it is better to drop support for Node.js v6 right away.