### PR TITLE
Fix issue; node roles are defaulting to true when undefined (false) breaking usage of nodeFilter option

### DIFF
--- a/lib/pool/BaseConnectionPool.js
+++ b/lib/pool/BaseConnectionPool.js
@@ -212,9 +212,9 @@ class BaseConnectionPool {
         url: new URL(address),
         id: ids[i],
         roles: Object.assign({
-          [Connection.roles.MASTER]: true,
-          [Connection.roles.DATA]: true,
-          [Connection.roles.INGEST]: true,
+          [Connection.roles.MASTER]: false,
+          [Connection.roles.DATA]: false,
+          [Connection.roles.INGEST]: false,
           [Connection.roles.ML]: false
         }, roles)
       })

--- a/test/unit/connection-pool.test.js
+++ b/test/unit/connection-pool.test.js
@@ -474,6 +474,45 @@ test('API', t => {
       t.end()
     })
 
+    t.test('Should map roles', t => {
+      const pool = new ConnectionPool({ Connection })
+      const nodes = {
+        a1: {
+          http: {
+            publish_address: 'example.com:9200'
+          },
+          roles: ['master', 'data', 'ingest', 'ml']
+        },
+        a2: {
+          http: {
+            publish_address: 'example.com:9201'
+          },
+          roles: []
+        }
+      }
+      t.same(pool.nodesToHost(nodes, 'http:'), [{
+        url: new URL('http://example.com:9200'),
+        id: 'a1',
+        roles: {
+          master: true,
+          data: true,
+          ingest: true,
+          ml: true
+        }
+      }, {
+        url: new URL('http://example.com:9201'),
+        id: 'a2',
+        roles: {
+          master: false,
+          data: false,
+          ingest: false,
+          ml: false
+        }
+      }])
+
+      t.end()
+    })
+
     t.end()
   })
 


### PR DESCRIPTION
nodeFilter option was unable to filter nodes where master, data or ingest roles were false because they were defaulting to true when not set.

The example below demonstrates the problem:
```
// roles are returned from the elastic API as a list
roleslist = ['master', 'ingest']
console.log(roleslist)

// The client converts the list to a dictionary
const roles = roleslist.reduce((acc,role) => { acc[role] = true; return acc}, {})
console.log(roles)

// The client then assigns default values to undefined roles
console.log(
        Object.assign({'data': true, 'master': true, 'injest': true, 'ml': false}, roles)
)

```

Output:
```
[ 'master', 'ingest' ]
{ master: true, ingest: true }
{ data: true, master: true, injest: true, ml: false, ingest: true }
```
data is `true` when it should be `false`.