### PR TITLE
[DOCS] Fix broken links for ES API docs move

### DIFF
--- a/api/api/clear_scroll.js
+++ b/api/api/clear_scroll.js
@@ -26,7 +26,7 @@ function buildClearScroll (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
   /**
-   * Perform a [clear_scroll](http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html) request
+   * Perform a [clear_scroll](http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#search-request-scroll) request
    *
    * @param {list} scroll_id - A comma-separated list of scroll IDs to clear
    * @param {object} body - A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter

--- a/api/api/scroll.js
+++ b/api/api/scroll.js
@@ -26,7 +26,7 @@ function buildScroll (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
   /**
-   * Perform a [scroll](http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html) request
+   * Perform a [scroll](http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#search-request-scroll) request
    *
    * @param {string} scroll_id - The scroll ID
    * @param {time} scroll - Specify how long a consistent view of the index should be maintained for scrolled search


### PR DESCRIPTION
elastic/elasticsearch/pull/44238 moved several Elasticsearch APIs to a REST APIs section.

As a result of that move, some pages were converted to anchored sections. This will fix links to those pages once the above PR is re-applied.