### PR TITLE
[DOCS] Fix broken links for ES API docs move

### DIFF
--- a/api/api/clear_scroll.js
+++ b/api/api/clear_scroll.js
@@ -26,7 +26,7 @@ function buildClearScroll (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
   /**
-   * Perform a [clear_scroll](http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html) request
+   * Perform a [clear_scroll](http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#search-request-scroll) request
    *
    * @param {list} scroll_id - A comma-separated list of scroll IDs to clear
    * @param {object} body - A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter

--- a/api/api/indices.flush_synced.js
+++ b/api/api/indices.flush_synced.js
@@ -26,7 +26,7 @@ function buildIndicesFlushSynced (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
   /**
-   * Perform a [indices.flush_synced](http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html) request
+   * Perform a [indices.flush_synced](http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html#indices-synced-flush) request
    *
    * @param {list} index - A comma-separated list of index names; use `_all` or empty string for all indices
    * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)

--- a/api/api/scroll.js
+++ b/api/api/scroll.js
@@ -26,7 +26,7 @@ function buildScroll (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
   /**
-   * Perform a [scroll](http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html) request
+   * Perform a [scroll](http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#search-request-scroll) request
    *
    * @param {string} scroll_id - The scroll ID
    * @param {time} scroll - Specify how long a consistent view of the index should be maintained for scrolled search

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -757,7 +757,7 @@ link:{ref}/cat-thread-pool.html[Reference]
 ----
 client.clearScroll([params] [, options] [, callback])
 ----
-link:{ref}/search-request-scroll.html[Reference]
+link:{ref}/search-request-body.html#search-request-scroll[Reference]
 [cols=2*]
 |===
 |`scroll_id` or `scrollId`
@@ -1976,7 +1976,7 @@ _Default:_ `open`
 ----
 client.indices.flushSynced([params] [, options] [, callback])
 ----
-link:{ref}/indices-synced-flush.html[Reference]
+link:{ref}/indices-flush.html#indices-synced-flush[Reference]
 [cols=2*]
 |===
 |`index`
@@ -3305,7 +3305,7 @@ link:https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-exec
 ----
 client.scroll([params] [, options] [, callback])
 ----
-link:{ref}/search-request-scroll.html[Reference]
+link:{ref}/search-request-body.html#search-request-scroll[Reference]
 [cols=2*]
 |===
 |`scroll_id` or `scrollId`


### PR DESCRIPTION
elastic/elasticsearch/pull/44238 moved several Elasticsearch APIs to a REST APIs section.

As a result of that move, some pages were converted to anchored sections. This will fix links to those pages once the above PR is re-applied.

I plan to merge this PR simultaneously with:
- elastic/elasticsearch/pull/44238
- elastic/elasticsearch/pull/44279
- elastic/kibana/pull/41001
- elastic/elasticsearch-hadoop/pull/1317
- elastic/stack-docs/pull/411