### PR TITLE
Update RequestEvent to use parameterized type T

### DIFF
--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -50,7 +50,7 @@ interface TransportOptions {
 }
 
 export interface RequestEvent<T = any> {
-  body: any;
+  body: T;
   statusCode: number | null;
   headers: anyObject | null;
   warnings: string[] | null;


### PR DESCRIPTION
Updated `RequestEvent` to use parameterized type `T`.  In reference to:

https://github.com/elastic/elasticsearch-js/pull/819#issuecomment-484594841