### PR TITLE
Support for deprecated paths

### DIFF
--- a/api/api/clear_scroll.js
+++ b/api/api/clear_scroll.js
@@ -78,7 +78,11 @@ function buildClearScroll (opts) {
 
     var path = ''
 
-    path = '/' + '_search' + '/' + 'scroll'
+    if ((scroll_id || scrollId) != null) {
+      path = '/' + '_search' + '/' + 'scroll' + '/' + encodeURIComponent(scroll_id || scrollId)
+    } else {
+      path = '/' + '_search' + '/' + 'scroll'
+    }
 
     // build request object
     const request = {

--- a/api/api/count.js
+++ b/api/api/count.js
@@ -94,6 +94,12 @@ function buildCount (opts) {
       options = {}
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -115,7 +121,9 @@ function buildCount (opts) {
 
     var path = ''
 
-    if ((index) != null) {
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_count'
+    } else if ((index) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_count'
     } else {
       path = '/' + '_count'

--- a/api/api/create.js
+++ b/api/api/create.js
@@ -112,7 +112,11 @@ function buildCreate (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_create' + '/' + encodeURIComponent(id)
+    if ((index) != null && (type) != null && (id) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_create'
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_create' + '/' + encodeURIComponent(id)
+    }
 
     // build request object
     const request = {

--- a/api/api/delete.js
+++ b/api/api/delete.js
@@ -94,12 +94,6 @@ function buildDelete (opts) {
       return handleError(err, callback)
     }
 
-    // check required url components
-    if (params['id'] != null && (params['index'] == null)) {
-      const err = new ConfigurationError('Missing required parameter of the url: index')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -121,7 +115,11 @@ function buildDelete (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
+    if ((index) != null && (type) != null && (id) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id)
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
+    }
 
     // build request object
     const request = {

--- a/api/api/delete_by_query.js
+++ b/api/api/delete_by_query.js
@@ -147,6 +147,12 @@ function buildDeleteByQuery (opts) {
       return handleError(err, callback)
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -168,7 +174,11 @@ function buildDeleteByQuery (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_delete_by_query'
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_delete_by_query'
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_delete_by_query'
+    }
 
     // build request object
     const request = {

--- a/api/api/exists.js
+++ b/api/api/exists.js
@@ -119,7 +119,11 @@ function buildExists (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
+    if ((index) != null && (type) != null && (id) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id)
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
+    }
 
     // build request object
     const request = {

--- a/api/api/exists_source.js
+++ b/api/api/exists_source.js
@@ -96,7 +96,10 @@ function buildExistsSource (opts) {
     }
 
     // check required url components
-    if (params['id'] != null && (params['index'] == null)) {
+    if (params['id'] != null && (params['type'] == null || params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: type, index')
+      return handleError(err, callback)
+    } else if (params['type'] != null && (params['index'] == null)) {
       const err = new ConfigurationError('Missing required parameter of the url: index')
       return handleError(err, callback)
     }
@@ -122,7 +125,11 @@ function buildExistsSource (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_source' + '/' + encodeURIComponent(id)
+    if ((index) != null && (type) != null && (id) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_source'
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_source' + '/' + encodeURIComponent(id)
+    }
 
     // build request object
     const request = {

--- a/api/api/explain.js
+++ b/api/api/explain.js
@@ -121,7 +121,11 @@ function buildExplain (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_explain' + '/' + encodeURIComponent(id)
+    if ((index) != null && (type) != null && (id) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_explain'
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_explain' + '/' + encodeURIComponent(id)
+    }
 
     // build request object
     const request = {

--- a/api/api/get.js
+++ b/api/api/get.js
@@ -119,7 +119,11 @@ function buildGet (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
+    if ((index) != null && (type) != null && (id) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id)
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
+    }
 
     // build request object
     const request = {

--- a/api/api/get_source.js
+++ b/api/api/get_source.js
@@ -116,7 +116,11 @@ function buildGetSource (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_source' + '/' + encodeURIComponent(id)
+    if ((index) != null && (type) != null && (id) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_source'
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_source' + '/' + encodeURIComponent(id)
+    }
 
     // build request object
     const request = {

--- a/api/api/graph.explore.js
+++ b/api/api/graph.explore.js
@@ -56,6 +56,12 @@ function buildGraphExplore (opts) {
       options = {}
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -77,7 +83,11 @@ function buildGraphExplore (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_graph' + '/' + 'explore'
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_graph' + '/' + 'explore'
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_graph' + '/' + 'explore'
+    }
 
     // build request object
     const request = {

--- a/api/api/index.js
+++ b/api/api/index.js
@@ -96,12 +96,6 @@ function buildIndex (opts) {
       return handleError(err, callback)
     }
 
-    // check required url components
-    if (params['id'] != null && (params['index'] == null)) {
-      const err = new ConfigurationError('Missing required parameter of the url: index')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -123,8 +117,12 @@ function buildIndex (opts) {
 
     var path = ''
 
-    if ((index) != null && (id) != null) {
+    if ((index) != null && (type) != null && (id) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id)
+    } else if ((index) != null && (id) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
+    } else if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type)
     } else {
       path = '/' + encodeURIComponent(index) + '/' + '_doc'
     }

--- a/api/api/indices.get_field_mapping.js
+++ b/api/api/indices.get_field_mapping.js
@@ -106,8 +106,12 @@ function buildIndicesGetFieldMapping (opts) {
 
     var path = ''
 
-    if ((index) != null && (fields) != null) {
+    if ((index) != null && (type) != null && (fields) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + '_mapping' + '/' + encodeURIComponent(type) + '/' + 'field' + '/' + encodeURIComponent(fields)
+    } else if ((index) != null && (fields) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_mapping' + '/' + 'field' + '/' + encodeURIComponent(fields)
+    } else if ((type) != null && (fields) != null) {
+      path = '/' + '_mapping' + '/' + encodeURIComponent(type) + '/' + 'field' + '/' + encodeURIComponent(fields)
     } else {
       path = '/' + '_mapping' + '/' + 'field' + '/' + encodeURIComponent(fields)
     }

--- a/api/api/indices.get_mapping.js
+++ b/api/api/indices.get_mapping.js
@@ -101,8 +101,12 @@ function buildIndicesGetMapping (opts) {
 
     var path = ''
 
-    if ((index) != null) {
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + '_mapping' + '/' + encodeURIComponent(type)
+    } else if ((index) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_mapping'
+    } else if ((type) != null) {
+      path = '/' + '_mapping' + '/' + encodeURIComponent(type)
     } else {
       path = '/' + '_mapping'
     }

--- a/api/api/indices.put_mapping.js
+++ b/api/api/indices.put_mapping.js
@@ -102,7 +102,23 @@ function buildIndicesPutMapping (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_mapping'
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_mapping'
+    } else if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + '_mapping' + '/' + encodeURIComponent(type)
+    } else if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_mappings'
+    } else if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + '_mappings' + '/' + encodeURIComponent(type)
+    } else if ((type) != null) {
+      path = '/' + '_mappings' + '/' + encodeURIComponent(type)
+    } else if ((type) != null) {
+      path = '/' + '_mapping' + '/' + encodeURIComponent(type)
+    } else if ((index) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + '_mapping'
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_mappings'
+    }
 
     // build request object
     const request = {

--- a/api/api/indices.validate_query.js
+++ b/api/api/indices.validate_query.js
@@ -88,6 +88,12 @@ function buildIndicesValidateQuery (opts) {
       options = {}
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -109,7 +115,9 @@ function buildIndicesValidateQuery (opts) {
 
     var path = ''
 
-    if ((index) != null) {
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_validate' + '/' + 'query'
+    } else if ((index) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_validate' + '/' + 'query'
     } else {
       path = '/' + '_validate' + '/' + 'query'

--- a/api/api/mget.js
+++ b/api/api/mget.js
@@ -83,6 +83,12 @@ function buildMget (opts) {
       return handleError(err, callback)
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -104,7 +110,9 @@ function buildMget (opts) {
 
     var path = ''
 
-    if ((index) != null) {
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_mget'
+    } else if ((index) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_mget'
     } else {
       path = '/' + '_mget'

--- a/api/api/monitoring.bulk.js
+++ b/api/api/monitoring.bulk.js
@@ -86,7 +86,11 @@ function buildMonitoringBulk (opts) {
 
     var path = ''
 
-    path = '/' + '_monitoring' + '/' + 'bulk'
+    if ((type) != null) {
+      path = '/' + '_monitoring' + '/' + encodeURIComponent(type) + '/' + 'bulk'
+    } else {
+      path = '/' + '_monitoring' + '/' + 'bulk'
+    }
 
     // build request object
     const request = {

--- a/api/api/msearch.js
+++ b/api/api/msearch.js
@@ -85,6 +85,12 @@ function buildMsearch (opts) {
       return handleError(err, callback)
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -106,7 +112,9 @@ function buildMsearch (opts) {
 
     var path = ''
 
-    if ((index) != null) {
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_msearch'
+    } else if ((index) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_msearch'
     } else {
       path = '/' + '_msearch'

--- a/api/api/msearch_template.js
+++ b/api/api/msearch_template.js
@@ -79,6 +79,12 @@ function buildMsearchTemplate (opts) {
       return handleError(err, callback)
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -100,7 +106,9 @@ function buildMsearchTemplate (opts) {
 
     var path = ''
 
-    if ((index) != null) {
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_msearch' + '/' + 'template'
+    } else if ((index) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_msearch' + '/' + 'template'
     } else {
       path = '/' + '_msearch' + '/' + 'template'

--- a/api/api/mtermvectors.js
+++ b/api/api/mtermvectors.js
@@ -87,6 +87,12 @@ function buildMtermvectors (opts) {
       options = {}
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -108,7 +114,9 @@ function buildMtermvectors (opts) {
 
     var path = ''
 
-    if ((index) != null) {
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_mtermvectors'
+    } else if ((index) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_mtermvectors'
     } else {
       path = '/' + '_mtermvectors'

--- a/api/api/nodes.hot_threads.js
+++ b/api/api/nodes.hot_threads.js
@@ -97,7 +97,13 @@ function buildNodesHotThreads (opts) {
     var path = ''
 
     if ((node_id || nodeId) != null) {
+      path = '/' + '_cluster' + '/' + 'nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'hotthreads'
+    } else if ((node_id || nodeId) != null) {
+      path = '/' + '_cluster' + '/' + 'nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'hot_threads'
+    } else if ((node_id || nodeId) != null) {
       path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'hot_threads'
+    } else if ((node_id || nodeId) != null) {
+      path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'hotthreads'
     } else {
       path = '/' + '_nodes' + '/' + 'hot_threads'
     }

--- a/api/api/rollup.rollup_search.js
+++ b/api/api/rollup.rollup_search.js
@@ -67,6 +67,12 @@ function buildRollupRollupSearch (opts) {
       return handleError(err, callback)
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -88,7 +94,11 @@ function buildRollupRollupSearch (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_rollup_search'
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_rollup_search'
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_rollup_search'
+    }
 
     // build request object
     const request = {

--- a/api/api/scroll.js
+++ b/api/api/scroll.js
@@ -86,7 +86,11 @@ function buildScroll (opts) {
 
     var path = ''
 
-    path = '/' + '_search' + '/' + 'scroll'
+    if ((scroll_id || scrollId) != null) {
+      path = '/' + '_search' + '/' + 'scroll' + '/' + encodeURIComponent(scroll_id || scrollId)
+    } else {
+      path = '/' + '_search' + '/' + 'scroll'
+    }
 
     // build request object
     const request = {

--- a/api/api/search.js
+++ b/api/api/search.js
@@ -169,6 +169,12 @@ function buildSearch (opts) {
       options = {}
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -190,7 +196,9 @@ function buildSearch (opts) {
 
     var path = ''
 
-    if ((index) != null) {
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_search'
+    } else if ((index) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_search'
     } else {
       path = '/' + '_search'

--- a/api/api/search_template.js
+++ b/api/api/search_template.js
@@ -98,6 +98,12 @@ function buildSearchTemplate (opts) {
       return handleError(err, callback)
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -119,7 +125,9 @@ function buildSearchTemplate (opts) {
 
     var path = ''
 
-    if ((index) != null) {
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_search' + '/' + 'template'
+    } else if ((index) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_search' + '/' + 'template'
     } else {
       path = '/' + '_search' + '/' + 'template'

--- a/api/api/termvectors.js
+++ b/api/api/termvectors.js
@@ -113,8 +113,12 @@ function buildTermvectors (opts) {
 
     var path = ''
 
-    if ((index) != null && (id) != null) {
+    if ((index) != null && (type) != null && (id) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_termvectors'
+    } else if ((index) != null && (id) != null) {
       path = '/' + encodeURIComponent(index) + '/' + '_termvectors' + '/' + encodeURIComponent(id)
+    } else if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_termvectors'
     } else {
       path = '/' + encodeURIComponent(index) + '/' + '_termvectors'
     }

--- a/api/api/update.js
+++ b/api/api/update.js
@@ -124,7 +124,11 @@ function buildUpdate (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_update' + '/' + encodeURIComponent(id)
+    if ((index) != null && (type) != null && (id) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_update'
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_update' + '/' + encodeURIComponent(id)
+    }
 
     // build request object
     const request = {

--- a/api/api/update_by_query.js
+++ b/api/api/update_by_query.js
@@ -148,6 +148,12 @@ function buildUpdateByQuery (opts) {
       return handleError(err, callback)
     }
 
+    // check required url components
+    if (params['type'] != null && (params['index'] == null)) {
+      const err = new ConfigurationError('Missing required parameter of the url: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -169,7 +175,11 @@ function buildUpdateByQuery (opts) {
 
     var path = ''
 
-    path = '/' + encodeURIComponent(index) + '/' + '_update_by_query'
+    if ((index) != null && (type) != null) {
+      path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_update_by_query'
+    } else {
+      path = '/' + encodeURIComponent(index) + '/' + '_update_by_query'
+    }
 
     // build request object
     const request = {

--- a/scripts/utils/generateApis.js
+++ b/scripts/utils/generateApis.js
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+/* eslint camelcase: 0 */
+
 'use strict'
 
 const dedent = require('dedent')
@@ -33,6 +35,7 @@ const noPathValidation = [
   'explain',
   'get',
   'get_source',
+  'index',
   'indices.get_alias',
   'indices.exists_alias',
   'indices.get_field_mapping',
@@ -40,6 +43,7 @@ const noPathValidation = [
   'indices.get_settings',
   'indices.put_mapping',
   'indices.stats',
+  'delete',
   'nodes.info',
   'nodes.stats',
   'nodes.usage',
@@ -66,9 +70,15 @@ function generate (spec, common) {
     .replace(/_([a-z])/g, k => k[1].toUpperCase())
 
   const methods = spec[api].methods
-  const { paths, parts, params } = spec[api].url
+  const { paths, deprecated_paths, parts, params } = spec[api].url
   const acceptedQuerystring = []
   const required = []
+
+  if (deprecated_paths) {
+    for (const p of deprecated_paths) {
+      paths.push(p.path)
+    }
+  }
 
   for (const key in parts) {
     if (parts[key].required) {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -34,6 +34,9 @@ const esFolder = join(__dirname, '..', '..', 'elasticsearch')
 const yamlFolder = join(esFolder, 'rest-api-spec', 'src', 'main', 'resources', 'rest-api-spec', 'test')
 const xPackYamlFolder = join(esFolder, 'x-pack', 'plugin', 'src', 'test', 'resources', 'rest-api-spec', 'test')
 const customSkips = [
+  // TODO: remove this once 'arbitrary_key' is implemented
+  // https://github.com/elastic/elasticsearch/pull/41492
+  'indices.split/30_copy_settings.yml',
   // skipping because we are booting ES with `discovery.type=single-node`
   // and this test will fail because of this configuration
   'nodes.stats/30_discovery.yml',


### PR DESCRIPTION
This pr adds support for the `deprecated_paths` field in the spec.

Related: https://github.com/elastic/elasticsearch/pull/39063