### PR TITLE
Fix inaccurate description sniffEndpoint

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -86,7 +86,7 @@ _Default:_ `false`
 _Default:_ `false`
 
 |`sniffEndpoint`
-|`string` - Max request timeout for each request. +
+|`string` - Endpoint to ping during a sniff. +
 _Default:_ `'_nodes/_all/http'`
 
 |`sniffOnConnectionFault`


### PR DESCRIPTION
[Documentation](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/client-configuration.html) for client configuration is incorrect at `sniffEndpoint`. It is currently documented as `requestTimeout`.