### PR TITLE
fix(Typings): sniffInterval can also be boolean

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,7 +97,7 @@ interface ClientOptions {
   maxRetries?: number;
   requestTimeout?: number;
   pingTimeout?: number;
-  sniffInterval?: number;
+  sniffInterval?: number | boolean;
   sniffOnStart?: boolean;
   sniffEndpoint?: string;
   sniffOnConnectionFault?: boolean;


### PR DESCRIPTION
`sniffInterval` configuration option can be boolean as [documented](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/7.x/client-configuration.html) and in [practice](https://github.com/elastic/elasticsearch-js/blob/master/index.js#L83)