### PR TITLE
remove duplicate scroll_id paramter in client.scroll

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -4163,7 +4163,6 @@ link:https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-exec
 client.scroll({
   scroll_id: string,
   scroll: string,
-  scroll_id: string,
   rest_total_hits_as_int: boolean,
   body: object
 })


### PR DESCRIPTION
The elasticsearch JavaScript API reference has duplicate parameter scroll_id in client.scroll example. So basically, i removed the above duplicate.

<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->
