### PR TITLE
Remove duplicated 'type' parameter from Bulk API

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -57,9 +57,6 @@ link:{ref}/docs-bulk.html[Reference]
 |`timeout`
 |`string` - Explicit operation timeout
 
-|`type`
-|`string` - Default document type for items which don't provide one
-
 |`_source`
 |`string, string[]` - True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request
 


### PR DESCRIPTION
There is already `type` parameter, so just removed the duplicated one.

![image](https://user-images.githubusercontent.com/16997074/57846728-8424e900-77dd-11e9-94f9-9fafce6483f3.png)
