### PR TITLE
Remove duplication from reference.asciidoc

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -57,9 +57,6 @@ link:{ref}/docs-bulk.html[Reference]
 |`timeout`
 |`string` - Explicit operation timeout
 
-|`type`
-|`string` - Default document type for items which don't provide one
-
 |`_source`
 |`string, string[]` - True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request
 


### PR DESCRIPTION
Duplicated type entry, I left the entry at the top given that index + type are often mentioned in close proximity.

<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->
