### PR TITLE
Jenkins pipeline testing fixes

### DIFF
--- a/.ci/jobs/elastic+elasticsearch-js+jenkins-pipelines.yml
+++ b/.ci/jobs/elastic+elasticsearch-js+jenkins-pipelines.yml
@@ -4,6 +4,8 @@
     display-name: 'elastic / elasticsearch-js # jenkins-pipelines'
     description: Testing the elasticsearch-js jenkins-pipelines branch.
     project-type: multibranch
+    properties: []
+    triggers: []
     logrotate:
       daysToKeep: 30
       numToKeep: 100


### PR DESCRIPTION
The pipelines configuration did not like the default values that were being merged from [defaults.yml](https://github.com/elastic/elasticsearch-js/blob/master/.ci/jobs/defaults.yml)