### PR TITLE
Update code generation

### DIFF
--- a/api/api/bulk.js
+++ b/api/api/bulk.js
@@ -10,22 +10,6 @@
 function buildBulk (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [bulk](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html) request
-   *
-   * @param {string} index - Default index for items which don't provide one
-   * @param {string} type - Default document type for items which don't provide one
-   * @param {string} wait_for_active_shards - Sets the number of shard copies that must be active before proceeding with the bulk operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-   * @param {enum} refresh - If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
-   * @param {string} routing - Specific routing value
-   * @param {time} timeout - Explicit operation timeout
-   * @param {string} type - Default document type for items which don't provide one
-   * @param {list} _source - True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request
-   * @param {list} _source_excludes - Default list of fields to exclude from the returned _source field, can be overridden on each sub-request
-   * @param {list} _source_includes - Default list of fields to extract and return from the _source field, can be overridden on each sub-request
-   * @param {string} pipeline - The pipeline id to preprocess incoming documents with
-   * @param {object} body - The operation definition and data (action-data pairs), separated by newlines
-   */
 
   const acceptedQuerystring = [
     'wait_for_active_shards',
@@ -56,6 +40,11 @@ function buildBulk (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a bulk request
+   * Allows to perform multiple index/update/delete operations in a single request.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html
+   */
   return function bulk (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -90,10 +79,6 @@ function buildBulk (opts) {
     var { method, body, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -102,10 +87,13 @@ function buildBulk (opts) {
     var path = ''
 
     if ((index) != null && (type) != null) {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_bulk'
     } else if ((index) != null) {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_bulk'
     } else {
+      if (method == null) method = 'POST'
       path = '/' + '_bulk'
     }
 

--- a/api/api/cat.aliases.js
+++ b/api/api/cat.aliases.js
@@ -10,18 +10,6 @@
 function buildCatAliases (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.aliases](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html) request
-   *
-   * @param {list} name - A comma-separated list of alias names to return
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -44,6 +32,11 @@ function buildCatAliases (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.aliases request
+   * Shows information about currently configured aliases to indices including filter and routing infos.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html
+   */
   return function catAliases (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -56,12 +49,6 @@ function buildCatAliases (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -72,10 +59,6 @@ function buildCatAliases (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -84,8 +67,10 @@ function buildCatAliases (opts) {
     var path = ''
 
     if ((name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'aliases' + '/' + encodeURIComponent(name)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'aliases'
     }
 

--- a/api/api/cat.allocation.js
+++ b/api/api/cat.allocation.js
@@ -10,19 +10,6 @@
 function buildCatAllocation (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.allocation](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html) request
-   *
-   * @param {list} node_id - A comma-separated list of node IDs or names to limit the returned information
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {enum} bytes - The unit in which to display byte values
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -46,6 +33,11 @@ function buildCatAllocation (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.allocation request
+   * Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html
+   */
   return function catAllocation (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,12 +50,6 @@ function buildCatAllocation (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -74,10 +60,6 @@ function buildCatAllocation (opts) {
     var { method, body, nodeId, node_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -86,8 +68,10 @@ function buildCatAllocation (opts) {
     var path = ''
 
     if ((node_id || nodeId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'allocation' + '/' + encodeURIComponent(node_id || nodeId)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'allocation'
     }
 

--- a/api/api/cat.count.js
+++ b/api/api/cat.count.js
@@ -10,18 +10,6 @@
 function buildCatCount (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.count](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to limit the returned information
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -44,6 +32,11 @@ function buildCatCount (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.count request
+   * Provides quick access to the document count of the entire cluster, or individual indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html
+   */
   return function catCount (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -56,12 +49,6 @@ function buildCatCount (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -72,10 +59,6 @@ function buildCatCount (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -84,8 +67,10 @@ function buildCatCount (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'count' + '/' + encodeURIComponent(index)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'count'
     }
 

--- a/api/api/cat.fielddata.js
+++ b/api/api/cat.fielddata.js
@@ -10,20 +10,6 @@
 function buildCatFielddata (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.fielddata](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html) request
-   *
-   * @param {list} fields - A comma-separated list of fields to return the fielddata size
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {enum} bytes - The unit in which to display byte values
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   * @param {list} fields - A comma-separated list of fields to return in the output
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -48,6 +34,11 @@ function buildCatFielddata (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.fielddata request
+   * Shows how much heap memory is currently being used by fielddata on every data node in the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html
+   */
   return function catFielddata (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -60,12 +51,6 @@ function buildCatFielddata (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -76,10 +61,6 @@ function buildCatFielddata (opts) {
     var { method, body, fields, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -88,8 +69,10 @@ function buildCatFielddata (opts) {
     var path = ''
 
     if ((fields) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'fielddata' + '/' + encodeURIComponent(fields)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'fielddata'
     }
 

--- a/api/api/cat.health.js
+++ b/api/api/cat.health.js
@@ -10,18 +10,6 @@
 function buildCatHealth (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.health](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html) request
-   *
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} ts - Set to false to disable timestamping
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -45,6 +33,11 @@ function buildCatHealth (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.health request
+   * Returns a concise representation of the cluster health.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html
+   */
   return function catHealth (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,12 +50,6 @@ function buildCatHealth (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -73,10 +60,6 @@ function buildCatHealth (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -84,6 +67,7 @@ function buildCatHealth (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cat' + '/' + 'health'
 
     // build request object

--- a/api/api/cat.help.js
+++ b/api/api/cat.help.js
@@ -10,12 +10,6 @@
 function buildCatHelp (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.help](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html) request
-   *
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   */
 
   const acceptedQuerystring = [
     'help',
@@ -32,6 +26,11 @@ function buildCatHelp (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.help request
+   * Returns help for the Cat APIs.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html
+   */
   return function catHelp (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -44,12 +43,6 @@ function buildCatHelp (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -60,10 +53,6 @@ function buildCatHelp (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -71,6 +60,7 @@ function buildCatHelp (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cat'
 
     // build request object

--- a/api/api/cat.indices.js
+++ b/api/api/cat.indices.js
@@ -10,22 +10,6 @@
 function buildCatIndices (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.indices](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to limit the returned information
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {enum} bytes - The unit in which to display byte values
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {enum} health - A health status ("green", "yellow", or "red" to filter only indices matching the specified health status
-   * @param {boolean} help - Return help information
-   * @param {boolean} pri - Set to true to return stats only for primary shards
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   * @param {boolean} include_unloaded_segments - If set to true segment stats will include stats for segments that are not currently loaded into memory
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -53,6 +37,11 @@ function buildCatIndices (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.indices request
+   * Returns information about indices: number of primaries and replicas, document counts, disk size, ...
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html
+   */
   return function catIndices (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -65,12 +54,6 @@ function buildCatIndices (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -81,10 +64,6 @@ function buildCatIndices (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -93,8 +72,10 @@ function buildCatIndices (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'indices' + '/' + encodeURIComponent(index)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'indices'
     }
 

--- a/api/api/cat.master.js
+++ b/api/api/cat.master.js
@@ -10,17 +10,6 @@
 function buildCatMaster (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.master](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html) request
-   *
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -43,6 +32,11 @@ function buildCatMaster (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.master request
+   * Returns information about the master node.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html
+   */
   return function catMaster (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -55,12 +49,6 @@ function buildCatMaster (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -71,10 +59,6 @@ function buildCatMaster (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -82,6 +66,7 @@ function buildCatMaster (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cat' + '/' + 'master'
 
     // build request object

--- a/api/api/cat.nodeattrs.js
+++ b/api/api/cat.nodeattrs.js
@@ -10,17 +10,6 @@
 function buildCatNodeattrs (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.nodeattrs](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html) request
-   *
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -43,6 +32,11 @@ function buildCatNodeattrs (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.nodeattrs request
+   * Returns information about custom node attributes.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html
+   */
   return function catNodeattrs (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -55,12 +49,6 @@ function buildCatNodeattrs (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -71,10 +59,6 @@ function buildCatNodeattrs (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -82,6 +66,7 @@ function buildCatNodeattrs (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cat' + '/' + 'nodeattrs'
 
     // build request object

--- a/api/api/cat.nodes.js
+++ b/api/api/cat.nodes.js
@@ -10,18 +10,6 @@
 function buildCatNodes (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.nodes](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html) request
-   *
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} full_id - Return the full node ID instead of the shortened version (default: false)
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -46,6 +34,11 @@ function buildCatNodes (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.nodes request
+   * Returns basic statistics about performance of cluster nodes.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html
+   */
   return function catNodes (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,12 +51,6 @@ function buildCatNodes (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -74,10 +61,6 @@ function buildCatNodes (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -85,6 +68,7 @@ function buildCatNodes (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cat' + '/' + 'nodes'
 
     // build request object

--- a/api/api/cat.pending_tasks.js
+++ b/api/api/cat.pending_tasks.js
@@ -10,17 +10,6 @@
 function buildCatPendingTasks (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.pending_tasks](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html) request
-   *
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -43,6 +32,11 @@ function buildCatPendingTasks (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.pending_tasks request
+   * Returns a concise representation of the cluster pending tasks.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html
+   */
   return function catPendingTasks (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -55,12 +49,6 @@ function buildCatPendingTasks (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -71,10 +59,6 @@ function buildCatPendingTasks (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -82,6 +66,7 @@ function buildCatPendingTasks (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cat' + '/' + 'pending_tasks'
 
     // build request object

--- a/api/api/cat.plugins.js
+++ b/api/api/cat.plugins.js
@@ -10,17 +10,6 @@
 function buildCatPlugins (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.plugins](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html) request
-   *
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -43,6 +32,11 @@ function buildCatPlugins (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.plugins request
+   * Returns information about installed plugins across nodes node.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html
+   */
   return function catPlugins (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -55,12 +49,6 @@ function buildCatPlugins (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -71,10 +59,6 @@ function buildCatPlugins (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -82,6 +66,7 @@ function buildCatPlugins (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cat' + '/' + 'plugins'
 
     // build request object

--- a/api/api/cat.recovery.js
+++ b/api/api/cat.recovery.js
@@ -10,18 +10,6 @@
 function buildCatRecovery (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.recovery](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to limit the returned information
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {enum} bytes - The unit in which to display byte values
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -44,6 +32,11 @@ function buildCatRecovery (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.recovery request
+   * Returns information about index shard recoveries, both on-going completed.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html
+   */
   return function catRecovery (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -56,12 +49,6 @@ function buildCatRecovery (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -72,10 +59,6 @@ function buildCatRecovery (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -84,8 +67,10 @@ function buildCatRecovery (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'recovery' + '/' + encodeURIComponent(index)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'recovery'
     }
 

--- a/api/api/cat.repositories.js
+++ b/api/api/cat.repositories.js
@@ -10,17 +10,6 @@
 function buildCatRepositories (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.repositories](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html) request
-   *
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} local - Return local information, do not retrieve the state from master node
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -43,6 +32,11 @@ function buildCatRepositories (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.repositories request
+   * Returns information about snapshot repositories registered in the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html
+   */
   return function catRepositories (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -55,12 +49,6 @@ function buildCatRepositories (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -71,10 +59,6 @@ function buildCatRepositories (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -82,6 +66,7 @@ function buildCatRepositories (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cat' + '/' + 'repositories'
 
     // build request object

--- a/api/api/cat.segments.js
+++ b/api/api/cat.segments.js
@@ -10,17 +10,6 @@
 function buildCatSegments (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.segments](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to limit the returned information
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {enum} bytes - The unit in which to display byte values
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -41,6 +30,11 @@ function buildCatSegments (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.segments request
+   * Provides low-level information about the segments in the shards of an index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html
+   */
   return function catSegments (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,12 +47,6 @@ function buildCatSegments (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -69,10 +57,6 @@ function buildCatSegments (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -81,8 +65,10 @@ function buildCatSegments (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'segments' + '/' + encodeURIComponent(index)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'segments'
     }
 

--- a/api/api/cat.shards.js
+++ b/api/api/cat.shards.js
@@ -10,19 +10,6 @@
 function buildCatShards (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.shards](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to limit the returned information
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {enum} bytes - The unit in which to display byte values
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -46,6 +33,11 @@ function buildCatShards (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.shards request
+   * Provides a detailed view of shard allocation on nodes.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html
+   */
   return function catShards (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,12 +50,6 @@ function buildCatShards (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -74,10 +60,6 @@ function buildCatShards (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -86,8 +68,10 @@ function buildCatShards (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'shards' + '/' + encodeURIComponent(index)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'shards'
     }
 

--- a/api/api/cat.snapshots.js
+++ b/api/api/cat.snapshots.js
@@ -10,18 +10,6 @@
 function buildCatSnapshots (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.snapshots](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html) request
-   *
-   * @param {list} repository - Name of repository from which to fetch the snapshot information
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} ignore_unavailable - Set to true to ignore unavailable snapshots
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -45,6 +33,11 @@ function buildCatSnapshots (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.snapshots request
+   * Returns all snapshots in a specific repository.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html
+   */
   return function catSnapshots (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,12 +50,6 @@ function buildCatSnapshots (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -73,10 +60,6 @@ function buildCatSnapshots (opts) {
     var { method, body, repository, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -85,8 +68,10 @@ function buildCatSnapshots (opts) {
     var path = ''
 
     if ((repository) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'snapshots' + '/' + encodeURIComponent(repository)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'snapshots'
     }
 

--- a/api/api/cat.tasks.js
+++ b/api/api/cat.tasks.js
@@ -10,19 +10,6 @@
 function buildCatTasks (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.tasks](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html) request
-   *
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {list} node_id - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
-   * @param {list} actions - A comma-separated list of actions that should be returned. Leave empty to return all.
-   * @param {boolean} detailed - Return detailed task information (default: false)
-   * @param {number} parent_task - Return tasks with specified parent task id. Set to -1 to return all.
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -48,6 +35,11 @@ function buildCatTasks (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.tasks request
+   * Returns information about the tasks currently executing on one or more nodes in the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
+   */
   return function catTasks (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -60,12 +52,6 @@ function buildCatTasks (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -76,10 +62,6 @@ function buildCatTasks (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -87,6 +69,7 @@ function buildCatTasks (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cat' + '/' + 'tasks'
 
     // build request object

--- a/api/api/cat.templates.js
+++ b/api/api/cat.templates.js
@@ -10,18 +10,6 @@
 function buildCatTemplates (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.templates](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html) request
-   *
-   * @param {string} name - A pattern that returned template names must match
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -44,6 +32,11 @@ function buildCatTemplates (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.templates request
+   * Returns information about existing templates.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html
+   */
   return function catTemplates (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -56,12 +49,6 @@ function buildCatTemplates (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -72,10 +59,6 @@ function buildCatTemplates (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -84,8 +67,10 @@ function buildCatTemplates (opts) {
     var path = ''
 
     if ((name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'templates' + '/' + encodeURIComponent(name)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'templates'
     }
 

--- a/api/api/cat.thread_pool.js
+++ b/api/api/cat.thread_pool.js
@@ -10,19 +10,6 @@
 function buildCatThreadPool (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cat.thread_pool](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html) request
-   *
-   * @param {list} thread_pool_patterns - A comma-separated list of regular-expressions to filter the thread pools in the output
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {enum} size - The multiplier in which to display values
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {list} h - Comma-separated list of column names to display
-   * @param {boolean} help - Return help information
-   * @param {list} s - Comma-separated list of column names or column aliases to sort by
-   * @param {boolean} v - Verbose mode. Display column headers
-   */
 
   const acceptedQuerystring = [
     'format',
@@ -46,6 +33,12 @@ function buildCatThreadPool (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cat.thread_pool request
+   * Returns cluster-wide thread pool statistics per node.
+By default the active, queue and rejected statistics are returned for all thread pools.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html
+   */
   return function catThreadPool (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,12 +51,6 @@ function buildCatThreadPool (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -74,10 +61,6 @@ function buildCatThreadPool (opts) {
     var { method, body, threadPoolPatterns, thread_pool_patterns, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -86,8 +69,10 @@ function buildCatThreadPool (opts) {
     var path = ''
 
     if ((thread_pool_patterns || threadPoolPatterns) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'thread_pool' + '/' + encodeURIComponent(thread_pool_patterns || threadPoolPatterns)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cat' + '/' + 'thread_pool'
     }
 

--- a/api/api/ccr.delete_auto_follow_pattern.js
+++ b/api/api/ccr.delete_auto_follow_pattern.js
@@ -10,11 +10,6 @@
 function buildCcrDeleteAutoFollowPattern (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.delete_auto_follow_pattern](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html) request
-   *
-   * @param {string} name - The name of the auto follow pattern.
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildCcrDeleteAutoFollowPattern (opts) {
 
   }
 
+  /**
+   * Perform a ccr.delete_auto_follow_pattern request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html
+   */
   return function ccrDeleteAutoFollowPattern (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildCcrDeleteAutoFollowPattern (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildCcrDeleteAutoFollowPattern (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ccr' + '/' + 'auto_follow' + '/' + encodeURIComponent(name)
 
     // build request object

--- a/api/api/ccr.follow.js
+++ b/api/api/ccr.follow.js
@@ -10,13 +10,6 @@
 function buildCcrFollow (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.follow](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html) request
-   *
-   * @param {string} index - The name of the follower index
-   * @param {string} wait_for_active_shards - Sets the number of shard copies that must be active before returning. Defaults to 0. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-   * @param {object} body - The name of the leader index and other optional ccr related parameters
-   */
 
   const acceptedQuerystring = [
     'wait_for_active_shards'
@@ -26,6 +19,10 @@ function buildCcrFollow (opts) {
     waitForActiveShards: 'wait_for_active_shards'
   }
 
+  /**
+   * Perform a ccr.follow request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html
+   */
   return function ccrFollow (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,10 +55,6 @@ function buildCcrFollow (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,6 +62,7 @@ function buildCcrFollow (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + encodeURIComponent(index) + '/' + '_ccr' + '/' + 'follow'
 
     // build request object

--- a/api/api/ccr.follow_info.js
+++ b/api/api/ccr.follow_info.js
@@ -10,11 +10,6 @@
 function buildCcrFollowInfo (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.follow_info](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-info.html) request
-   *
-   * @param {list} index - A comma-separated list of index patterns; use `_all` to perform the operation on all indices
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildCcrFollowInfo (opts) {
 
   }
 
+  /**
+   * Perform a ccr.follow_info request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-info.html
+   */
   return function ccrFollowInfo (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,6 +35,12 @@ function buildCcrFollowInfo (opts) {
       options = {}
     }
 
+    // check required parameters
+    if (params['index'] == null) {
+      const err = new ConfigurationError('Missing required parameter: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -46,10 +51,6 @@ function buildCcrFollowInfo (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -57,6 +58,7 @@ function buildCcrFollowInfo (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + encodeURIComponent(index) + '/' + '_ccr' + '/' + 'info'
 
     // build request object

--- a/api/api/ccr.follow_stats.js
+++ b/api/api/ccr.follow_stats.js
@@ -10,11 +10,6 @@
 function buildCcrFollowStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.follow_stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html) request
-   *
-   * @param {list} index - A comma-separated list of index patterns; use `_all` to perform the operation on all indices
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildCcrFollowStats (opts) {
 
   }
 
+  /**
+   * Perform a ccr.follow_stats request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html
+   */
   return function ccrFollowStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildCcrFollowStats (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildCcrFollowStats (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + encodeURIComponent(index) + '/' + '_ccr' + '/' + 'stats'
 
     // build request object

--- a/api/api/ccr.forget_follower.js
+++ b/api/api/ccr.forget_follower.js
@@ -10,12 +10,6 @@
 function buildCcrForgetFollower (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.forget_follower](http://www.elastic.co/guide/en/elasticsearch/reference/current) request
-   *
-   * @param {string} index - the name of the leader index for which specified follower retention leases should be removed
-   * @param {object} body - the name and UUID of the follower index, the name of the cluster containing the follower index, and the alias from the perspective of that cluster for the remote cluster containing the leader index
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildCcrForgetFollower (opts) {
 
   }
 
+  /**
+   * Perform a ccr.forget_follower request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current
+   */
   return function ccrForgetFollower (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +55,6 @@ function buildCcrForgetFollower (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +62,7 @@ function buildCcrForgetFollower (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_ccr' + '/' + 'forget_follower'
 
     // build request object

--- a/api/api/ccr.get_auto_follow_pattern.js
+++ b/api/api/ccr.get_auto_follow_pattern.js
@@ -10,11 +10,6 @@
 function buildCcrGetAutoFollowPattern (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.get_auto_follow_pattern](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html) request
-   *
-   * @param {string} name - The name of the auto follow pattern.
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildCcrGetAutoFollowPattern (opts) {
 
   }
 
+  /**
+   * Perform a ccr.get_auto_follow_pattern request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html
+   */
   return function ccrGetAutoFollowPattern (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,10 +45,6 @@ function buildCcrGetAutoFollowPattern (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -58,8 +53,10 @@ function buildCcrGetAutoFollowPattern (opts) {
     var path = ''
 
     if ((name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_ccr' + '/' + 'auto_follow' + '/' + encodeURIComponent(name)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_ccr' + '/' + 'auto_follow'
     }
 

--- a/api/api/ccr.pause_follow.js
+++ b/api/api/ccr.pause_follow.js
@@ -10,11 +10,6 @@
 function buildCcrPauseFollow (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.pause_follow](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html) request
-   *
-   * @param {string} index - The name of the follower index that should pause following its leader index.
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildCcrPauseFollow (opts) {
 
   }
 
+  /**
+   * Perform a ccr.pause_follow request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html
+   */
   return function ccrPauseFollow (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildCcrPauseFollow (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildCcrPauseFollow (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_ccr' + '/' + 'pause_follow'
 
     // build request object

--- a/api/api/ccr.put_auto_follow_pattern.js
+++ b/api/api/ccr.put_auto_follow_pattern.js
@@ -10,12 +10,6 @@
 function buildCcrPutAutoFollowPattern (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.put_auto_follow_pattern](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html) request
-   *
-   * @param {string} name - The name of the auto follow pattern.
-   * @param {object} body - The specification of the auto follow pattern
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildCcrPutAutoFollowPattern (opts) {
 
   }
 
+  /**
+   * Perform a ccr.put_auto_follow_pattern request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html
+   */
   return function ccrPutAutoFollowPattern (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +55,6 @@ function buildCcrPutAutoFollowPattern (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +62,7 @@ function buildCcrPutAutoFollowPattern (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_ccr' + '/' + 'auto_follow' + '/' + encodeURIComponent(name)
 
     // build request object

--- a/api/api/ccr.resume_follow.js
+++ b/api/api/ccr.resume_follow.js
@@ -10,12 +10,6 @@
 function buildCcrResumeFollow (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.resume_follow](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html) request
-   *
-   * @param {string} index - The name of the follow index to resume following.
-   * @param {object} body - The name of the leader index and other optional ccr related parameters
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildCcrResumeFollow (opts) {
 
   }
 
+  /**
+   * Perform a ccr.resume_follow request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html
+   */
   return function ccrResumeFollow (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,10 +51,6 @@ function buildCcrResumeFollow (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,6 +58,7 @@ function buildCcrResumeFollow (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_ccr' + '/' + 'resume_follow'
 
     // build request object

--- a/api/api/ccr.stats.js
+++ b/api/api/ccr.stats.js
@@ -10,10 +10,6 @@
 function buildCcrStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildCcrStats (opts) {
 
   }
 
+  /**
+   * Perform a ccr.stats request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html
+   */
   return function ccrStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -45,10 +45,6 @@ function buildCcrStats (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -56,6 +52,7 @@ function buildCcrStats (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_ccr' + '/' + 'stats'
 
     // build request object

--- a/api/api/ccr.unfollow.js
+++ b/api/api/ccr.unfollow.js
@@ -10,11 +10,6 @@
 function buildCcrUnfollow (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ccr.unfollow](http://www.elastic.co/guide/en/elasticsearch/reference/current) request
-   *
-   * @param {string} index - The name of the follower index that should be turned into a regular index.
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildCcrUnfollow (opts) {
 
   }
 
+  /**
+   * Perform a ccr.unfollow request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current
+   */
   return function ccrUnfollow (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildCcrUnfollow (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildCcrUnfollow (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_ccr' + '/' + 'unfollow'
 
     // build request object

--- a/api/api/clear_scroll.js
+++ b/api/api/clear_scroll.js
@@ -10,12 +10,6 @@
 function buildClearScroll (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [clear_scroll](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#_clear_scroll_api) request
-   *
-   * @param {list} scroll_id - A comma-separated list of scroll IDs to clear
-   * @param {object} body - A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter
-   */
 
   const acceptedQuerystring = [
     'pretty',
@@ -30,6 +24,11 @@ function buildClearScroll (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a clear_scroll request
+   * Explicitly clears the search context for a scroll.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#_clear_scroll_api
+   */
   return function clearScroll (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildClearScroll (opts) {
     var { method, body, scrollId, scroll_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,8 +59,10 @@ function buildClearScroll (opts) {
     var path = ''
 
     if ((scroll_id || scrollId) != null) {
+      if (method == null) method = 'DELETE'
       path = '/' + '_search' + '/' + 'scroll' + '/' + encodeURIComponent(scroll_id || scrollId)
     } else {
+      if (method == null) method = 'DELETE'
       path = '/' + '_search' + '/' + 'scroll'
     }
 

--- a/api/api/cluster.allocation_explain.js
+++ b/api/api/cluster.allocation_explain.js
@@ -10,13 +10,6 @@
 function buildClusterAllocationExplain (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cluster.allocation_explain](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html) request
-   *
-   * @param {boolean} include_yes_decisions - Return 'YES' decisions in explanation (default: false)
-   * @param {boolean} include_disk_info - Return information about disk usage and shard sizes (default: false)
-   * @param {object} body - The index, shard, and primary flag to explain. Empty means 'explain the first unassigned shard'
-   */
 
   const acceptedQuerystring = [
     'include_yes_decisions',
@@ -35,6 +28,11 @@ function buildClusterAllocationExplain (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cluster.allocation_explain request
+   * Provides explanations for shard allocations in the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html
+   */
   return function clusterAllocationExplain (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +55,6 @@ function buildClusterAllocationExplain (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +62,7 @@ function buildClusterAllocationExplain (opts) {
 
     var path = ''
 
+    if (method == null) method = body == null ? 'GET' : 'POST'
     path = '/' + '_cluster' + '/' + 'allocation' + '/' + 'explain'
 
     // build request object

--- a/api/api/cluster.get_settings.js
+++ b/api/api/cluster.get_settings.js
@@ -10,14 +10,6 @@
 function buildClusterGetSettings (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cluster.get_settings](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html) request
-   *
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {time} timeout - Explicit operation timeout
-   * @param {boolean} include_defaults - Whether to return all default clusters setting.
-   */
 
   const acceptedQuerystring = [
     'flat_settings',
@@ -39,6 +31,11 @@ function buildClusterGetSettings (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cluster.get_settings request
+   * Returns cluster settings.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html
+   */
   return function clusterGetSettings (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -51,12 +48,6 @@ function buildClusterGetSettings (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -67,10 +58,6 @@ function buildClusterGetSettings (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -78,6 +65,7 @@ function buildClusterGetSettings (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cluster' + '/' + 'settings'
 
     // build request object

--- a/api/api/cluster.health.js
+++ b/api/api/cluster.health.js
@@ -10,22 +10,6 @@
 function buildClusterHealth (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cluster.health](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html) request
-   *
-   * @param {list} index - Limit the information returned to a specific index
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {enum} level - Specify the level of detail for returned information
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {time} timeout - Explicit operation timeout
-   * @param {string} wait_for_active_shards - Wait until the specified number of shards is active
-   * @param {string} wait_for_nodes - Wait until the specified number of nodes is available
-   * @param {enum} wait_for_events - Wait until all currently queued events with the given priority are processed
-   * @param {boolean} wait_for_no_relocating_shards - Whether to wait until there are no relocating shards in the cluster
-   * @param {boolean} wait_for_no_initializing_shards - Whether to wait until there are no initializing shards in the cluster
-   * @param {enum} wait_for_status - Wait until cluster is in a specific state
-   */
 
   const acceptedQuerystring = [
     'expand_wildcards',
@@ -59,6 +43,11 @@ function buildClusterHealth (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cluster.health request
+   * Returns basic information about the health of the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html
+   */
   return function clusterHealth (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -71,12 +60,6 @@ function buildClusterHealth (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -87,10 +70,6 @@ function buildClusterHealth (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -99,8 +78,10 @@ function buildClusterHealth (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cluster' + '/' + 'health' + '/' + encodeURIComponent(index)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cluster' + '/' + 'health'
     }
 

--- a/api/api/cluster.pending_tasks.js
+++ b/api/api/cluster.pending_tasks.js
@@ -10,12 +10,6 @@
 function buildClusterPendingTasks (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cluster.pending_tasks](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html) request
-   *
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Specify timeout for connection to master
-   */
 
   const acceptedQuerystring = [
     'local',
@@ -33,6 +27,12 @@ function buildClusterPendingTasks (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cluster.pending_tasks request
+   * Returns a list of any cluster-level changes (e.g. create index, update mapping,
+allocate or fail shard) which have not yet been executed.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html
+   */
   return function clusterPendingTasks (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -45,12 +45,6 @@ function buildClusterPendingTasks (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -61,10 +55,6 @@ function buildClusterPendingTasks (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -72,6 +62,7 @@ function buildClusterPendingTasks (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_cluster' + '/' + 'pending_tasks'
 
     // build request object

--- a/api/api/cluster.put_settings.js
+++ b/api/api/cluster.put_settings.js
@@ -10,14 +10,6 @@
 function buildClusterPutSettings (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cluster.put_settings](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html) request
-   *
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {time} timeout - Explicit operation timeout
-   * @param {object} body - The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).
-   */
 
   const acceptedQuerystring = [
     'flat_settings',
@@ -37,6 +29,11 @@ function buildClusterPutSettings (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cluster.put_settings request
+   * Updates the cluster settings.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html
+   */
   return function clusterPutSettings (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -65,10 +62,6 @@ function buildClusterPutSettings (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -76,6 +69,7 @@ function buildClusterPutSettings (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_cluster' + '/' + 'settings'
 
     // build request object

--- a/api/api/cluster.remote_info.js
+++ b/api/api/cluster.remote_info.js
@@ -10,10 +10,6 @@
 function buildClusterRemoteInfo (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cluster.remote_info](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html) request
-   *
-   */
 
   const acceptedQuerystring = [
     'pretty',
@@ -28,6 +24,11 @@ function buildClusterRemoteInfo (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cluster.remote_info request
+   * Returns the information about configured remote clusters.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html
+   */
   return function clusterRemoteInfo (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -40,12 +41,6 @@ function buildClusterRemoteInfo (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -56,10 +51,6 @@ function buildClusterRemoteInfo (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,6 +58,7 @@ function buildClusterRemoteInfo (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_remote' + '/' + 'info'
 
     // build request object

--- a/api/api/cluster.reroute.js
+++ b/api/api/cluster.reroute.js
@@ -10,17 +10,6 @@
 function buildClusterReroute (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cluster.reroute](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html) request
-   *
-   * @param {boolean} dry_run - Simulate the operation only and return the resulting state
-   * @param {boolean} explain - Return an explanation of why the commands can or cannot be executed
-   * @param {boolean} retry_failed - Retries allocation of shards that are blocked due to too many subsequent allocation failures
-   * @param {list} metric - Limit the information returned to the specified metrics. Defaults to all but metadata
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {time} timeout - Explicit operation timeout
-   * @param {object} body - The definition of `commands` to perform (`move`, `cancel`, `allocate`)
-   */
 
   const acceptedQuerystring = [
     'dry_run',
@@ -44,6 +33,11 @@ function buildClusterReroute (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cluster.reroute request
+   * Allows to manually change the allocation of individual shards in the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html
+   */
   return function clusterReroute (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -66,10 +60,6 @@ function buildClusterReroute (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -77,6 +67,7 @@ function buildClusterReroute (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_cluster' + '/' + 'reroute'
 
     // build request object

--- a/api/api/cluster.state.js
+++ b/api/api/cluster.state.js
@@ -10,20 +10,6 @@
 function buildClusterState (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cluster.state](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {list} metric - Limit the information returned to the specified metrics
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {number} wait_for_metadata_version - Wait for the metadata version to be equal or greater than the specified metadata version
-   * @param {time} wait_for_timeout - The maximum time to wait for wait_for_metadata_version before timing out
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   */
 
   const acceptedQuerystring = [
     'local',
@@ -53,6 +39,11 @@ function buildClusterState (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cluster.state request
+   * Returns a comprehensive information about the state of the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html
+   */
   return function clusterState (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -63,12 +54,6 @@ function buildClusterState (opts) {
       callback = params
       params = {}
       options = {}
-    }
-
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
     }
 
     // check required url components
@@ -84,12 +69,8 @@ function buildClusterState (opts) {
     }
 
     var warnings = []
-    var { method, body, index, metric, ...querystring } = params
+    var { method, body, metric, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
-
-    if (method == null) {
-      method = 'GET'
-    }
 
     var ignore = options.ignore
     if (typeof ignore === 'number') {
@@ -99,10 +80,13 @@ function buildClusterState (opts) {
     var path = ''
 
     if ((metric) != null && (index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cluster' + '/' + 'state' + '/' + encodeURIComponent(metric) + '/' + encodeURIComponent(index)
     } else if ((metric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cluster' + '/' + 'state' + '/' + encodeURIComponent(metric)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cluster' + '/' + 'state'
     }
 

--- a/api/api/cluster.stats.js
+++ b/api/api/cluster.stats.js
@@ -10,13 +10,6 @@
 function buildClusterStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [cluster.stats](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html) request
-   *
-   * @param {list} node_id - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {time} timeout - Explicit operation timeout
-   */
 
   const acceptedQuerystring = [
     'flat_settings',
@@ -34,6 +27,11 @@ function buildClusterStats (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a cluster.stats request
+   * Returns high-level overview of cluster statistics.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html
+   */
   return function clusterStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,12 +44,6 @@ function buildClusterStats (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -62,10 +54,6 @@ function buildClusterStats (opts) {
     var { method, body, nodeId, node_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -74,8 +62,10 @@ function buildClusterStats (opts) {
     var path = ''
 
     if ((node_id || nodeId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cluster' + '/' + 'stats' + '/' + 'nodes' + '/' + encodeURIComponent(node_id || nodeId)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_cluster' + '/' + 'stats'
     }
 

--- a/api/api/count.js
+++ b/api/api/count.js
@@ -10,27 +10,6 @@
 function buildCount (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [count](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html) request
-   *
-   * @param {list} index - A comma-separated list of indices to restrict the results
-   * @param {list} type - A comma-separated list of types to restrict the results
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} ignore_throttled - Whether specified concrete, expanded or aliased indices should be ignored when throttled
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {number} min_score - Include only documents with a specific `_score` value in the result
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {list} routing - A comma-separated list of specific routing values
-   * @param {string} q - Query in the Lucene query string syntax
-   * @param {string} analyzer - The analyzer to use for the query string
-   * @param {boolean} analyze_wildcard - Specify whether wildcard and prefix queries should be analyzed (default: false)
-   * @param {enum} default_operator - The default operator for query string query (AND or OR)
-   * @param {string} df - The field to use as default where no field prefix is given in the query string
-   * @param {boolean} lenient - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-   * @param {number} terminate_after - The maximum count for each shard, upon reaching which the query execution will terminate early
-   * @param {object} body - A query to restrict the results specified with the Query DSL (optional)
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -67,6 +46,11 @@ function buildCount (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a count request
+   * Returns number of documents matching a query.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html
+   */
   return function count (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -86,12 +70,8 @@ function buildCount (opts) {
     }
 
     var warnings = []
-    var { method, body, index, type, ...querystring } = params
+    var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
-
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
 
     var ignore = options.ignore
     if (typeof ignore === 'number') {
@@ -101,8 +81,10 @@ function buildCount (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_count'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_count'
     }
 

--- a/api/api/create.js
+++ b/api/api/create.js
@@ -10,21 +10,6 @@
 function buildCreate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [create](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html) request
-   *
-   * @param {string} id - Document ID
-   * @param {string} index - The name of the index
-   * @param {string} type - The type of the document
-   * @param {string} wait_for_active_shards - Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-   * @param {enum} refresh - If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
-   * @param {string} routing - Specific routing value
-   * @param {time} timeout - Explicit operation timeout
-   * @param {number} version - Explicit version number for concurrency control
-   * @param {enum} version_type - Specific version type
-   * @param {string} pipeline - The pipeline id to preprocess incoming documents with
-   * @param {object} body - The document
-   */
 
   const acceptedQuerystring = [
     'wait_for_active_shards',
@@ -48,6 +33,13 @@ function buildCreate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a create request
+   * Creates a new document in the index.
+
+Returns a 409 response when a document with a same ID already exists in the index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html
+   */
   return function create (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -84,10 +76,6 @@ function buildCreate (opts) {
     var { method, body, id, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -96,8 +84,10 @@ function buildCreate (opts) {
     var path = ''
 
     if ((index) != null && (type) != null && (id) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_create'
     } else {
+      if (method == null) method = 'PUT'
       path = '/' + encodeURIComponent(index) + '/' + '_create' + '/' + encodeURIComponent(id)
     }
 

--- a/api/api/data_frame.delete_data_frame_transform.js
+++ b/api/api/data_frame.delete_data_frame_transform.js
@@ -10,12 +10,6 @@
 function buildDataFrameDeleteDataFrameTransform (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [data_frame.delete_data_frame_transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-data-frame-transform.html) request
-   *
-   * @param {string} transform_id - The id of the transform to delete
-   * @param {boolean} force - When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted.
-   */
 
   const acceptedQuerystring = [
     'force'
@@ -25,6 +19,10 @@ function buildDataFrameDeleteDataFrameTransform (opts) {
 
   }
 
+  /**
+   * Perform a data_frame.delete_data_frame_transform request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-data-frame-transform.html
+   */
   return function dataFrameDeleteDataFrameTransform (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,10 +40,6 @@ function buildDataFrameDeleteDataFrameTransform (opts) {
       const err = new ConfigurationError('Missing required parameter: transform_id or transformId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -57,10 +51,6 @@ function buildDataFrameDeleteDataFrameTransform (opts) {
     var { method, body, transformId, transform_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,13 +58,14 @@ function buildDataFrameDeleteDataFrameTransform (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_data_frame' + '/' + 'transforms' + '/' + encodeURIComponent(transform_id || transformId)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/data_frame.get_data_frame_transform.js
+++ b/api/api/data_frame.get_data_frame_transform.js
@@ -10,14 +10,6 @@
 function buildDataFrameGetDataFrameTransform (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [data_frame.get_data_frame_transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-data-frame-transform.html) request
-   *
-   * @param {string} transform_id - The id or comma delimited list of id expressions of the transforms to get, '_all' or '*' implies get all transforms
-   * @param {int} from - skips a number of transform configs, defaults to 0
-   * @param {int} size - specifies a max number of transforms to get, defaults to 100
-   * @param {boolean} allow_no_match - Whether to ignore if a wildcard expression matches no data frame transforms. (This includes `_all` string or when no data frame transforms have been specified)
-   */
 
   const acceptedQuerystring = [
     'from',
@@ -29,6 +21,10 @@ function buildDataFrameGetDataFrameTransform (opts) {
     allowNoMatch: 'allow_no_match'
   }
 
+  /**
+   * Perform a data_frame.get_data_frame_transform request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/get-data-frame-transform.html
+   */
   return function dataFrameGetDataFrameTransform (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,12 +37,6 @@ function buildDataFrameGetDataFrameTransform (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -57,10 +47,6 @@ function buildDataFrameGetDataFrameTransform (opts) {
     var { method, body, transformId, transform_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,8 +55,10 @@ function buildDataFrameGetDataFrameTransform (opts) {
     var path = ''
 
     if ((transform_id || transformId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_data_frame' + '/' + 'transforms' + '/' + encodeURIComponent(transform_id || transformId)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_data_frame' + '/' + 'transforms'
     }
 

--- a/api/api/data_frame.get_data_frame_transform_stats.js
+++ b/api/api/data_frame.get_data_frame_transform_stats.js
@@ -10,14 +10,6 @@
 function buildDataFrameGetDataFrameTransformStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [data_frame.get_data_frame_transform_stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-data-frame-transform-stats.html) request
-   *
-   * @param {string} transform_id - The id of the transform for which to get stats. '_all' or '*' implies all transforms
-   * @param {number} from - skips a number of transform stats, defaults to 0
-   * @param {number} size - specifies a max number of transform stats to get, defaults to 100
-   * @param {boolean} allow_no_match - Whether to ignore if a wildcard expression matches no data frame transforms. (This includes `_all` string or when no data frame transforms have been specified)
-   */
 
   const acceptedQuerystring = [
     'from',
@@ -29,6 +21,10 @@ function buildDataFrameGetDataFrameTransformStats (opts) {
     allowNoMatch: 'allow_no_match'
   }
 
+  /**
+   * Perform a data_frame.get_data_frame_transform_stats request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/get-data-frame-transform-stats.html
+   */
   return function dataFrameGetDataFrameTransformStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,8 +38,8 @@ function buildDataFrameGetDataFrameTransformStats (opts) {
     }
 
     // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
+    if (params['transform_id'] == null && params['transformId'] == null) {
+      const err = new ConfigurationError('Missing required parameter: transform_id or transformId')
       return handleError(err, callback)
     }
 
@@ -57,10 +53,6 @@ function buildDataFrameGetDataFrameTransformStats (opts) {
     var { method, body, transformId, transform_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +60,7 @@ function buildDataFrameGetDataFrameTransformStats (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_data_frame' + '/' + 'transforms' + '/' + encodeURIComponent(transform_id || transformId) + '/' + '_stats'
 
     // build request object

--- a/api/api/data_frame.preview_data_frame_transform.js
+++ b/api/api/data_frame.preview_data_frame_transform.js
@@ -10,11 +10,6 @@
 function buildDataFramePreviewDataFrameTransform (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [data_frame.preview_data_frame_transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-data-frame-transform.html) request
-   *
-   * @param {object} body - The definition for the data_frame transform to preview
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildDataFramePreviewDataFrameTransform (opts) {
 
   }
 
+  /**
+   * Perform a data_frame.preview_data_frame_transform request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-data-frame-transform.html
+   */
   return function dataFramePreviewDataFrameTransform (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildDataFramePreviewDataFrameTransform (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildDataFramePreviewDataFrameTransform (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_data_frame' + '/' + 'transforms' + '/' + '_preview'
 
     // build request object

--- a/api/api/data_frame.put_data_frame_transform.js
+++ b/api/api/data_frame.put_data_frame_transform.js
@@ -10,13 +10,6 @@
 function buildDataFramePutDataFrameTransform (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [data_frame.put_data_frame_transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-data-frame-transform.html) request
-   *
-   * @param {string} transform_id - The id of the new transform.
-   * @param {boolean} defer_validation - If validations should be deferred until data frame transform starts, defaults to false.
-   * @param {object} body - The data frame transform definition
-   */
 
   const acceptedQuerystring = [
     'defer_validation'
@@ -26,6 +19,10 @@ function buildDataFramePutDataFrameTransform (opts) {
     deferValidation: 'defer_validation'
   }
 
+  /**
+   * Perform a data_frame.put_data_frame_transform request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/put-data-frame-transform.html
+   */
   return function dataFramePutDataFrameTransform (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,10 +55,6 @@ function buildDataFramePutDataFrameTransform (opts) {
     var { method, body, transformId, transform_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,6 +62,7 @@ function buildDataFramePutDataFrameTransform (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_data_frame' + '/' + 'transforms' + '/' + encodeURIComponent(transform_id || transformId)
 
     // build request object

--- a/api/api/data_frame.start_data_frame_transform.js
+++ b/api/api/data_frame.start_data_frame_transform.js
@@ -10,12 +10,6 @@
 function buildDataFrameStartDataFrameTransform (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [data_frame.start_data_frame_transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/start-data-frame-transform.html) request
-   *
-   * @param {string} transform_id - The id of the transform to start
-   * @param {time} timeout - Controls the time to wait for the transform to start
-   */
 
   const acceptedQuerystring = [
     'timeout'
@@ -25,6 +19,10 @@ function buildDataFrameStartDataFrameTransform (opts) {
 
   }
 
+  /**
+   * Perform a data_frame.start_data_frame_transform request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/start-data-frame-transform.html
+   */
   return function dataFrameStartDataFrameTransform (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,10 +40,6 @@ function buildDataFrameStartDataFrameTransform (opts) {
       const err = new ConfigurationError('Missing required parameter: transform_id or transformId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -57,10 +51,6 @@ function buildDataFrameStartDataFrameTransform (opts) {
     var { method, body, transformId, transform_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,13 +58,14 @@ function buildDataFrameStartDataFrameTransform (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_data_frame' + '/' + 'transforms' + '/' + encodeURIComponent(transform_id || transformId) + '/' + '_start'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/data_frame.stop_data_frame_transform.js
+++ b/api/api/data_frame.stop_data_frame_transform.js
@@ -10,14 +10,6 @@
 function buildDataFrameStopDataFrameTransform (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [data_frame.stop_data_frame_transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-data-frame-transform.html) request
-   *
-   * @param {string} transform_id - The id of the transform to stop
-   * @param {boolean} wait_for_completion - Whether to wait for the transform to fully stop before returning or not. Default to false
-   * @param {time} timeout - Controls the time to wait until the transform has stopped. Default to 30 seconds
-   * @param {boolean} allow_no_match - Whether to ignore if a wildcard expression matches no data frame transforms. (This includes `_all` string or when no data frame transforms have been specified)
-   */
 
   const acceptedQuerystring = [
     'wait_for_completion',
@@ -30,6 +22,10 @@ function buildDataFrameStopDataFrameTransform (opts) {
     allowNoMatch: 'allow_no_match'
   }
 
+  /**
+   * Perform a data_frame.stop_data_frame_transform request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-data-frame-transform.html
+   */
   return function dataFrameStopDataFrameTransform (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -47,10 +43,6 @@ function buildDataFrameStopDataFrameTransform (opts) {
       const err = new ConfigurationError('Missing required parameter: transform_id or transformId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -62,10 +54,6 @@ function buildDataFrameStopDataFrameTransform (opts) {
     var { method, body, transformId, transform_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -73,13 +61,14 @@ function buildDataFrameStopDataFrameTransform (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_data_frame' + '/' + 'transforms' + '/' + encodeURIComponent(transform_id || transformId) + '/' + '_stop'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/data_frame.update_data_frame_transform.js
+++ b/api/api/data_frame.update_data_frame_transform.js
@@ -10,13 +10,6 @@
 function buildDataFrameUpdateDataFrameTransform (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [data_frame.update_data_frame_transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/update-data-frame-transform.html) request
-   *
-   * @param {string} transform_id - The id of the transform.
-   * @param {boolean} defer_validation - If validations should be deferred until data frame transform starts, defaults to false.
-   * @param {object} body - The update data frame transform definition
-   */
 
   const acceptedQuerystring = [
     'defer_validation'
@@ -26,6 +19,10 @@ function buildDataFrameUpdateDataFrameTransform (opts) {
     deferValidation: 'defer_validation'
   }
 
+  /**
+   * Perform a data_frame.update_data_frame_transform request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/update-data-frame-transform.html
+   */
   return function dataFrameUpdateDataFrameTransform (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,10 +55,6 @@ function buildDataFrameUpdateDataFrameTransform (opts) {
     var { method, body, transformId, transform_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,6 +62,7 @@ function buildDataFrameUpdateDataFrameTransform (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_data_frame' + '/' + 'transforms' + '/' + encodeURIComponent(transform_id || transformId) + '/' + '_update'
 
     // build request object

--- a/api/api/delete.js
+++ b/api/api/delete.js
@@ -10,21 +10,6 @@
 function buildDelete (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [delete](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html) request
-   *
-   * @param {string} id - The document ID
-   * @param {string} index - The name of the index
-   * @param {string} type - The type of the document
-   * @param {string} wait_for_active_shards - Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-   * @param {enum} refresh - If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
-   * @param {string} routing - Specific routing value
-   * @param {time} timeout - Explicit operation timeout
-   * @param {number} if_seq_no - only perform the delete operation if the last operation that has changed the document has the specified sequence number
-   * @param {number} if_primary_term - only perform the delete operation if the last operation that has changed the document has the specified primary term
-   * @param {number} version - Explicit version number for concurrency control
-   * @param {enum} version_type - Specific version type
-   */
 
   const acceptedQuerystring = [
     'wait_for_active_shards',
@@ -51,6 +36,11 @@ function buildDelete (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a delete request
+   * Removes a document from the index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html
+   */
   return function _delete (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -72,10 +62,6 @@ function buildDelete (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -87,10 +73,6 @@ function buildDelete (opts) {
     var { method, body, id, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -99,8 +81,10 @@ function buildDelete (opts) {
     var path = ''
 
     if ((index) != null && (type) != null && (id) != null) {
+      if (method == null) method = 'DELETE'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id)
     } else {
+      if (method == null) method = 'DELETE'
       path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
     }
 
@@ -108,7 +92,7 @@ function buildDelete (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/delete_by_query.js
+++ b/api/api/delete_by_query.js
@@ -10,44 +10,6 @@
 function buildDeleteByQuery (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [delete_by_query](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-   * @param {string} analyzer - The analyzer to use for the query string
-   * @param {boolean} analyze_wildcard - Specify whether wildcard and prefix queries should be analyzed (default: false)
-   * @param {enum} default_operator - The default operator for query string query (AND or OR)
-   * @param {string} df - The field to use as default where no field prefix is given in the query string
-   * @param {number} from - Starting offset (default: 0)
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} conflicts - What to do when the delete by query hits version conflicts?
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} lenient - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {string} q - Query in the Lucene query string syntax
-   * @param {list} routing - A comma-separated list of specific routing values
-   * @param {time} scroll - Specify how long a consistent view of the index should be maintained for scrolled search
-   * @param {enum} search_type - Search operation type
-   * @param {time} search_timeout - Explicit timeout for each search request. Defaults to no timeout.
-   * @param {number} max_docs - Maximum number of documents to process (default: all documents)
-   * @param {list} sort - A comma-separated list of <field>:<direction> pairs
-   * @param {list} _source - True or false to return the _source field or not, or a list of fields to return
-   * @param {list} _source_excludes - A list of fields to exclude from the returned _source field
-   * @param {list} _source_includes - A list of fields to extract and return from the _source field
-   * @param {number} terminate_after - The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
-   * @param {list} stats - Specific 'tag' of the request for logging and statistical purposes
-   * @param {boolean} version - Specify whether to return document version as part of a hit
-   * @param {boolean} request_cache - Specify if request cache should be used for this request or not, defaults to index level setting
-   * @param {boolean} refresh - Should the effected indexes be refreshed?
-   * @param {time} timeout - Time each individual bulk request should wait for shards that are unavailable.
-   * @param {string} wait_for_active_shards - Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-   * @param {number} scroll_size - Size on the scroll request powering the delete by query
-   * @param {boolean} wait_for_completion - Should the request should block until the delete by query is complete.
-   * @param {number} requests_per_second - The throttle for this request in sub-requests per second. -1 means no throttle.
-   * @param {number} slices - The number of slices this task should be divided into. Defaults to 1 meaning the task isn't sliced into subtasks.
-   * @param {object} body - The search definition using the Query DSL
-   */
 
   const acceptedQuerystring = [
     'analyzer',
@@ -114,6 +76,11 @@ function buildDeleteByQuery (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a delete_by_query request
+   * Deletes documents matching the provided query.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html
+   */
   return function deleteByQuery (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -146,10 +113,6 @@ function buildDeleteByQuery (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -157,6 +120,7 @@ function buildDeleteByQuery (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_delete_by_query'
 
     // build request object

--- a/api/api/delete_by_query_rethrottle.js
+++ b/api/api/delete_by_query_rethrottle.js
@@ -10,12 +10,6 @@
 function buildDeleteByQueryRethrottle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [delete_by_query_rethrottle](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html) request
-   *
-   * @param {string} task_id - The task id to rethrottle
-   * @param {number} requests_per_second - The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
-   */
 
   const acceptedQuerystring = [
     'requests_per_second',
@@ -32,6 +26,11 @@ function buildDeleteByQueryRethrottle (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a delete_by_query_rethrottle request
+   * Changes the number of requests per second for a particular Delete By Query operation.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+   */
   return function deleteByQueryRethrottle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,10 +52,6 @@ function buildDeleteByQueryRethrottle (opts) {
       const err = new ConfigurationError('Missing required parameter: requests_per_second or requestsPerSecond')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -68,10 +63,6 @@ function buildDeleteByQueryRethrottle (opts) {
     var { method, body, taskId, task_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -79,13 +70,14 @@ function buildDeleteByQueryRethrottle (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_delete_by_query' + '/' + encodeURIComponent(task_id || taskId) + '/' + '_rethrottle'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/delete_script.js
+++ b/api/api/delete_script.js
@@ -10,13 +10,6 @@
 function buildDeleteScript (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [delete_script](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html) request
-   *
-   * @param {string} id - Script ID
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -34,6 +27,11 @@ function buildDeleteScript (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a delete_script request
+   * Deletes a script.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
+   */
   return function deleteScript (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -51,10 +49,6 @@ function buildDeleteScript (opts) {
       const err = new ConfigurationError('Missing required parameter: id')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -66,10 +60,6 @@ function buildDeleteScript (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -77,13 +67,14 @@ function buildDeleteScript (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_scripts' + '/' + encodeURIComponent(id)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/exists.js
+++ b/api/api/exists.js
@@ -10,23 +10,6 @@
 function buildExists (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [exists](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html) request
-   *
-   * @param {string} id - The document ID
-   * @param {string} index - The name of the index
-   * @param {string} type - The type of the document (use `_all` to fetch the first document matching the ID across all types)
-   * @param {list} stored_fields - A comma-separated list of stored fields to return in the response
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {boolean} realtime - Specify whether to perform the operation in realtime or search mode
-   * @param {boolean} refresh - Refresh the shard containing the document before performing the operation
-   * @param {string} routing - Specific routing value
-   * @param {list} _source - True or false to return the _source field or not, or a list of fields to return
-   * @param {list} _source_excludes - A list of fields to exclude from the returned _source field
-   * @param {list} _source_includes - A list of fields to extract and return from the _source field
-   * @param {number} version - Explicit version number for concurrency control
-   * @param {enum} version_type - Specific version type
-   */
 
   const acceptedQuerystring = [
     'stored_fields',
@@ -59,6 +42,11 @@ function buildExists (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a exists request
+   * Returns information about whether a document exists in an index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html
+   */
   return function exists (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -80,10 +68,6 @@ function buildExists (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -95,10 +79,6 @@ function buildExists (opts) {
     var { method, body, id, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'HEAD'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -107,8 +87,10 @@ function buildExists (opts) {
     var path = ''
 
     if ((index) != null && (type) != null && (id) != null) {
+      if (method == null) method = 'HEAD'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id)
     } else {
+      if (method == null) method = 'HEAD'
       path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
     }
 

--- a/api/api/exists_source.js
+++ b/api/api/exists_source.js
@@ -10,22 +10,6 @@
 function buildExistsSource (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [exists_source](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html) request
-   *
-   * @param {string} id - The document ID
-   * @param {string} index - The name of the index
-   * @param {string} type - The type of the document; deprecated and optional starting with 7.0
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {boolean} realtime - Specify whether to perform the operation in realtime or search mode
-   * @param {boolean} refresh - Refresh the shard containing the document before performing the operation
-   * @param {string} routing - Specific routing value
-   * @param {list} _source - True or false to return the _source field or not, or a list of fields to return
-   * @param {list} _source_excludes - A list of fields to exclude from the returned _source field
-   * @param {list} _source_includes - A list of fields to extract and return from the _source field
-   * @param {number} version - Explicit version number for concurrency control
-   * @param {enum} version_type - Specific version type
-   */
 
   const acceptedQuerystring = [
     'preference',
@@ -56,6 +40,11 @@ function buildExistsSource (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a exists_source request
+   * Returns information about whether a document source exists in an index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html
+   */
   return function existsSource (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -75,10 +64,6 @@ function buildExistsSource (opts) {
     }
     if (params['index'] == null) {
       const err = new ConfigurationError('Missing required parameter: index')
-      return handleError(err, callback)
-    }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
       return handleError(err, callback)
     }
 
@@ -101,10 +86,6 @@ function buildExistsSource (opts) {
     var { method, body, id, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'HEAD'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -113,8 +94,10 @@ function buildExistsSource (opts) {
     var path = ''
 
     if ((index) != null && (type) != null && (id) != null) {
+      if (method == null) method = 'HEAD'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_source'
     } else {
+      if (method == null) method = 'HEAD'
       path = '/' + encodeURIComponent(index) + '/' + '_source' + '/' + encodeURIComponent(id)
     }
 

--- a/api/api/explain.js
+++ b/api/api/explain.js
@@ -10,26 +10,6 @@
 function buildExplain (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [explain](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html) request
-   *
-   * @param {string} id - The document ID
-   * @param {string} index - The name of the index
-   * @param {string} type - The type of the document
-   * @param {boolean} analyze_wildcard - Specify whether wildcards and prefix queries in the query string query should be analyzed (default: false)
-   * @param {string} analyzer - The analyzer for the query string query
-   * @param {enum} default_operator - The default operator for query string query (AND or OR)
-   * @param {string} df - The default field for query string query (default: _all)
-   * @param {list} stored_fields - A comma-separated list of stored fields to return in the response
-   * @param {boolean} lenient - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {string} q - Query in the Lucene query string syntax
-   * @param {string} routing - Specific routing value
-   * @param {list} _source - True or false to return the _source field or not, or a list of fields to return
-   * @param {list} _source_excludes - A list of fields to exclude from the returned _source field
-   * @param {list} _source_includes - A list of fields to extract and return from the _source field
-   * @param {object} body - The query definition using the Query DSL
-   */
 
   const acceptedQuerystring = [
     'analyze_wildcard',
@@ -65,6 +45,11 @@ function buildExplain (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a explain request
+   * Returns information about why a specific matches (or doesn't match) a query.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html
+   */
   return function explain (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -97,10 +82,6 @@ function buildExplain (opts) {
     var { method, body, id, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -109,8 +90,10 @@ function buildExplain (opts) {
     var path = ''
 
     if ((index) != null && (type) != null && (id) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_explain'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_explain' + '/' + encodeURIComponent(id)
     }
 

--- a/api/api/field_caps.js
+++ b/api/api/field_caps.js
@@ -10,16 +10,6 @@
 function buildFieldCaps (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [field_caps](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {list} fields - A comma-separated list of field names
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} include_unmapped - Indicates whether unmapped fields should be included in the response.
-   */
 
   const acceptedQuerystring = [
     'fields',
@@ -43,6 +33,11 @@ function buildFieldCaps (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a field_caps request
+   * Returns the information about the capabilities of fields among multiple indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html
+   */
   return function fieldCaps (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -55,12 +50,6 @@ function buildFieldCaps (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -71,10 +60,6 @@ function buildFieldCaps (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -83,8 +68,10 @@ function buildFieldCaps (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_field_caps'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_field_caps'
     }
 
@@ -92,7 +79,7 @@ function buildFieldCaps (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/get.js
+++ b/api/api/get.js
@@ -10,23 +10,6 @@
 function buildGet (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [get](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html) request
-   *
-   * @param {string} id - The document ID
-   * @param {string} index - The name of the index
-   * @param {string} type - The type of the document (use `_all` to fetch the first document matching the ID across all types)
-   * @param {list} stored_fields - A comma-separated list of stored fields to return in the response
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {boolean} realtime - Specify whether to perform the operation in realtime or search mode
-   * @param {boolean} refresh - Refresh the shard containing the document before performing the operation
-   * @param {string} routing - Specific routing value
-   * @param {list} _source - True or false to return the _source field or not, or a list of fields to return
-   * @param {list} _source_excludes - A list of fields to exclude from the returned _source field
-   * @param {list} _source_includes - A list of fields to extract and return from the _source field
-   * @param {number} version - Explicit version number for concurrency control
-   * @param {enum} version_type - Specific version type
-   */
 
   const acceptedQuerystring = [
     'stored_fields',
@@ -59,6 +42,11 @@ function buildGet (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a get request
+   * Returns a document.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html
+   */
   return function get (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -80,10 +68,6 @@ function buildGet (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -95,10 +79,6 @@ function buildGet (opts) {
     var { method, body, id, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -107,8 +87,10 @@ function buildGet (opts) {
     var path = ''
 
     if ((index) != null && (type) != null && (id) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
     }
 

--- a/api/api/get_script.js
+++ b/api/api/get_script.js
@@ -10,12 +10,6 @@
 function buildGetScript (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [get_script](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html) request
-   *
-   * @param {string} id - Script ID
-   * @param {time} master_timeout - Specify timeout for connection to master
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -32,6 +26,11 @@ function buildGetScript (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a get_script request
+   * Returns a script.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
+   */
   return function getScript (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -49,10 +48,6 @@ function buildGetScript (opts) {
       const err = new ConfigurationError('Missing required parameter: id')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -64,10 +59,6 @@ function buildGetScript (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -75,6 +66,7 @@ function buildGetScript (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_scripts' + '/' + encodeURIComponent(id)
 
     // build request object

--- a/api/api/get_source.js
+++ b/api/api/get_source.js
@@ -10,22 +10,6 @@
 function buildGetSource (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [get_source](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html) request
-   *
-   * @param {string} id - The document ID
-   * @param {string} index - The name of the index
-   * @param {string} type - The type of the document; deprecated and optional starting with 7.0
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {boolean} realtime - Specify whether to perform the operation in realtime or search mode
-   * @param {boolean} refresh - Refresh the shard containing the document before performing the operation
-   * @param {string} routing - Specific routing value
-   * @param {list} _source - True or false to return the _source field or not, or a list of fields to return
-   * @param {list} _source_excludes - A list of fields to exclude from the returned _source field
-   * @param {list} _source_includes - A list of fields to extract and return from the _source field
-   * @param {number} version - Explicit version number for concurrency control
-   * @param {enum} version_type - Specific version type
-   */
 
   const acceptedQuerystring = [
     'preference',
@@ -56,6 +40,11 @@ function buildGetSource (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a get_source request
+   * Returns the source of a document.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html
+   */
   return function getSource (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -77,10 +66,6 @@ function buildGetSource (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -92,10 +77,6 @@ function buildGetSource (opts) {
     var { method, body, id, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -104,8 +85,10 @@ function buildGetSource (opts) {
     var path = ''
 
     if ((index) != null && (type) != null && (id) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_source'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_source' + '/' + encodeURIComponent(id)
     }
 

--- a/api/api/graph.explore.js
+++ b/api/api/graph.explore.js
@@ -10,15 +10,6 @@
 function buildGraphExplore (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [graph.explore](https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-   * @param {list} type - A comma-separated list of document types to search; leave empty to perform the operation on all types
-   * @param {string} routing - Specific routing value
-   * @param {time} timeout - Explicit operation timeout
-   * @param {object} body - Graph Query DSL
-   */
 
   const acceptedQuerystring = [
     'routing',
@@ -29,6 +20,10 @@ function buildGraphExplore (opts) {
 
   }
 
+  /**
+   * Perform a graph.explore request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html
+   */
   return function graphExplore (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -39,6 +34,12 @@ function buildGraphExplore (opts) {
       callback = params
       params = {}
       options = {}
+    }
+
+    // check required parameters
+    if (params['index'] == null) {
+      const err = new ConfigurationError('Missing required parameter: index')
+      return handleError(err, callback)
     }
 
     // check required url components
@@ -57,10 +58,6 @@ function buildGraphExplore (opts) {
     var { method, body, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,8 +66,10 @@ function buildGraphExplore (opts) {
     var path = ''
 
     if ((index) != null && (type) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_graph' + '/' + 'explore'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_graph' + '/' + 'explore'
     }
 

--- a/api/api/ilm.delete_lifecycle.js
+++ b/api/api/ilm.delete_lifecycle.js
@@ -10,11 +10,6 @@
 function buildIlmDeleteLifecycle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ilm.delete_lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html) request
-   *
-   * @param {string} policy - The name of the index lifecycle policy
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildIlmDeleteLifecycle (opts) {
 
   }
 
+  /**
+   * Perform a ilm.delete_lifecycle request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html
+   */
   return function ilmDeleteLifecycle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,8 +36,8 @@ function buildIlmDeleteLifecycle (opts) {
     }
 
     // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
+    if (params['policy'] == null) {
+      const err = new ConfigurationError('Missing required parameter: policy')
       return handleError(err, callback)
     }
 
@@ -52,10 +51,6 @@ function buildIlmDeleteLifecycle (opts) {
     var { method, body, policy, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,13 +58,14 @@ function buildIlmDeleteLifecycle (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ilm' + '/' + 'policy' + '/' + encodeURIComponent(policy)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ilm.explain_lifecycle.js
+++ b/api/api/ilm.explain_lifecycle.js
@@ -10,13 +10,6 @@
 function buildIlmExplainLifecycle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ilm.explain_lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html) request
-   *
-   * @param {string} index - The name of the index to explain
-   * @param {boolean} only_managed - filters the indices included in the response to ones managed by ILM
-   * @param {boolean} only_errors - filters the indices included in the response to ones in an ILM error state, implies only_managed
-   */
 
   const acceptedQuerystring = [
     'only_managed',
@@ -28,6 +21,10 @@ function buildIlmExplainLifecycle (opts) {
     onlyErrors: 'only_errors'
   }
 
+  /**
+   * Perform a ilm.explain_lifecycle request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html
+   */
   return function ilmExplainLifecycle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,8 +38,8 @@ function buildIlmExplainLifecycle (opts) {
     }
 
     // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
+    if (params['index'] == null) {
+      const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
 
@@ -56,10 +53,6 @@ function buildIlmExplainLifecycle (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,6 +60,7 @@ function buildIlmExplainLifecycle (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + encodeURIComponent(index) + '/' + '_ilm' + '/' + 'explain'
 
     // build request object

--- a/api/api/ilm.get_lifecycle.js
+++ b/api/api/ilm.get_lifecycle.js
@@ -10,11 +10,6 @@
 function buildIlmGetLifecycle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ilm.get_lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html) request
-   *
-   * @param {string} policy - The name of the index lifecycle policy
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildIlmGetLifecycle (opts) {
 
   }
 
+  /**
+   * Perform a ilm.get_lifecycle request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html
+   */
   return function ilmGetLifecycle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,12 +35,6 @@ function buildIlmGetLifecycle (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -52,10 +45,6 @@ function buildIlmGetLifecycle (opts) {
     var { method, body, policy, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,8 +53,10 @@ function buildIlmGetLifecycle (opts) {
     var path = ''
 
     if ((policy) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_ilm' + '/' + 'policy' + '/' + encodeURIComponent(policy)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_ilm' + '/' + 'policy'
     }
 

--- a/api/api/ilm.get_status.js
+++ b/api/api/ilm.get_status.js
@@ -10,10 +10,6 @@
 function buildIlmGetStatus (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ilm.get_status](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildIlmGetStatus (opts) {
 
   }
 
+  /**
+   * Perform a ilm.get_status request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html
+   */
   return function ilmGetStatus (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildIlmGetStatus (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildIlmGetStatus (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,6 +52,7 @@ function buildIlmGetStatus (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_ilm' + '/' + 'status'
 
     // build request object

--- a/api/api/ilm.move_to_step.js
+++ b/api/api/ilm.move_to_step.js
@@ -10,12 +10,6 @@
 function buildIlmMoveToStep (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ilm.move_to_step](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html) request
-   *
-   * @param {string} index - The name of the index whose lifecycle step is to change
-   * @param {object} body - The new lifecycle step to move to
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildIlmMoveToStep (opts) {
 
   }
 
+  /**
+   * Perform a ilm.move_to_step request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html
+   */
   return function ilmMoveToStep (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,6 +35,12 @@ function buildIlmMoveToStep (opts) {
       options = {}
     }
 
+    // check required parameters
+    if (params['index'] == null) {
+      const err = new ConfigurationError('Missing required parameter: index')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -47,10 +51,6 @@ function buildIlmMoveToStep (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -58,6 +58,7 @@ function buildIlmMoveToStep (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ilm' + '/' + 'move' + '/' + encodeURIComponent(index)
 
     // build request object

--- a/api/api/ilm.put_lifecycle.js
+++ b/api/api/ilm.put_lifecycle.js
@@ -10,12 +10,6 @@
 function buildIlmPutLifecycle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ilm.put_lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html) request
-   *
-   * @param {string} policy - The name of the index lifecycle policy
-   * @param {object} body - The lifecycle policy definition to register
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildIlmPutLifecycle (opts) {
 
   }
 
+  /**
+   * Perform a ilm.put_lifecycle request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html
+   */
   return function ilmPutLifecycle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,6 +35,12 @@ function buildIlmPutLifecycle (opts) {
       options = {}
     }
 
+    // check required parameters
+    if (params['policy'] == null) {
+      const err = new ConfigurationError('Missing required parameter: policy')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -47,10 +51,6 @@ function buildIlmPutLifecycle (opts) {
     var { method, body, policy, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -58,6 +58,7 @@ function buildIlmPutLifecycle (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_ilm' + '/' + 'policy' + '/' + encodeURIComponent(policy)
 
     // build request object

--- a/api/api/ilm.remove_policy.js
+++ b/api/api/ilm.remove_policy.js
@@ -10,11 +10,6 @@
 function buildIlmRemovePolicy (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ilm.remove_policy](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html) request
-   *
-   * @param {string} index - The name of the index to remove policy on
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildIlmRemovePolicy (opts) {
 
   }
 
+  /**
+   * Perform a ilm.remove_policy request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html
+   */
   return function ilmRemovePolicy (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,8 +36,8 @@ function buildIlmRemovePolicy (opts) {
     }
 
     // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
+    if (params['index'] == null) {
+      const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
 
@@ -52,10 +51,6 @@ function buildIlmRemovePolicy (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,13 +58,14 @@ function buildIlmRemovePolicy (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_ilm' + '/' + 'remove'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ilm.retry.js
+++ b/api/api/ilm.retry.js
@@ -10,11 +10,6 @@
 function buildIlmRetry (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ilm.retry](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html) request
-   *
-   * @param {string} index - The name of the indices (comma-separated) whose failed lifecycle step is to be retry
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildIlmRetry (opts) {
 
   }
 
+  /**
+   * Perform a ilm.retry request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html
+   */
   return function ilmRetry (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,8 +36,8 @@ function buildIlmRetry (opts) {
     }
 
     // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
+    if (params['index'] == null) {
+      const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
 
@@ -52,10 +51,6 @@ function buildIlmRetry (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,13 +58,14 @@ function buildIlmRetry (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_ilm' + '/' + 'retry'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ilm.start.js
+++ b/api/api/ilm.start.js
@@ -10,10 +10,6 @@
 function buildIlmStart (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ilm.start](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildIlmStart (opts) {
 
   }
 
+  /**
+   * Perform a ilm.start request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html
+   */
   return function ilmStart (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildIlmStart (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildIlmStart (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,13 +52,14 @@ function buildIlmStart (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ilm' + '/' + 'start'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ilm.stop.js
+++ b/api/api/ilm.stop.js
@@ -10,10 +10,6 @@
 function buildIlmStop (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ilm.stop](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildIlmStop (opts) {
 
   }
 
+  /**
+   * Perform a ilm.stop request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html
+   */
   return function ilmStop (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildIlmStop (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildIlmStop (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,13 +52,14 @@ function buildIlmStop (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ilm' + '/' + 'stop'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/index.js
+++ b/api/api/index.js
@@ -10,24 +10,6 @@
 function buildIndex (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [index](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html) request
-   *
-   * @param {string} id - Document ID
-   * @param {string} index - The name of the index
-   * @param {string} type - The type of the document
-   * @param {string} wait_for_active_shards - Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-   * @param {enum} op_type - Explicit operation type
-   * @param {enum} refresh - If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
-   * @param {string} routing - Specific routing value
-   * @param {time} timeout - Explicit operation timeout
-   * @param {number} version - Explicit version number for concurrency control
-   * @param {enum} version_type - Specific version type
-   * @param {number} if_seq_no - only perform the index operation if the last operation that has changed the document has the specified sequence number
-   * @param {number} if_primary_term - only perform the index operation if the last operation that has changed the document has the specified primary term
-   * @param {string} pipeline - The pipeline id to preprocess incoming documents with
-   * @param {object} body - The document
-   */
 
   const acceptedQuerystring = [
     'wait_for_active_shards',
@@ -57,6 +39,11 @@ function buildIndex (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a index request
+   * Creates or updates a document in an index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html
+   */
   return function _index (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -89,10 +76,6 @@ function buildIndex (opts) {
     var { method, body, id, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -101,12 +84,16 @@ function buildIndex (opts) {
     var path = ''
 
     if ((index) != null && (type) != null && (id) != null) {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id)
     } else if ((index) != null && (id) != null) {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_doc' + '/' + encodeURIComponent(id)
     } else if ((index) != null && (type) != null) {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type)
     } else {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_doc'
     }
 

--- a/api/api/indices.analyze.js
+++ b/api/api/indices.analyze.js
@@ -10,13 +10,6 @@
 function buildIndicesAnalyze (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.analyze](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html) request
-   *
-   * @param {string} index - The name of the index to scope the operation
-   * @param {string} index - The name of the index to scope the operation
-   * @param {object} body - Define analyzer/tokenizer parameters and the text on which the analysis should be performed
-   */
 
   const acceptedQuerystring = [
     'index',
@@ -32,6 +25,11 @@ function buildIndicesAnalyze (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.analyze request
+   * Performs the analysis process on a text and return the tokens breakdown of the text.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html
+   */
   return function indicesAnalyze (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -54,10 +52,6 @@ function buildIndicesAnalyze (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -66,8 +60,10 @@ function buildIndicesAnalyze (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_analyze'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_analyze'
     }
 

--- a/api/api/indices.clear_cache.js
+++ b/api/api/indices.clear_cache.js
@@ -10,19 +10,6 @@
 function buildIndicesClearCache (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.clear_cache](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html) request
-   *
-   * @param {list} index - A comma-separated list of index name to limit the operation
-   * @param {boolean} fielddata - Clear field data
-   * @param {list} fields - A comma-separated list of fields to clear when using the `fielddata` parameter (default: all)
-   * @param {boolean} query - Clear query caches
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {list} index - A comma-separated list of index name to limit the operation
-   * @param {boolean} request - Clear request cache
-   */
 
   const acceptedQuerystring = [
     'fielddata',
@@ -48,6 +35,11 @@ function buildIndicesClearCache (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.clear_cache request
+   * Clears all or specific caches for one or more indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html
+   */
   return function indicesClearCache (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -60,12 +52,6 @@ function buildIndicesClearCache (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -76,10 +62,6 @@ function buildIndicesClearCache (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -88,8 +70,10 @@ function buildIndicesClearCache (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_cache' + '/' + 'clear'
     } else {
+      if (method == null) method = 'POST'
       path = '/' + '_cache' + '/' + 'clear'
     }
 
@@ -97,7 +81,7 @@ function buildIndicesClearCache (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.clone.js
+++ b/api/api/indices.clone.js
@@ -10,16 +10,6 @@
 function buildIndicesClone (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.clone](http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html) request
-   *
-   * @param {string} index - The name of the source index to clone
-   * @param {string} target - The name of the target index to clone into
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {string} wait_for_active_shards - Set the number of active shards to wait for on the cloned index before the operation returns.
-   * @param {object} body - The configuration for the target index (`settings` and `aliases`)
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -39,6 +29,11 @@ function buildIndicesClone (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.clone request
+   * Clones an index
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html
+   */
   return function indicesClone (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -77,10 +72,6 @@ function buildIndicesClone (opts) {
     var { method, body, index, target, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -88,6 +79,7 @@ function buildIndicesClone (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + encodeURIComponent(index) + '/' + '_clone' + '/' + encodeURIComponent(target)
 
     // build request object

--- a/api/api/indices.close.js
+++ b/api/api/indices.close.js
@@ -10,17 +10,6 @@
 function buildIndicesClose (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.close](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html) request
-   *
-   * @param {list} index - A comma separated list of indices to close
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {string} wait_for_active_shards - Sets the number of active shards to wait for before the operation returns.
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -46,6 +35,11 @@ function buildIndicesClose (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.close request
+   * Closes an index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html
+   */
   return function indicesClose (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -63,10 +57,6 @@ function buildIndicesClose (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -78,10 +68,6 @@ function buildIndicesClose (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -89,13 +75,14 @@ function buildIndicesClose (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_close'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.create.js
+++ b/api/api/indices.create.js
@@ -10,16 +10,6 @@
 function buildIndicesCreate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.create](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html) request
-   *
-   * @param {string} index - The name of the index
-   * @param {boolean} include_type_name - Whether a type should be expected in the body of the mappings.
-   * @param {string} wait_for_active_shards - Set the number of active shards to wait for before the operation returns.
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {object} body - The configuration for the index (`settings` and `mappings`)
-   */
 
   const acceptedQuerystring = [
     'include_type_name',
@@ -41,6 +31,11 @@ function buildIndicesCreate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.create request
+   * Creates an index with optional settings and mappings.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html
+   */
   return function indicesCreate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -69,10 +64,6 @@ function buildIndicesCreate (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -80,6 +71,7 @@ function buildIndicesCreate (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + encodeURIComponent(index)
 
     // build request object

--- a/api/api/indices.delete.js
+++ b/api/api/indices.delete.js
@@ -10,16 +10,6 @@
 function buildIndicesDelete (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.delete](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html) request
-   *
-   * @param {list} index - A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {boolean} ignore_unavailable - Ignore unavailable indexes (default: false)
-   * @param {boolean} allow_no_indices - Ignore if a wildcard expression resolves to no concrete indices (default: false)
-   * @param {enum} expand_wildcards - Whether wildcard expressions should get expanded to open or closed indices (default: open)
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -43,6 +33,11 @@ function buildIndicesDelete (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.delete request
+   * Deletes an index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html
+   */
   return function indicesDelete (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -60,10 +55,6 @@ function buildIndicesDelete (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -75,10 +66,6 @@ function buildIndicesDelete (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -86,13 +73,14 @@ function buildIndicesDelete (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + encodeURIComponent(index)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.delete_alias.js
+++ b/api/api/indices.delete_alias.js
@@ -10,14 +10,6 @@
 function buildIndicesDeleteAlias (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.delete_alias](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html) request
-   *
-   * @param {list} index - A comma-separated list of index names (supports wildcards); use `_all` for all indices
-   * @param {list} name - A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.
-   * @param {time} timeout - Explicit timestamp for the document
-   * @param {time} master_timeout - Specify timeout for connection to master
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -35,6 +27,11 @@ function buildIndicesDeleteAlias (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.delete_alias request
+   * Deletes an alias.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
+   */
   return function indicesDeleteAlias (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -56,10 +53,6 @@ function buildIndicesDeleteAlias (opts) {
       const err = new ConfigurationError('Missing required parameter: name')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // check required url components
     if (params['name'] != null && (params['index'] == null)) {
@@ -77,10 +70,6 @@ function buildIndicesDeleteAlias (opts) {
     var { method, body, index, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -89,16 +78,18 @@ function buildIndicesDeleteAlias (opts) {
     var path = ''
 
     if ((index) != null && (name) != null) {
-      path = '/' + encodeURIComponent(index) + '/' + '_alias' + '/' + encodeURIComponent(name)
-    } else {
+      if (method == null) method = 'DELETE'
       path = '/' + encodeURIComponent(index) + '/' + '_aliases' + '/' + encodeURIComponent(name)
+    } else {
+      if (method == null) method = 'DELETE'
+      path = '/' + encodeURIComponent(index) + '/' + '_alias' + '/' + encodeURIComponent(name)
     }
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.delete_template.js
+++ b/api/api/indices.delete_template.js
@@ -10,13 +10,6 @@
 function buildIndicesDeleteTemplate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.delete_template](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html) request
-   *
-   * @param {string} name - The name of the template
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -34,6 +27,11 @@ function buildIndicesDeleteTemplate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.delete_template request
+   * Deletes an index template.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
+   */
   return function indicesDeleteTemplate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -51,10 +49,6 @@ function buildIndicesDeleteTemplate (opts) {
       const err = new ConfigurationError('Missing required parameter: name')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -66,10 +60,6 @@ function buildIndicesDeleteTemplate (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -77,13 +67,14 @@ function buildIndicesDeleteTemplate (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_template' + '/' + encodeURIComponent(name)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.exists.js
+++ b/api/api/indices.exists.js
@@ -10,17 +10,6 @@
 function buildIndicesExists (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.exists](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html) request
-   *
-   * @param {list} index - A comma-separated list of index names
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {boolean} ignore_unavailable - Ignore unavailable indexes (default: false)
-   * @param {boolean} allow_no_indices - Ignore if a wildcard expression resolves to no concrete indices (default: false)
-   * @param {enum} expand_wildcards - Whether wildcard expressions should get expanded to open or closed indices (default: open)
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {boolean} include_defaults - Whether to return all default setting for each of the indices.
-   */
 
   const acceptedQuerystring = [
     'local',
@@ -46,6 +35,11 @@ function buildIndicesExists (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.exists request
+   * Returns information about whether a particular index exists.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html
+   */
   return function indicesExists (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -63,10 +57,6 @@ function buildIndicesExists (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -78,10 +68,6 @@ function buildIndicesExists (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'HEAD'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -89,6 +75,7 @@ function buildIndicesExists (opts) {
 
     var path = ''
 
+    if (method == null) method = 'HEAD'
     path = '/' + encodeURIComponent(index)
 
     // build request object

--- a/api/api/indices.exists_alias.js
+++ b/api/api/indices.exists_alias.js
@@ -10,16 +10,6 @@
 function buildIndicesExistsAlias (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.exists_alias](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to filter aliases
-   * @param {list} name - A comma-separated list of alias names to return
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -41,6 +31,11 @@ function buildIndicesExistsAlias (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.exists_alias request
+   * Returns information about whether a particular alias exists.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
+   */
   return function indicesExistsAlias (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,10 +53,6 @@ function buildIndicesExistsAlias (opts) {
       const err = new ConfigurationError('Missing required parameter: name')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -70,12 +61,8 @@ function buildIndicesExistsAlias (opts) {
     }
 
     var warnings = []
-    var { method, body, index, name, ...querystring } = params
+    var { method, body, name, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
-
-    if (method == null) {
-      method = 'HEAD'
-    }
 
     var ignore = options.ignore
     if (typeof ignore === 'number') {
@@ -85,8 +72,10 @@ function buildIndicesExistsAlias (opts) {
     var path = ''
 
     if ((index) != null && (name) != null) {
+      if (method == null) method = 'HEAD'
       path = '/' + encodeURIComponent(index) + '/' + '_alias' + '/' + encodeURIComponent(name)
     } else {
+      if (method == null) method = 'HEAD'
       path = '/' + '_alias' + '/' + encodeURIComponent(name)
     }
 

--- a/api/api/indices.exists_template.js
+++ b/api/api/indices.exists_template.js
@@ -10,14 +10,6 @@
 function buildIndicesExistsTemplate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.exists_template](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html) request
-   *
-   * @param {list} name - The comma separated names of the index templates
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   */
 
   const acceptedQuerystring = [
     'flat_settings',
@@ -37,6 +29,11 @@ function buildIndicesExistsTemplate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.exists_template request
+   * Returns information about whether a particular index template exists.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
+   */
   return function indicesExistsTemplate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -54,10 +51,6 @@ function buildIndicesExistsTemplate (opts) {
       const err = new ConfigurationError('Missing required parameter: name')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -69,10 +62,6 @@ function buildIndicesExistsTemplate (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'HEAD'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -80,6 +69,7 @@ function buildIndicesExistsTemplate (opts) {
 
     var path = ''
 
+    if (method == null) method = 'HEAD'
     path = '/' + '_template' + '/' + encodeURIComponent(name)
 
     // build request object

--- a/api/api/indices.exists_type.js
+++ b/api/api/indices.exists_type.js
@@ -10,16 +10,6 @@
 function buildIndicesExistsType (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.exists_type](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` to check the types across all indices
-   * @param {list} type - A comma-separated list of document types to check
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -41,6 +31,11 @@ function buildIndicesExistsType (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.exists_type request
+   * Returns information about whether a particular document type exists. (DEPRECATED)
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html
+   */
   return function indicesExistsType (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -62,10 +57,6 @@ function buildIndicesExistsType (opts) {
       const err = new ConfigurationError('Missing required parameter: type')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // check required url components
     if (params['type'] != null && (params['index'] == null)) {
@@ -83,10 +74,6 @@ function buildIndicesExistsType (opts) {
     var { method, body, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'HEAD'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -94,6 +81,7 @@ function buildIndicesExistsType (opts) {
 
     var path = ''
 
+    if (method == null) method = 'HEAD'
     path = '/' + encodeURIComponent(index) + '/' + '_mapping' + '/' + encodeURIComponent(type)
 
     // build request object

--- a/api/api/indices.flush.js
+++ b/api/api/indices.flush.js
@@ -10,16 +10,6 @@
 function buildIndicesFlush (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.flush](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string for all indices
-   * @param {boolean} force - Whether a flush should be forced even if it is not necessarily needed ie. if no changes will be committed to the index. This is useful if transaction log IDs should be incremented even if no uncommitted changes are present. (This setting can be considered as internal)
-   * @param {boolean} wait_if_ongoing - If set to true the flush operation will block until the flush can be executed if another flush operation is already executing. The default is true. If set to false the flush will be skipped iff if another flush operation is already running.
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   */
 
   const acceptedQuerystring = [
     'force',
@@ -43,6 +33,11 @@ function buildIndicesFlush (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.flush request
+   * Performs the flush operation on one or more indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
+   */
   return function indicesFlush (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -55,12 +50,6 @@ function buildIndicesFlush (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -71,10 +60,6 @@ function buildIndicesFlush (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -83,8 +68,10 @@ function buildIndicesFlush (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_flush'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_flush'
     }
 
@@ -92,7 +79,7 @@ function buildIndicesFlush (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.flush_synced.js
+++ b/api/api/indices.flush_synced.js
@@ -10,14 +10,6 @@
 function buildIndicesFlushSynced (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.flush_synced](http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html#synced-flush-api) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string for all indices
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -38,6 +30,11 @@ function buildIndicesFlushSynced (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.flush_synced request
+   * Performs a synced flush operation on one or more indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html#synced-flush-api
+   */
   return function indicesFlushSynced (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -50,12 +47,6 @@ function buildIndicesFlushSynced (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -66,10 +57,6 @@ function buildIndicesFlushSynced (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -78,8 +65,10 @@ function buildIndicesFlushSynced (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_flush' + '/' + 'synced'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_flush' + '/' + 'synced'
     }
 
@@ -87,7 +76,7 @@ function buildIndicesFlushSynced (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.forcemerge.js
+++ b/api/api/indices.forcemerge.js
@@ -10,17 +10,6 @@
 function buildIndicesForcemerge (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.forcemerge](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {boolean} flush - Specify whether the index should be flushed after performing the operation (default: true)
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {number} max_num_segments - The number of segments the index should be merged into (default: dynamic)
-   * @param {boolean} only_expunge_deletes - Specify whether the operation should only expunge deleted documents
-   */
 
   const acceptedQuerystring = [
     'flush',
@@ -46,6 +35,11 @@ function buildIndicesForcemerge (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.forcemerge request
+   * Performs the force merge operation on one or more indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html
+   */
   return function indicesForcemerge (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,12 +52,6 @@ function buildIndicesForcemerge (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -74,10 +62,6 @@ function buildIndicesForcemerge (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -86,8 +70,10 @@ function buildIndicesForcemerge (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_forcemerge'
     } else {
+      if (method == null) method = 'POST'
       path = '/' + '_forcemerge'
     }
 
@@ -95,7 +81,7 @@ function buildIndicesForcemerge (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.freeze.js
+++ b/api/api/indices.freeze.js
@@ -10,17 +10,6 @@
 function buildIndicesFreeze (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.freeze](https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html) request
-   *
-   * @param {string} index - The name of the index to freeze
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {string} wait_for_active_shards - Sets the number of active shards to wait for before the operation returns.
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -39,6 +28,10 @@ function buildIndicesFreeze (opts) {
     waitForActiveShards: 'wait_for_active_shards'
   }
 
+  /**
+   * Perform a indices.freeze request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html
+   */
   return function indicesFreeze (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -56,10 +49,6 @@ function buildIndicesFreeze (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -71,10 +60,6 @@ function buildIndicesFreeze (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -82,13 +67,14 @@ function buildIndicesFreeze (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_freeze'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.get.js
+++ b/api/api/indices.get.js
@@ -10,19 +10,6 @@
 function buildIndicesGet (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.get](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html) request
-   *
-   * @param {list} index - A comma-separated list of index names
-   * @param {boolean} include_type_name - Whether to add the type name to the response (default: false)
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {boolean} ignore_unavailable - Ignore unavailable indexes (default: false)
-   * @param {boolean} allow_no_indices - Ignore if a wildcard expression resolves to no concrete indices (default: false)
-   * @param {enum} expand_wildcards - Whether wildcard expressions should get expanded to open or closed indices (default: open)
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {boolean} include_defaults - Whether to return all default setting for each of the indices.
-   * @param {time} master_timeout - Specify timeout for connection to master
-   */
 
   const acceptedQuerystring = [
     'include_type_name',
@@ -52,6 +39,11 @@ function buildIndicesGet (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.get request
+   * Returns information about one or more indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html
+   */
   return function indicesGet (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -69,10 +61,6 @@ function buildIndicesGet (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -84,10 +72,6 @@ function buildIndicesGet (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -95,6 +79,7 @@ function buildIndicesGet (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + encodeURIComponent(index)
 
     // build request object

--- a/api/api/indices.get_alias.js
+++ b/api/api/indices.get_alias.js
@@ -10,16 +10,6 @@
 function buildIndicesGetAlias (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.get_alias](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to filter aliases
-   * @param {list} name - A comma-separated list of alias names to return
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -41,6 +31,11 @@ function buildIndicesGetAlias (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.get_alias request
+   * Returns an alias.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
+   */
   return function indicesGetAlias (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,12 +48,6 @@ function buildIndicesGetAlias (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -66,12 +55,8 @@ function buildIndicesGetAlias (opts) {
     }
 
     var warnings = []
-    var { method, body, index, name, ...querystring } = params
+    var { method, body, name, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
-
-    if (method == null) {
-      method = 'GET'
-    }
 
     var ignore = options.ignore
     if (typeof ignore === 'number') {
@@ -81,12 +66,16 @@ function buildIndicesGetAlias (opts) {
     var path = ''
 
     if ((index) != null && (name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_alias' + '/' + encodeURIComponent(name)
     } else if ((name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_alias' + '/' + encodeURIComponent(name)
     } else if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_alias'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_alias'
     }
 

--- a/api/api/indices.get_field_mapping.js
+++ b/api/api/indices.get_field_mapping.js
@@ -10,19 +10,6 @@
 function buildIndicesGetFieldMapping (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.get_field_mapping](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html) request
-   *
-   * @param {list} index - A comma-separated list of index names
-   * @param {list} type - A comma-separated list of document types
-   * @param {list} fields - A comma-separated list of fields
-   * @param {boolean} include_type_name - Whether a type should be returned in the body of the mappings.
-   * @param {boolean} include_defaults - Whether the default mapping values should be returned as well
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   */
 
   const acceptedQuerystring = [
     'include_type_name',
@@ -48,6 +35,11 @@ function buildIndicesGetFieldMapping (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.get_field_mapping request
+   * Returns mapping for one or more fields.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html
+   */
   return function indicesGetFieldMapping (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -65,10 +57,6 @@ function buildIndicesGetFieldMapping (opts) {
       const err = new ConfigurationError('Missing required parameter: fields')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -77,12 +65,8 @@ function buildIndicesGetFieldMapping (opts) {
     }
 
     var warnings = []
-    var { method, body, index, type, fields, ...querystring } = params
+    var { method, body, fields, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
-
-    if (method == null) {
-      method = 'GET'
-    }
 
     var ignore = options.ignore
     if (typeof ignore === 'number') {
@@ -92,12 +76,16 @@ function buildIndicesGetFieldMapping (opts) {
     var path = ''
 
     if ((index) != null && (type) != null && (fields) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_mapping' + '/' + encodeURIComponent(type) + '/' + 'field' + '/' + encodeURIComponent(fields)
     } else if ((index) != null && (fields) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_mapping' + '/' + 'field' + '/' + encodeURIComponent(fields)
     } else if ((type) != null && (fields) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_mapping' + '/' + encodeURIComponent(type) + '/' + 'field' + '/' + encodeURIComponent(fields)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_mapping' + '/' + 'field' + '/' + encodeURIComponent(fields)
     }
 

--- a/api/api/indices.get_mapping.js
+++ b/api/api/indices.get_mapping.js
@@ -10,18 +10,6 @@
 function buildIndicesGetMapping (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.get_mapping](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html) request
-   *
-   * @param {list} index - A comma-separated list of index names
-   * @param {list} type - A comma-separated list of document types
-   * @param {boolean} include_type_name - Whether to add the type name to the response (default: false)
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   */
 
   const acceptedQuerystring = [
     'include_type_name',
@@ -47,6 +35,11 @@ function buildIndicesGetMapping (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.get_mapping request
+   * Returns mappings for one or more indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html
+   */
   return function indicesGetMapping (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -59,12 +52,6 @@ function buildIndicesGetMapping (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -75,10 +62,6 @@ function buildIndicesGetMapping (opts) {
     var { method, body, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -87,12 +70,16 @@ function buildIndicesGetMapping (opts) {
     var path = ''
 
     if ((index) != null && (type) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_mapping' + '/' + encodeURIComponent(type)
     } else if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_mapping'
     } else if ((type) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_mapping' + '/' + encodeURIComponent(type)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_mapping'
     }
 

--- a/api/api/indices.get_settings.js
+++ b/api/api/indices.get_settings.js
@@ -10,19 +10,6 @@
 function buildIndicesGetSettings (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.get_settings](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {list} name - The name of the settings that should be included
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {boolean} include_defaults - Whether to return all default setting for each of the indices.
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -50,6 +37,11 @@ function buildIndicesGetSettings (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.get_settings request
+   * Returns settings for one or more indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html
+   */
   return function indicesGetSettings (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -62,12 +54,6 @@ function buildIndicesGetSettings (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -78,10 +64,6 @@ function buildIndicesGetSettings (opts) {
     var { method, body, index, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -90,12 +72,16 @@ function buildIndicesGetSettings (opts) {
     var path = ''
 
     if ((index) != null && (name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_settings' + '/' + encodeURIComponent(name)
     } else if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_settings'
     } else if ((name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_settings' + '/' + encodeURIComponent(name)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_settings'
     }
 

--- a/api/api/indices.get_template.js
+++ b/api/api/indices.get_template.js
@@ -10,15 +10,6 @@
 function buildIndicesGetTemplate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.get_template](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html) request
-   *
-   * @param {list} name - The comma separated names of the index templates
-   * @param {boolean} include_type_name - Whether a type should be returned in the body of the mappings.
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   */
 
   const acceptedQuerystring = [
     'include_type_name',
@@ -40,6 +31,11 @@ function buildIndicesGetTemplate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.get_template request
+   * Returns an index template.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
+   */
   return function indicesGetTemplate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,12 +48,6 @@ function buildIndicesGetTemplate (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -68,10 +58,6 @@ function buildIndicesGetTemplate (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -80,8 +66,10 @@ function buildIndicesGetTemplate (opts) {
     var path = ''
 
     if ((name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_template' + '/' + encodeURIComponent(name)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_template'
     }
 

--- a/api/api/indices.get_upgrade.js
+++ b/api/api/indices.get_upgrade.js
@@ -10,14 +10,6 @@
 function buildIndicesGetUpgrade (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.get_upgrade](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -38,6 +30,11 @@ function buildIndicesGetUpgrade (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.get_upgrade request
+   * The _upgrade API is no longer useful and will be removed.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html
+   */
   return function indicesGetUpgrade (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -50,12 +47,6 @@ function buildIndicesGetUpgrade (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -66,10 +57,6 @@ function buildIndicesGetUpgrade (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -78,8 +65,10 @@ function buildIndicesGetUpgrade (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_upgrade'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_upgrade'
     }
 

--- a/api/api/indices.open.js
+++ b/api/api/indices.open.js
@@ -10,17 +10,6 @@
 function buildIndicesOpen (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.open](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html) request
-   *
-   * @param {list} index - A comma separated list of indices to open
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {string} wait_for_active_shards - Sets the number of active shards to wait for before the operation returns.
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -46,6 +35,11 @@ function buildIndicesOpen (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.open request
+   * Opens an index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html
+   */
   return function indicesOpen (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -63,10 +57,6 @@ function buildIndicesOpen (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -78,10 +68,6 @@ function buildIndicesOpen (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -89,13 +75,14 @@ function buildIndicesOpen (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_open'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.put_alias.js
+++ b/api/api/indices.put_alias.js
@@ -10,15 +10,6 @@
 function buildIndicesPutAlias (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.put_alias](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html) request
-   *
-   * @param {list} index - A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.
-   * @param {string} name - The name of the alias to be created or updated
-   * @param {time} timeout - Explicit timestamp for the document
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {object} body - The settings for the alias, such as `routing` or `filter`
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -36,6 +27,11 @@ function buildIndicesPutAlias (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.put_alias request
+   * Creates or updates an alias.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
+   */
   return function indicesPutAlias (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -74,10 +70,6 @@ function buildIndicesPutAlias (opts) {
     var { method, body, index, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -86,9 +78,11 @@ function buildIndicesPutAlias (opts) {
     var path = ''
 
     if ((index) != null && (name) != null) {
-      path = '/' + encodeURIComponent(index) + '/' + '_alias' + '/' + encodeURIComponent(name)
-    } else {
+      if (method == null) method = 'PUT'
       path = '/' + encodeURIComponent(index) + '/' + '_aliases' + '/' + encodeURIComponent(name)
+    } else {
+      if (method == null) method = 'PUT'
+      path = '/' + encodeURIComponent(index) + '/' + '_alias' + '/' + encodeURIComponent(name)
     }
 
     // build request object

--- a/api/api/indices.put_mapping.js
+++ b/api/api/indices.put_mapping.js
@@ -10,19 +10,6 @@
 function buildIndicesPutMapping (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.put_mapping](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html) request
-   *
-   * @param {list} index - A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.
-   * @param {string} type - The name of the document type
-   * @param {boolean} include_type_name - Whether a type should be expected in the body of the mappings.
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {object} body - The mapping definition
-   */
 
   const acceptedQuerystring = [
     'include_type_name',
@@ -48,6 +35,11 @@ function buildIndicesPutMapping (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.put_mapping request
+   * Updates the index mappings.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html
+   */
   return function indicesPutMapping (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -76,10 +68,6 @@ function buildIndicesPutMapping (opts) {
     var { method, body, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -88,21 +76,29 @@ function buildIndicesPutMapping (opts) {
     var path = ''
 
     if ((index) != null && (type) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_mapping'
     } else if ((index) != null && (type) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + encodeURIComponent(index) + '/' + '_mapping' + '/' + encodeURIComponent(type)
     } else if ((index) != null && (type) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_mappings'
     } else if ((index) != null && (type) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + encodeURIComponent(index) + '/' + '_mappings' + '/' + encodeURIComponent(type)
-    } else if ((type) != null) {
-      path = '/' + '_mappings' + '/' + encodeURIComponent(type)
-    } else if ((type) != null) {
-      path = '/' + '_mapping' + '/' + encodeURIComponent(type)
     } else if ((index) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + encodeURIComponent(index) + '/' + '_mapping'
-    } else {
+    } else if ((type) != null) {
+      if (method == null) method = 'PUT'
+      path = '/' + '_mappings' + '/' + encodeURIComponent(type)
+    } else if ((index) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + encodeURIComponent(index) + '/' + '_mappings'
+    } else {
+      if (method == null) method = 'PUT'
+      path = '/' + '_mapping' + '/' + encodeURIComponent(type)
     }
 
     // build request object

--- a/api/api/indices.put_settings.js
+++ b/api/api/indices.put_settings.js
@@ -10,19 +10,6 @@
 function buildIndicesPutSettings (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.put_settings](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {time} timeout - Explicit operation timeout
-   * @param {boolean} preserve_existing - Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {object} body - The index settings to be updated
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -50,6 +37,11 @@ function buildIndicesPutSettings (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.put_settings request
+   * Updates the index settings.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html
+   */
   return function indicesPutSettings (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -78,10 +70,6 @@ function buildIndicesPutSettings (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -90,8 +78,10 @@ function buildIndicesPutSettings (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + encodeURIComponent(index) + '/' + '_settings'
     } else {
+      if (method == null) method = 'PUT'
       path = '/' + '_settings'
     }
 

--- a/api/api/indices.put_template.js
+++ b/api/api/indices.put_template.js
@@ -10,18 +10,6 @@
 function buildIndicesPutTemplate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.put_template](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html) request
-   *
-   * @param {string} name - The name of the template
-   * @param {boolean} include_type_name - Whether a type should be returned in the body of the mappings.
-   * @param {number} order - The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)
-   * @param {boolean} create - Whether the index template should only be added if new or can also replace an existing one
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {object} body - The template definition
-   */
 
   const acceptedQuerystring = [
     'include_type_name',
@@ -45,6 +33,11 @@ function buildIndicesPutTemplate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.put_template request
+   * Creates or updates an index template.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
+   */
   return function indicesPutTemplate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -77,10 +70,6 @@ function buildIndicesPutTemplate (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -88,6 +77,7 @@ function buildIndicesPutTemplate (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_template' + '/' + encodeURIComponent(name)
 
     // build request object

--- a/api/api/indices.recovery.js
+++ b/api/api/indices.recovery.js
@@ -10,13 +10,6 @@
 function buildIndicesRecovery (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.recovery](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {boolean} detailed - Whether to display detailed information about shard recovery
-   * @param {boolean} active_only - Display only those recoveries that are currently on-going
-   */
 
   const acceptedQuerystring = [
     'detailed',
@@ -34,6 +27,11 @@ function buildIndicesRecovery (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.recovery request
+   * Returns information about ongoing index shard recoveries.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html
+   */
   return function indicesRecovery (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,12 +44,6 @@ function buildIndicesRecovery (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -62,10 +54,6 @@ function buildIndicesRecovery (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -74,8 +62,10 @@ function buildIndicesRecovery (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_recovery'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_recovery'
     }
 

--- a/api/api/indices.refresh.js
+++ b/api/api/indices.refresh.js
@@ -10,14 +10,6 @@
 function buildIndicesRefresh (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.refresh](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -38,6 +30,11 @@ function buildIndicesRefresh (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.refresh request
+   * Performs the refresh operation in one or more indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html
+   */
   return function indicesRefresh (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -50,12 +47,6 @@ function buildIndicesRefresh (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -66,10 +57,6 @@ function buildIndicesRefresh (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -78,8 +65,10 @@ function buildIndicesRefresh (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_refresh'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_refresh'
     }
 
@@ -87,7 +76,7 @@ function buildIndicesRefresh (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.reload_search_analyzers.js
+++ b/api/api/indices.reload_search_analyzers.js
@@ -10,14 +10,6 @@
 function buildIndicesReloadSearchAnalyzers (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.reload_search_analyzers](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to reload analyzers for
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -31,6 +23,10 @@ function buildIndicesReloadSearchAnalyzers (opts) {
     expandWildcards: 'expand_wildcards'
   }
 
+  /**
+   * Perform a indices.reload_search_analyzers request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html
+   */
   return function indicesReloadSearchAnalyzers (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -44,8 +40,8 @@ function buildIndicesReloadSearchAnalyzers (opts) {
     }
 
     // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
+    if (params['index'] == null) {
+      const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
 
@@ -59,10 +55,6 @@ function buildIndicesReloadSearchAnalyzers (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -70,13 +62,14 @@ function buildIndicesReloadSearchAnalyzers (opts) {
 
     var path = ''
 
+    if (method == null) method = body == null ? 'GET' : 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_reload_search_analyzers'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.rollover.js
+++ b/api/api/indices.rollover.js
@@ -10,18 +10,6 @@
 function buildIndicesRollover (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.rollover](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html) request
-   *
-   * @param {string} alias - The name of the alias to rollover
-   * @param {string} new_index - The name of the rollover index
-   * @param {boolean} include_type_name - Whether a type should be included in the body of the mappings.
-   * @param {time} timeout - Explicit operation timeout
-   * @param {boolean} dry_run - If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {string} wait_for_active_shards - Set the number of active shards to wait for on the newly created rollover index before the operation returns.
-   * @param {object} body - The conditions that needs to be met for executing rollover
-   */
 
   const acceptedQuerystring = [
     'include_type_name',
@@ -45,6 +33,12 @@ function buildIndicesRollover (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.rollover request
+   * Updates an alias to point to a new index when the existing index
+is considered to be too large or too old.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html
+   */
   return function indicesRollover (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -79,10 +73,6 @@ function buildIndicesRollover (opts) {
     var { method, body, alias, newIndex, new_index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -91,8 +81,10 @@ function buildIndicesRollover (opts) {
     var path = ''
 
     if ((alias) != null && (new_index || newIndex) != null) {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(alias) + '/' + '_rollover' + '/' + encodeURIComponent(new_index || newIndex)
     } else {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(alias) + '/' + '_rollover'
     }
 

--- a/api/api/indices.segments.js
+++ b/api/api/indices.segments.js
@@ -10,15 +10,6 @@
 function buildIndicesSegments (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.segments](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} verbose - Includes detailed memory usage by Lucene.
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -40,6 +31,11 @@ function buildIndicesSegments (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.segments request
+   * Provides low-level information about segments in a Lucene index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html
+   */
   return function indicesSegments (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,12 +48,6 @@ function buildIndicesSegments (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -68,10 +58,6 @@ function buildIndicesSegments (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -80,8 +66,10 @@ function buildIndicesSegments (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_segments'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_segments'
     }
 

--- a/api/api/indices.shard_stores.js
+++ b/api/api/indices.shard_stores.js
@@ -10,15 +10,6 @@
 function buildIndicesShardStores (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.shard_stores](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {list} status - A comma-separated list of statuses used to filter on shards to get store information for
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   */
 
   const acceptedQuerystring = [
     'status',
@@ -40,6 +31,11 @@ function buildIndicesShardStores (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.shard_stores request
+   * Provides store information for shard copies of indices.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html
+   */
   return function indicesShardStores (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,12 +48,6 @@ function buildIndicesShardStores (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -68,10 +58,6 @@ function buildIndicesShardStores (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -80,8 +66,10 @@ function buildIndicesShardStores (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_shard_stores'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_shard_stores'
     }
 

--- a/api/api/indices.shrink.js
+++ b/api/api/indices.shrink.js
@@ -10,16 +10,6 @@
 function buildIndicesShrink (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.shrink](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html) request
-   *
-   * @param {string} index - The name of the source index to shrink
-   * @param {string} target - The name of the target index to shrink into
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {string} wait_for_active_shards - Set the number of active shards to wait for on the shrunken index before the operation returns.
-   * @param {object} body - The configuration for the target index (`settings` and `aliases`)
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -39,6 +29,11 @@ function buildIndicesShrink (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.shrink request
+   * Allow to shrink an existing index into a new index with fewer primary shards.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html
+   */
   return function indicesShrink (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -77,10 +72,6 @@ function buildIndicesShrink (opts) {
     var { method, body, index, target, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -88,6 +79,7 @@ function buildIndicesShrink (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + encodeURIComponent(index) + '/' + '_shrink' + '/' + encodeURIComponent(target)
 
     // build request object

--- a/api/api/indices.split.js
+++ b/api/api/indices.split.js
@@ -10,16 +10,6 @@
 function buildIndicesSplit (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.split](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html) request
-   *
-   * @param {string} index - The name of the source index to split
-   * @param {string} target - The name of the target index to split into
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {string} wait_for_active_shards - Set the number of active shards to wait for on the shrunken index before the operation returns.
-   * @param {object} body - The configuration for the target index (`settings` and `aliases`)
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -39,6 +29,11 @@ function buildIndicesSplit (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.split request
+   * Allows you to split an existing index into a new index with more primary shards.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html
+   */
   return function indicesSplit (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -77,10 +72,6 @@ function buildIndicesSplit (opts) {
     var { method, body, index, target, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -88,6 +79,7 @@ function buildIndicesSplit (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + encodeURIComponent(index) + '/' + '_split' + '/' + encodeURIComponent(target)
 
     // build request object

--- a/api/api/indices.stats.js
+++ b/api/api/indices.stats.js
@@ -10,22 +10,6 @@
 function buildIndicesStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.stats](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {list} metric - Limit the information returned the specific metrics.
-   * @param {list} completion_fields - A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)
-   * @param {list} fielddata_fields - A comma-separated list of fields for `fielddata` index metric (supports wildcards)
-   * @param {list} fields - A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)
-   * @param {list} groups - A comma-separated list of search groups for `search` index metric
-   * @param {enum} level - Return stats aggregated at cluster, index or shard level
-   * @param {list} types - A comma-separated list of document types for the `indexing` index metric
-   * @param {boolean} include_segment_file_sizes - Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)
-   * @param {boolean} include_unloaded_segments - If set to true segment stats will include stats for segments that are not currently loaded into memory
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} forbid_closed_indices - If set to false stats will also collected from closed indices if explicitly specified or if expand_wildcards expands to closed indices
-   */
 
   const acceptedQuerystring = [
     'completion_fields',
@@ -56,6 +40,11 @@ function buildIndicesStats (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.stats request
+   * Provides statistics on operations happening in an index.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html
+   */
   return function indicesStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -68,12 +57,6 @@ function buildIndicesStats (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -81,12 +64,8 @@ function buildIndicesStats (opts) {
     }
 
     var warnings = []
-    var { method, body, index, metric, ...querystring } = params
+    var { method, body, metric, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
-
-    if (method == null) {
-      method = 'GET'
-    }
 
     var ignore = options.ignore
     if (typeof ignore === 'number') {
@@ -96,12 +75,16 @@ function buildIndicesStats (opts) {
     var path = ''
 
     if ((index) != null && (metric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_stats' + '/' + encodeURIComponent(metric)
     } else if ((metric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_stats' + '/' + encodeURIComponent(metric)
     } else if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_stats'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_stats'
     }
 

--- a/api/api/indices.unfreeze.js
+++ b/api/api/indices.unfreeze.js
@@ -10,17 +10,6 @@
 function buildIndicesUnfreeze (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.unfreeze](https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html) request
-   *
-   * @param {string} index - The name of the index to unfreeze
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {string} wait_for_active_shards - Sets the number of active shards to wait for before the operation returns.
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -39,6 +28,10 @@ function buildIndicesUnfreeze (opts) {
     waitForActiveShards: 'wait_for_active_shards'
   }
 
+  /**
+   * Perform a indices.unfreeze request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html
+   */
   return function indicesUnfreeze (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -56,10 +49,6 @@ function buildIndicesUnfreeze (opts) {
       const err = new ConfigurationError('Missing required parameter: index')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -71,10 +60,6 @@ function buildIndicesUnfreeze (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -82,13 +67,14 @@ function buildIndicesUnfreeze (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_unfreeze'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.update_aliases.js
+++ b/api/api/indices.update_aliases.js
@@ -10,13 +10,6 @@
 function buildIndicesUpdateAliases (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.update_aliases](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html) request
-   *
-   * @param {time} timeout - Request timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {object} body - The definition of `actions` to perform
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -34,6 +27,11 @@ function buildIndicesUpdateAliases (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.update_aliases request
+   * Updates index aliases.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
+   */
   return function indicesUpdateAliases (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -62,10 +60,6 @@ function buildIndicesUpdateAliases (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -73,6 +67,7 @@ function buildIndicesUpdateAliases (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_aliases'
 
     // build request object

--- a/api/api/indices.upgrade.js
+++ b/api/api/indices.upgrade.js
@@ -10,16 +10,6 @@
 function buildIndicesUpgrade (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.upgrade](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html) request
-   *
-   * @param {list} index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} wait_for_completion - Specify whether the request should block until the all segments are upgraded (default: false)
-   * @param {boolean} only_ancient_segments - If true, only ancient (an older Lucene major release) segments will be upgraded
-   */
 
   const acceptedQuerystring = [
     'allow_no_indices',
@@ -44,6 +34,11 @@ function buildIndicesUpgrade (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.upgrade request
+   * The _upgrade API is no longer useful and will be removed.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html
+   */
   return function indicesUpgrade (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -56,12 +51,6 @@ function buildIndicesUpgrade (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -72,10 +61,6 @@ function buildIndicesUpgrade (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -84,8 +69,10 @@ function buildIndicesUpgrade (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_upgrade'
     } else {
+      if (method == null) method = 'POST'
       path = '/' + '_upgrade'
     }
 
@@ -93,7 +80,7 @@ function buildIndicesUpgrade (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/indices.validate_query.js
+++ b/api/api/indices.validate_query.js
@@ -10,25 +10,6 @@
 function buildIndicesValidateQuery (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [indices.validate_query](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices
-   * @param {list} type - A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types
-   * @param {boolean} explain - Return detailed information about the error
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {string} q - Query in the Lucene query string syntax
-   * @param {string} analyzer - The analyzer to use for the query string
-   * @param {boolean} analyze_wildcard - Specify whether wildcard and prefix queries should be analyzed (default: false)
-   * @param {enum} default_operator - The default operator for query string query (AND or OR)
-   * @param {string} df - The field to use as default where no field prefix is given in the query string
-   * @param {boolean} lenient - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-   * @param {boolean} rewrite - Provide a more detailed explanation showing the actual Lucene query that will be executed.
-   * @param {boolean} all_shards - Execute validation on all shards instead of one random shard per index
-   * @param {object} body - The query definition specified with the Query DSL
-   */
 
   const acceptedQuerystring = [
     'explain',
@@ -61,6 +42,11 @@ function buildIndicesValidateQuery (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a indices.validate_query request
+   * Allows a user to validate a potentially expensive query without executing it.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html
+   */
   return function indicesValidateQuery (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -89,10 +75,6 @@ function buildIndicesValidateQuery (opts) {
     var { method, body, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -101,10 +83,13 @@ function buildIndicesValidateQuery (opts) {
     var path = ''
 
     if ((index) != null && (type) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_validate' + '/' + 'query'
     } else if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_validate' + '/' + 'query'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_validate' + '/' + 'query'
     }
 

--- a/api/api/info.js
+++ b/api/api/info.js
@@ -10,10 +10,6 @@
 function buildInfo (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [info](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html) request
-   *
-   */
 
   const acceptedQuerystring = [
     'pretty',
@@ -28,6 +24,11 @@ function buildInfo (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a info request
+   * Returns basic information about the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+   */
   return function info (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -40,12 +41,6 @@ function buildInfo (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -56,10 +51,6 @@ function buildInfo (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,6 +58,7 @@ function buildInfo (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/'
 
     // build request object

--- a/api/api/ingest.delete_pipeline.js
+++ b/api/api/ingest.delete_pipeline.js
@@ -10,13 +10,6 @@
 function buildIngestDeletePipeline (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ingest.delete_pipeline](https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html) request
-   *
-   * @param {string} id - Pipeline ID
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {time} timeout - Explicit operation timeout
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -34,6 +27,11 @@ function buildIngestDeletePipeline (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a ingest.delete_pipeline request
+   * Deletes a pipeline.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html
+   */
   return function ingestDeletePipeline (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -51,10 +49,6 @@ function buildIngestDeletePipeline (opts) {
       const err = new ConfigurationError('Missing required parameter: id')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -66,10 +60,6 @@ function buildIngestDeletePipeline (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -77,13 +67,14 @@ function buildIngestDeletePipeline (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ingest' + '/' + 'pipeline' + '/' + encodeURIComponent(id)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ingest.get_pipeline.js
+++ b/api/api/ingest.get_pipeline.js
@@ -10,12 +10,6 @@
 function buildIngestGetPipeline (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ingest.get_pipeline](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html) request
-   *
-   * @param {string} id - Comma separated list of pipeline ids. Wildcards supported
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -32,6 +26,11 @@ function buildIngestGetPipeline (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a ingest.get_pipeline request
+   * Returns a pipeline.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html
+   */
   return function ingestGetPipeline (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -44,12 +43,6 @@ function buildIngestGetPipeline (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -60,10 +53,6 @@ function buildIngestGetPipeline (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -72,8 +61,10 @@ function buildIngestGetPipeline (opts) {
     var path = ''
 
     if ((id) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_ingest' + '/' + 'pipeline' + '/' + encodeURIComponent(id)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_ingest' + '/' + 'pipeline'
     }
 

--- a/api/api/ingest.processor_grok.js
+++ b/api/api/ingest.processor_grok.js
@@ -10,10 +10,6 @@
 function buildIngestProcessorGrok (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ingest.processor_grok](https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get) request
-   *
-   */
 
   const acceptedQuerystring = [
     'pretty',
@@ -28,6 +24,11 @@ function buildIngestProcessorGrok (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a ingest.processor_grok request
+   * Returns a list of the built-in patterns.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get
+   */
   return function ingestProcessorGrok (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -40,12 +41,6 @@ function buildIngestProcessorGrok (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -56,10 +51,6 @@ function buildIngestProcessorGrok (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,6 +58,7 @@ function buildIngestProcessorGrok (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_ingest' + '/' + 'processor' + '/' + 'grok'
 
     // build request object

--- a/api/api/ingest.put_pipeline.js
+++ b/api/api/ingest.put_pipeline.js
@@ -10,14 +10,6 @@
 function buildIngestPutPipeline (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ingest.put_pipeline](https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html) request
-   *
-   * @param {string} id - Pipeline ID
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {time} timeout - Explicit operation timeout
-   * @param {object} body - The ingest definition
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -35,6 +27,11 @@ function buildIngestPutPipeline (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a ingest.put_pipeline request
+   * Creates or updates a pipeline.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html
+   */
   return function ingestPutPipeline (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -67,10 +64,6 @@ function buildIngestPutPipeline (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -78,6 +71,7 @@ function buildIngestPutPipeline (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_ingest' + '/' + 'pipeline' + '/' + encodeURIComponent(id)
 
     // build request object

--- a/api/api/ingest.simulate.js
+++ b/api/api/ingest.simulate.js
@@ -10,13 +10,6 @@
 function buildIngestSimulate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ingest.simulate](https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html) request
-   *
-   * @param {string} id - Pipeline ID
-   * @param {boolean} verbose - Verbose mode. Display data output for each processor in executed pipeline
-   * @param {object} body - The simulate definition
-   */
 
   const acceptedQuerystring = [
     'verbose',
@@ -32,6 +25,11 @@ function buildIngestSimulate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a ingest.simulate request
+   * Allows to simulate a pipeline with example documents.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html
+   */
   return function ingestSimulate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -60,10 +58,6 @@ function buildIngestSimulate (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -72,8 +66,10 @@ function buildIngestSimulate (opts) {
     var path = ''
 
     if ((id) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_ingest' + '/' + 'pipeline' + '/' + encodeURIComponent(id) + '/' + '_simulate'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_ingest' + '/' + 'pipeline' + '/' + '_simulate'
     }
 

--- a/api/api/license.delete.js
+++ b/api/api/license.delete.js
@@ -10,10 +10,6 @@
 function buildLicenseDelete (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [license.delete](https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildLicenseDelete (opts) {
 
   }
 
+  /**
+   * Perform a license.delete request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html
+   */
   return function licenseDelete (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildLicenseDelete (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildLicenseDelete (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,13 +52,14 @@ function buildLicenseDelete (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_license'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/license.get.js
+++ b/api/api/license.get.js
@@ -10,11 +10,6 @@
 function buildLicenseGet (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [license.get](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html) request
-   *
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   */
 
   const acceptedQuerystring = [
     'local'
@@ -24,6 +19,10 @@ function buildLicenseGet (opts) {
 
   }
 
+  /**
+   * Perform a license.get request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html
+   */
   return function licenseGet (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,12 +35,6 @@ function buildLicenseGet (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -52,10 +45,6 @@ function buildLicenseGet (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +52,7 @@ function buildLicenseGet (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_license'
 
     // build request object

--- a/api/api/license.get_basic_status.js
+++ b/api/api/license.get_basic_status.js
@@ -10,10 +10,6 @@
 function buildLicenseGetBasicStatus (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [license.get_basic_status](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildLicenseGetBasicStatus (opts) {
 
   }
 
+  /**
+   * Perform a license.get_basic_status request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html
+   */
   return function licenseGetBasicStatus (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildLicenseGetBasicStatus (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildLicenseGetBasicStatus (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,6 +52,7 @@ function buildLicenseGetBasicStatus (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_license' + '/' + 'basic_status'
 
     // build request object

--- a/api/api/license.get_trial_status.js
+++ b/api/api/license.get_trial_status.js
@@ -10,10 +10,6 @@
 function buildLicenseGetTrialStatus (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [license.get_trial_status](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildLicenseGetTrialStatus (opts) {
 
   }
 
+  /**
+   * Perform a license.get_trial_status request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html
+   */
   return function licenseGetTrialStatus (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildLicenseGetTrialStatus (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildLicenseGetTrialStatus (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,6 +52,7 @@ function buildLicenseGetTrialStatus (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_license' + '/' + 'trial_status'
 
     // build request object

--- a/api/api/license.post.js
+++ b/api/api/license.post.js
@@ -10,12 +10,6 @@
 function buildLicensePost (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [license.post](https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html) request
-   *
-   * @param {boolean} acknowledge - whether the user has acknowledged acknowledge messages (default: false)
-   * @param {object} body - licenses to be installed
-   */
 
   const acceptedQuerystring = [
     'acknowledge'
@@ -25,6 +19,10 @@ function buildLicensePost (opts) {
 
   }
 
+  /**
+   * Perform a license.post request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html
+   */
   return function licensePost (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -47,10 +45,6 @@ function buildLicensePost (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -58,6 +52,7 @@ function buildLicensePost (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_license'
 
     // build request object

--- a/api/api/license.post_start_basic.js
+++ b/api/api/license.post_start_basic.js
@@ -10,11 +10,6 @@
 function buildLicensePostStartBasic (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [license.post_start_basic](https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html) request
-   *
-   * @param {boolean} acknowledge - whether the user has acknowledged acknowledge messages (default: false)
-   */
 
   const acceptedQuerystring = [
     'acknowledge'
@@ -24,6 +19,10 @@ function buildLicensePostStartBasic (opts) {
 
   }
 
+  /**
+   * Perform a license.post_start_basic request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html
+   */
   return function licensePostStartBasic (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,12 +35,6 @@ function buildLicensePostStartBasic (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -52,10 +45,6 @@ function buildLicensePostStartBasic (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,13 +52,14 @@ function buildLicensePostStartBasic (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_license' + '/' + 'start_basic'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/license.post_start_trial.js
+++ b/api/api/license.post_start_trial.js
@@ -10,12 +10,6 @@
 function buildLicensePostStartTrial (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [license.post_start_trial](https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html) request
-   *
-   * @param {string} type - The type of trial license to generate (default: "trial")
-   * @param {boolean} acknowledge - whether the user has acknowledged acknowledge messages (default: false)
-   */
 
   const acceptedQuerystring = [
     'type',
@@ -26,6 +20,10 @@ function buildLicensePostStartTrial (opts) {
 
   }
 
+  /**
+   * Perform a license.post_start_trial request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html
+   */
   return function licensePostStartTrial (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -38,12 +36,6 @@ function buildLicensePostStartTrial (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -54,10 +46,6 @@ function buildLicensePostStartTrial (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -65,13 +53,14 @@ function buildLicensePostStartTrial (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_license' + '/' + 'start_trial'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/mget.js
+++ b/api/api/mget.js
@@ -10,21 +10,6 @@
 function buildMget (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [mget](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html) request
-   *
-   * @param {string} index - The name of the index
-   * @param {string} type - The type of the document
-   * @param {list} stored_fields - A comma-separated list of stored fields to return in the response
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {boolean} realtime - Specify whether to perform the operation in realtime or search mode
-   * @param {boolean} refresh - Refresh the shard containing the document before performing the operation
-   * @param {string} routing - Specific routing value
-   * @param {list} _source - True or false to return the _source field or not, or a list of fields to return
-   * @param {list} _source_excludes - A list of fields to exclude from the returned _source field
-   * @param {list} _source_includes - A list of fields to extract and return from the _source field
-   * @param {object} body - Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.
-   */
 
   const acceptedQuerystring = [
     'stored_fields',
@@ -54,6 +39,11 @@ function buildMget (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a mget request
+   * Allows to get multiple documents in one request.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html
+   */
   return function mget (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -88,10 +78,6 @@ function buildMget (opts) {
     var { method, body, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -100,10 +86,13 @@ function buildMget (opts) {
     var path = ''
 
     if ((index) != null && (type) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_mget'
     } else if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_mget'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_mget'
     }
 

--- a/api/api/migration.deprecations.js
+++ b/api/api/migration.deprecations.js
@@ -10,11 +10,6 @@
 function buildMigrationDeprecations (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [migration.deprecations](http://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-deprecation.html) request
-   *
-   * @param {string} index - Index pattern
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildMigrationDeprecations (opts) {
 
   }
 
+  /**
+   * Perform a migration.deprecations request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-deprecation.html
+   */
   return function migrationDeprecations (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,12 +35,6 @@ function buildMigrationDeprecations (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -52,10 +45,6 @@ function buildMigrationDeprecations (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,8 +53,10 @@ function buildMigrationDeprecations (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = 'GET'
       path = '/' + encodeURIComponent(index) + '/' + '_migration' + '/' + 'deprecations'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_migration' + '/' + 'deprecations'
     }
 

--- a/api/api/ml.close_job.js
+++ b/api/api/ml.close_job.js
@@ -10,15 +10,6 @@
 function buildMlCloseJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.close_job](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html) request
-   *
-   * @param {string} job_id - The name of the job to close
-   * @param {boolean} allow_no_jobs - Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
-   * @param {boolean} force - True if the job should be forcefully closed
-   * @param {time} timeout - Controls the time to wait until a job has closed. Default to 30 minutes
-   * @param {object} body - The URL params optionally sent in the body
-   */
 
   const acceptedQuerystring = [
     'allow_no_jobs',
@@ -31,6 +22,10 @@ function buildMlCloseJob (opts) {
 
   }
 
+  /**
+   * Perform a ml.close_job request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html
+   */
   return function mlCloseJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -59,10 +54,6 @@ function buildMlCloseJob (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -70,6 +61,7 @@ function buildMlCloseJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + '_close'
 
     // build request object

--- a/api/api/ml.delete_calendar.js
+++ b/api/api/ml.delete_calendar.js
@@ -10,11 +10,6 @@
 function buildMlDeleteCalendar (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.delete_calendar](undefined) request
-   *
-   * @param {string} calendar_id - The ID of the calendar to delete
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,9 @@ function buildMlDeleteCalendar (opts) {
 
   }
 
+  /**
+   * Perform a ml.delete_calendar request
+   */
   return function mlDeleteCalendar (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,10 +39,6 @@ function buildMlDeleteCalendar (opts) {
       const err = new ConfigurationError('Missing required parameter: calendar_id or calendarId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -56,10 +50,6 @@ function buildMlDeleteCalendar (opts) {
     var { method, body, calendarId, calendar_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,13 +57,14 @@ function buildMlDeleteCalendar (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ml' + '/' + 'calendars' + '/' + encodeURIComponent(calendar_id || calendarId)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.delete_calendar_event.js
+++ b/api/api/ml.delete_calendar_event.js
@@ -10,12 +10,6 @@
 function buildMlDeleteCalendarEvent (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.delete_calendar_event](undefined) request
-   *
-   * @param {string} calendar_id - The ID of the calendar to modify
-   * @param {string} event_id - The ID of the event to remove from the calendar
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,9 @@ function buildMlDeleteCalendarEvent (opts) {
 
   }
 
+  /**
+   * Perform a ml.delete_calendar_event request
+   */
   return function mlDeleteCalendarEvent (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,10 +43,6 @@ function buildMlDeleteCalendarEvent (opts) {
       const err = new ConfigurationError('Missing required parameter: event_id or eventId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // check required url components
     if ((params['event_id'] != null || params['eventId'] != null) && ((params['calendar_id'] == null && params['calendarId'] == null))) {
@@ -67,10 +60,6 @@ function buildMlDeleteCalendarEvent (opts) {
     var { method, body, calendarId, calendar_id, eventId, event_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -78,13 +67,14 @@ function buildMlDeleteCalendarEvent (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ml' + '/' + 'calendars' + '/' + encodeURIComponent(calendar_id || calendarId) + '/' + 'events' + '/' + encodeURIComponent(event_id || eventId)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.delete_calendar_job.js
+++ b/api/api/ml.delete_calendar_job.js
@@ -10,12 +10,6 @@
 function buildMlDeleteCalendarJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.delete_calendar_job](undefined) request
-   *
-   * @param {string} calendar_id - The ID of the calendar to modify
-   * @param {string} job_id - The ID of the job to remove from the calendar
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,9 @@ function buildMlDeleteCalendarJob (opts) {
 
   }
 
+  /**
+   * Perform a ml.delete_calendar_job request
+   */
   return function mlDeleteCalendarJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,10 +43,6 @@ function buildMlDeleteCalendarJob (opts) {
       const err = new ConfigurationError('Missing required parameter: job_id or jobId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // check required url components
     if ((params['job_id'] != null || params['jobId'] != null) && ((params['calendar_id'] == null && params['calendarId'] == null))) {
@@ -67,10 +60,6 @@ function buildMlDeleteCalendarJob (opts) {
     var { method, body, calendarId, calendar_id, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -78,13 +67,14 @@ function buildMlDeleteCalendarJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ml' + '/' + 'calendars' + '/' + encodeURIComponent(calendar_id || calendarId) + '/' + 'jobs' + '/' + encodeURIComponent(job_id || jobId)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.delete_data_frame_analytics.js
+++ b/api/api/ml.delete_data_frame_analytics.js
@@ -10,11 +10,6 @@
 function buildMlDeleteDataFrameAnalytics (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.delete_data_frame_analytics](http://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html) request
-   *
-   * @param {string} id - The ID of the data frame analytics to delete
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildMlDeleteDataFrameAnalytics (opts) {
 
   }
 
+  /**
+   * Perform a ml.delete_data_frame_analytics request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html
+   */
   return function mlDeleteDataFrameAnalytics (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,10 +40,6 @@ function buildMlDeleteDataFrameAnalytics (opts) {
       const err = new ConfigurationError('Missing required parameter: id')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -56,10 +51,6 @@ function buildMlDeleteDataFrameAnalytics (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,13 +58,14 @@ function buildMlDeleteDataFrameAnalytics (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ml' + '/' + 'data_frame' + '/' + 'analytics' + '/' + encodeURIComponent(id)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.delete_datafeed.js
+++ b/api/api/ml.delete_datafeed.js
@@ -10,12 +10,6 @@
 function buildMlDeleteDatafeed (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.delete_datafeed](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html) request
-   *
-   * @param {string} datafeed_id - The ID of the datafeed to delete
-   * @param {boolean} force - True if the datafeed should be forcefully deleted
-   */
 
   const acceptedQuerystring = [
     'force'
@@ -25,6 +19,10 @@ function buildMlDeleteDatafeed (opts) {
 
   }
 
+  /**
+   * Perform a ml.delete_datafeed request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html
+   */
   return function mlDeleteDatafeed (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,10 +40,6 @@ function buildMlDeleteDatafeed (opts) {
       const err = new ConfigurationError('Missing required parameter: datafeed_id or datafeedId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -57,10 +51,6 @@ function buildMlDeleteDatafeed (opts) {
     var { method, body, datafeedId, datafeed_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,13 +58,14 @@ function buildMlDeleteDatafeed (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ml' + '/' + 'datafeeds' + '/' + encodeURIComponent(datafeed_id || datafeedId)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.delete_expired_data.js
+++ b/api/api/ml.delete_expired_data.js
@@ -10,10 +10,6 @@
 function buildMlDeleteExpiredData (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.delete_expired_data](undefined) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,9 @@ function buildMlDeleteExpiredData (opts) {
 
   }
 
+  /**
+   * Perform a ml.delete_expired_data request
+   */
   return function mlDeleteExpiredData (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +34,6 @@ function buildMlDeleteExpiredData (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +44,6 @@ function buildMlDeleteExpiredData (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,13 +51,14 @@ function buildMlDeleteExpiredData (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ml' + '/' + '_delete_expired_data'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.delete_filter.js
+++ b/api/api/ml.delete_filter.js
@@ -10,11 +10,6 @@
 function buildMlDeleteFilter (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.delete_filter](undefined) request
-   *
-   * @param {string} filter_id - The ID of the filter to delete
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,9 @@ function buildMlDeleteFilter (opts) {
 
   }
 
+  /**
+   * Perform a ml.delete_filter request
+   */
   return function mlDeleteFilter (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,10 +39,6 @@ function buildMlDeleteFilter (opts) {
       const err = new ConfigurationError('Missing required parameter: filter_id or filterId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -56,10 +50,6 @@ function buildMlDeleteFilter (opts) {
     var { method, body, filterId, filter_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,13 +57,14 @@ function buildMlDeleteFilter (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ml' + '/' + 'filters' + '/' + encodeURIComponent(filter_id || filterId)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.delete_forecast.js
+++ b/api/api/ml.delete_forecast.js
@@ -10,14 +10,6 @@
 function buildMlDeleteForecast (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.delete_forecast](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html) request
-   *
-   * @param {string} job_id - The ID of the job from which to delete forecasts
-   * @param {string} forecast_id - The ID of the forecast to delete, can be comma delimited list. Leaving blank implies `_all`
-   * @param {boolean} allow_no_forecasts - Whether to ignore if `_all` matches no forecasts
-   * @param {time} timeout - Controls the time to wait until the forecast(s) are deleted. Default to 30 seconds
-   */
 
   const acceptedQuerystring = [
     'allow_no_forecasts',
@@ -29,6 +21,10 @@ function buildMlDeleteForecast (opts) {
 
   }
 
+  /**
+   * Perform a ml.delete_forecast request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html
+   */
   return function mlDeleteForecast (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -44,10 +40,6 @@ function buildMlDeleteForecast (opts) {
     // check required parameters
     if (params['job_id'] == null && params['jobId'] == null) {
       const err = new ConfigurationError('Missing required parameter: job_id or jobId')
-      return handleError(err, callback)
-    }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
       return handleError(err, callback)
     }
 
@@ -67,10 +59,6 @@ function buildMlDeleteForecast (opts) {
     var { method, body, jobId, job_id, forecastId, forecast_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -79,8 +67,10 @@ function buildMlDeleteForecast (opts) {
     var path = ''
 
     if ((job_id || jobId) != null && (forecast_id || forecastId) != null) {
+      if (method == null) method = 'DELETE'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + '_forecast' + '/' + encodeURIComponent(forecast_id || forecastId)
     } else {
+      if (method == null) method = 'DELETE'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + '_forecast'
     }
 
@@ -88,7 +78,7 @@ function buildMlDeleteForecast (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.delete_job.js
+++ b/api/api/ml.delete_job.js
@@ -10,13 +10,6 @@
 function buildMlDeleteJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.delete_job](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html) request
-   *
-   * @param {string} job_id - The ID of the job to delete
-   * @param {boolean} force - True if the job should be forcefully deleted
-   * @param {boolean} wait_for_completion - Should this request wait until the operation has completed before returning
-   */
 
   const acceptedQuerystring = [
     'force',
@@ -27,6 +20,10 @@ function buildMlDeleteJob (opts) {
     waitForCompletion: 'wait_for_completion'
   }
 
+  /**
+   * Perform a ml.delete_job request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html
+   */
   return function mlDeleteJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -44,10 +41,6 @@ function buildMlDeleteJob (opts) {
       const err = new ConfigurationError('Missing required parameter: job_id or jobId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -59,10 +52,6 @@ function buildMlDeleteJob (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -70,13 +59,14 @@ function buildMlDeleteJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.delete_model_snapshot.js
+++ b/api/api/ml.delete_model_snapshot.js
@@ -10,12 +10,6 @@
 function buildMlDeleteModelSnapshot (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.delete_model_snapshot](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html) request
-   *
-   * @param {string} job_id - The ID of the job to fetch
-   * @param {string} snapshot_id - The ID of the snapshot to delete
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildMlDeleteModelSnapshot (opts) {
 
   }
 
+  /**
+   * Perform a ml.delete_model_snapshot request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html
+   */
   return function mlDeleteModelSnapshot (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,10 +44,6 @@ function buildMlDeleteModelSnapshot (opts) {
       const err = new ConfigurationError('Missing required parameter: snapshot_id or snapshotId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // check required url components
     if ((params['snapshot_id'] != null || params['snapshotId'] != null) && ((params['job_id'] == null && params['jobId'] == null))) {
@@ -67,10 +61,6 @@ function buildMlDeleteModelSnapshot (opts) {
     var { method, body, jobId, job_id, snapshotId, snapshot_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -78,13 +68,14 @@ function buildMlDeleteModelSnapshot (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'model_snapshots' + '/' + encodeURIComponent(snapshot_id || snapshotId)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.estimate_memory_usage.js
+++ b/api/api/ml.estimate_memory_usage.js
@@ -10,11 +10,6 @@
 function buildMlEstimateMemoryUsage (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.estimate_memory_usage](http://www.elastic.co/guide/en/elasticsearch/reference/current/estimate-memory-usage-dfanalytics.html) request
-   *
-   * @param {object} body - Memory usage estimation definition
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildMlEstimateMemoryUsage (opts) {
 
   }
 
+  /**
+   * Perform a ml.estimate_memory_usage request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/estimate-memory-usage-dfanalytics.html
+   */
   return function mlEstimateMemoryUsage (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildMlEstimateMemoryUsage (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildMlEstimateMemoryUsage (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'data_frame' + '/' + 'analytics' + '/' + '_estimate_memory_usage'
 
     // build request object

--- a/api/api/ml.evaluate_data_frame.js
+++ b/api/api/ml.evaluate_data_frame.js
@@ -10,11 +10,6 @@
 function buildMlEvaluateDataFrame (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.evaluate_data_frame](http://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html) request
-   *
-   * @param {object} body - The evaluation definition
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildMlEvaluateDataFrame (opts) {
 
   }
 
+  /**
+   * Perform a ml.evaluate_data_frame request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html
+   */
   return function mlEvaluateDataFrame (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildMlEvaluateDataFrame (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildMlEvaluateDataFrame (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'data_frame' + '/' + '_evaluate'
 
     // build request object

--- a/api/api/ml.find_file_structure.js
+++ b/api/api/ml.find_file_structure.js
@@ -10,25 +10,6 @@
 function buildMlFindFileStructure (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.find_file_structure](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-find-file-structure.html) request
-   *
-   * @param {int} lines_to_sample - How many lines of the file should be included in the analysis
-   * @param {int} line_merge_size_limit - Maximum number of characters permitted in a single message when lines are merged to create messages.
-   * @param {time} timeout - Timeout after which the analysis will be aborted
-   * @param {string} charset - Optional parameter to specify the character set of the file
-   * @param {enum} format - Optional parameter to specify the high level file format
-   * @param {boolean} has_header_row - Optional parameter to specify whether a delimited file includes the column names in its first row
-   * @param {list} column_names - Optional parameter containing a comma separated list of the column names for a delimited file
-   * @param {string} delimiter - Optional parameter to specify the delimiter character for a delimited file - must be a single character
-   * @param {string} quote - Optional parameter to specify the quote character for a delimited file - must be a single character
-   * @param {boolean} should_trim_fields - Optional parameter to specify whether the values between delimiters in a delimited file should have whitespace trimmed from them
-   * @param {string} grok_pattern - Optional parameter to specify the Grok pattern that should be used to extract fields from messages in a semi-structured text file
-   * @param {string} timestamp_field - Optional parameter to specify the timestamp field in the file
-   * @param {string} timestamp_format - Optional parameter to specify the timestamp format in the file - may be either a Joda or Java time format
-   * @param {boolean} explain - Whether to include a commentary on how the structure was derived
-   * @param {object} body - The contents of the file to be analyzed
-   */
 
   const acceptedQuerystring = [
     'lines_to_sample',
@@ -59,6 +40,10 @@ function buildMlFindFileStructure (opts) {
 
   }
 
+  /**
+   * Perform a ml.find_file_structure request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-find-file-structure.html
+   */
   return function mlFindFileStructure (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -87,10 +72,6 @@ function buildMlFindFileStructure (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -98,6 +79,7 @@ function buildMlFindFileStructure (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'find_file_structure'
 
     // build request object

--- a/api/api/ml.flush_job.js
+++ b/api/api/ml.flush_job.js
@@ -10,17 +10,6 @@
 function buildMlFlushJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.flush_job](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html) request
-   *
-   * @param {string} job_id - The name of the job to flush
-   * @param {boolean} calc_interim - Calculates interim results for the most recent bucket or all buckets within the latency period
-   * @param {string} start - When used in conjunction with calc_interim, specifies the range of buckets on which to calculate interim results
-   * @param {string} end - When used in conjunction with calc_interim, specifies the range of buckets on which to calculate interim results
-   * @param {string} advance_time - Advances time to the given value generating results and updating the model for the advanced interval
-   * @param {string} skip_time - Skips time to the given value without generating results or updating the model for the skipped interval
-   * @param {object} body - Flush parameters
-   */
 
   const acceptedQuerystring = [
     'calc_interim',
@@ -36,6 +25,10 @@ function buildMlFlushJob (opts) {
     skipTime: 'skip_time'
   }
 
+  /**
+   * Perform a ml.flush_job request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html
+   */
   return function mlFlushJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -64,10 +57,6 @@ function buildMlFlushJob (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -75,6 +64,7 @@ function buildMlFlushJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + '_flush'
 
     // build request object

--- a/api/api/ml.forecast.js
+++ b/api/api/ml.forecast.js
@@ -10,13 +10,6 @@
 function buildMlForecast (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.forecast](undefined) request
-   *
-   * @param {string} job_id - The ID of the job to forecast for
-   * @param {time} duration - The duration of the forecast
-   * @param {time} expires_in - The time interval after which the forecast expires. Expired forecasts will be deleted at the first opportunity.
-   */
 
   const acceptedQuerystring = [
     'duration',
@@ -27,6 +20,9 @@ function buildMlForecast (opts) {
     expiresIn: 'expires_in'
   }
 
+  /**
+   * Perform a ml.forecast request
+   */
   return function mlForecast (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -44,10 +40,6 @@ function buildMlForecast (opts) {
       const err = new ConfigurationError('Missing required parameter: job_id or jobId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -59,10 +51,6 @@ function buildMlForecast (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -70,13 +58,14 @@ function buildMlForecast (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + '_forecast'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.get_buckets.js
+++ b/api/api/ml.get_buckets.js
@@ -10,22 +10,6 @@
 function buildMlGetBuckets (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_buckets](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html) request
-   *
-   * @param {string} job_id - ID of the job to get bucket results from
-   * @param {string} timestamp - The timestamp of the desired single bucket result
-   * @param {boolean} expand - Include anomaly records
-   * @param {boolean} exclude_interim - Exclude interim results
-   * @param {int} from - skips a number of buckets
-   * @param {int} size - specifies a max number of buckets to get
-   * @param {string} start - Start time filter for buckets
-   * @param {string} end - End time filter for buckets
-   * @param {double} anomaly_score - Filter for the most anomalous buckets
-   * @param {string} sort - Sort buckets by a particular field
-   * @param {boolean} desc - Set the sort direction
-   * @param {object} body - Bucket selection details if not provided in URI
-   */
 
   const acceptedQuerystring = [
     'expand',
@@ -45,6 +29,10 @@ function buildMlGetBuckets (opts) {
 
   }
 
+  /**
+   * Perform a ml.get_buckets request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html
+   */
   return function mlGetBuckets (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -79,10 +67,6 @@ function buildMlGetBuckets (opts) {
     var { method, body, jobId, job_id, timestamp, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -91,8 +75,10 @@ function buildMlGetBuckets (opts) {
     var path = ''
 
     if ((job_id || jobId) != null && (timestamp) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'results' + '/' + 'buckets' + '/' + encodeURIComponent(timestamp)
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'results' + '/' + 'buckets'
     }
 

--- a/api/api/ml.get_calendar_events.js
+++ b/api/api/ml.get_calendar_events.js
@@ -10,16 +10,6 @@
 function buildMlGetCalendarEvents (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_calendar_events](undefined) request
-   *
-   * @param {string} calendar_id - The ID of the calendar containing the events
-   * @param {string} job_id - Get events for the job. When this option is used calendar_id must be '_all'
-   * @param {string} start - Get events after this time
-   * @param {date} end - Get events before this time
-   * @param {int} from - Skips a number of events
-   * @param {int} size - Specifies a max number of events to get
-   */
 
   const acceptedQuerystring = [
     'job_id',
@@ -34,6 +24,9 @@ function buildMlGetCalendarEvents (opts) {
 
   }
 
+  /**
+   * Perform a ml.get_calendar_events request
+   */
   return function mlGetCalendarEvents (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -51,10 +44,6 @@ function buildMlGetCalendarEvents (opts) {
       const err = new ConfigurationError('Missing required parameter: calendar_id or calendarId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -66,10 +55,6 @@ function buildMlGetCalendarEvents (opts) {
     var { method, body, calendarId, calendar_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -77,6 +62,7 @@ function buildMlGetCalendarEvents (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_ml' + '/' + 'calendars' + '/' + encodeURIComponent(calendar_id || calendarId) + '/' + 'events'
 
     // build request object

--- a/api/api/ml.get_calendars.js
+++ b/api/api/ml.get_calendars.js
@@ -10,14 +10,6 @@
 function buildMlGetCalendars (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_calendars](undefined) request
-   *
-   * @param {string} calendar_id - The ID of the calendar to fetch
-   * @param {int} from - skips a number of calendars
-   * @param {int} size - specifies a max number of calendars to get
-   * @param {object} body - The from and size parameters optionally sent in the body
-   */
 
   const acceptedQuerystring = [
     'from',
@@ -28,6 +20,9 @@ function buildMlGetCalendars (opts) {
 
   }
 
+  /**
+   * Perform a ml.get_calendars request
+   */
   return function mlGetCalendars (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -50,10 +45,6 @@ function buildMlGetCalendars (opts) {
     var { method, body, calendarId, calendar_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,8 +53,10 @@ function buildMlGetCalendars (opts) {
     var path = ''
 
     if ((calendar_id || calendarId) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_ml' + '/' + 'calendars' + '/' + encodeURIComponent(calendar_id || calendarId)
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_ml' + '/' + 'calendars'
     }
 

--- a/api/api/ml.get_categories.js
+++ b/api/api/ml.get_categories.js
@@ -10,15 +10,6 @@
 function buildMlGetCategories (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_categories](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html) request
-   *
-   * @param {string} job_id - The name of the job
-   * @param {long} category_id - The identifier of the category definition of interest
-   * @param {int} from - skips a number of categories
-   * @param {int} size - specifies a max number of categories to get
-   * @param {object} body - Category selection details if not provided in URI
-   */
 
   const acceptedQuerystring = [
     'from',
@@ -29,6 +20,10 @@ function buildMlGetCategories (opts) {
 
   }
 
+  /**
+   * Perform a ml.get_categories request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html
+   */
   return function mlGetCategories (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -47,6 +42,12 @@ function buildMlGetCategories (opts) {
       return handleError(err, callback)
     }
 
+    // check required url components
+    if ((params['category_id'] != null || params['categoryId'] != null) && ((params['job_id'] == null && params['jobId'] == null))) {
+      const err = new ConfigurationError('Missing required parameter of the url: job_id')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -57,10 +58,6 @@ function buildMlGetCategories (opts) {
     var { method, body, jobId, job_id, categoryId, category_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,8 +66,10 @@ function buildMlGetCategories (opts) {
     var path = ''
 
     if ((job_id || jobId) != null && (category_id || categoryId) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'results' + '/' + 'categories' + '/' + encodeURIComponent(category_id || categoryId)
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'results' + '/' + 'categories'
     }
 

--- a/api/api/ml.get_data_frame_analytics.js
+++ b/api/api/ml.get_data_frame_analytics.js
@@ -10,14 +10,6 @@
 function buildMlGetDataFrameAnalytics (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_data_frame_analytics](http://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html) request
-   *
-   * @param {string} id - The ID of the data frame analytics to fetch
-   * @param {boolean} allow_no_match - Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)
-   * @param {int} from - skips a number of analytics
-   * @param {int} size - specifies a max number of analytics to get
-   */
 
   const acceptedQuerystring = [
     'allow_no_match',
@@ -30,6 +22,10 @@ function buildMlGetDataFrameAnalytics (opts) {
 
   }
 
+  /**
+   * Perform a ml.get_data_frame_analytics request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html
+   */
   return function mlGetDataFrameAnalytics (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,12 +38,6 @@ function buildMlGetDataFrameAnalytics (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -58,10 +48,6 @@ function buildMlGetDataFrameAnalytics (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -70,8 +56,10 @@ function buildMlGetDataFrameAnalytics (opts) {
     var path = ''
 
     if ((id) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'data_frame' + '/' + 'analytics' + '/' + encodeURIComponent(id)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'data_frame' + '/' + 'analytics'
     }
 

--- a/api/api/ml.get_data_frame_analytics_stats.js
+++ b/api/api/ml.get_data_frame_analytics_stats.js
@@ -10,14 +10,6 @@
 function buildMlGetDataFrameAnalyticsStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_data_frame_analytics_stats](http://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html) request
-   *
-   * @param {string} id - The ID of the data frame analytics stats to fetch
-   * @param {boolean} allow_no_match - Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)
-   * @param {int} from - skips a number of analytics
-   * @param {int} size - specifies a max number of analytics to get
-   */
 
   const acceptedQuerystring = [
     'allow_no_match',
@@ -30,6 +22,10 @@ function buildMlGetDataFrameAnalyticsStats (opts) {
 
   }
 
+  /**
+   * Perform a ml.get_data_frame_analytics_stats request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html
+   */
   return function mlGetDataFrameAnalyticsStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,12 +38,6 @@ function buildMlGetDataFrameAnalyticsStats (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -58,10 +48,6 @@ function buildMlGetDataFrameAnalyticsStats (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -70,8 +56,10 @@ function buildMlGetDataFrameAnalyticsStats (opts) {
     var path = ''
 
     if ((id) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'data_frame' + '/' + 'analytics' + '/' + encodeURIComponent(id) + '/' + '_stats'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'data_frame' + '/' + 'analytics' + '/' + '_stats'
     }
 

--- a/api/api/ml.get_datafeed_stats.js
+++ b/api/api/ml.get_datafeed_stats.js
@@ -10,12 +10,6 @@
 function buildMlGetDatafeedStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_datafeed_stats](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html) request
-   *
-   * @param {string} datafeed_id - The ID of the datafeeds stats to fetch
-   * @param {boolean} allow_no_datafeeds - Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
-   */
 
   const acceptedQuerystring = [
     'allow_no_datafeeds'
@@ -25,6 +19,10 @@ function buildMlGetDatafeedStats (opts) {
     allowNoDatafeeds: 'allow_no_datafeeds'
   }
 
+  /**
+   * Perform a ml.get_datafeed_stats request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html
+   */
   return function mlGetDatafeedStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,12 +35,6 @@ function buildMlGetDatafeedStats (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -53,10 +45,6 @@ function buildMlGetDatafeedStats (opts) {
     var { method, body, datafeedId, datafeed_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -65,8 +53,10 @@ function buildMlGetDatafeedStats (opts) {
     var path = ''
 
     if ((datafeed_id || datafeedId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'datafeeds' + '/' + encodeURIComponent(datafeed_id || datafeedId) + '/' + '_stats'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'datafeeds' + '/' + '_stats'
     }
 

--- a/api/api/ml.get_datafeeds.js
+++ b/api/api/ml.get_datafeeds.js
@@ -10,12 +10,6 @@
 function buildMlGetDatafeeds (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_datafeeds](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html) request
-   *
-   * @param {string} datafeed_id - The ID of the datafeeds to fetch
-   * @param {boolean} allow_no_datafeeds - Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
-   */
 
   const acceptedQuerystring = [
     'allow_no_datafeeds'
@@ -25,6 +19,10 @@ function buildMlGetDatafeeds (opts) {
     allowNoDatafeeds: 'allow_no_datafeeds'
   }
 
+  /**
+   * Perform a ml.get_datafeeds request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html
+   */
   return function mlGetDatafeeds (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,12 +35,6 @@ function buildMlGetDatafeeds (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -53,10 +45,6 @@ function buildMlGetDatafeeds (opts) {
     var { method, body, datafeedId, datafeed_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -65,8 +53,10 @@ function buildMlGetDatafeeds (opts) {
     var path = ''
 
     if ((datafeed_id || datafeedId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'datafeeds' + '/' + encodeURIComponent(datafeed_id || datafeedId)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'datafeeds'
     }
 

--- a/api/api/ml.get_filters.js
+++ b/api/api/ml.get_filters.js
@@ -10,13 +10,6 @@
 function buildMlGetFilters (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_filters](undefined) request
-   *
-   * @param {string} filter_id - The ID of the filter to fetch
-   * @param {int} from - skips a number of filters
-   * @param {int} size - specifies a max number of filters to get
-   */
 
   const acceptedQuerystring = [
     'from',
@@ -27,6 +20,9 @@ function buildMlGetFilters (opts) {
 
   }
 
+  /**
+   * Perform a ml.get_filters request
+   */
   return function mlGetFilters (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -39,12 +35,6 @@ function buildMlGetFilters (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -55,10 +45,6 @@ function buildMlGetFilters (opts) {
     var { method, body, filterId, filter_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,8 +53,10 @@ function buildMlGetFilters (opts) {
     var path = ''
 
     if ((filter_id || filterId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'filters' + '/' + encodeURIComponent(filter_id || filterId)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'filters'
     }
 

--- a/api/api/ml.get_influencers.js
+++ b/api/api/ml.get_influencers.js
@@ -10,20 +10,6 @@
 function buildMlGetInfluencers (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_influencers](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html) request
-   *
-   * @param {string} job_id -
-   * @param {boolean} exclude_interim - Exclude interim results
-   * @param {int} from - skips a number of influencers
-   * @param {int} size - specifies a max number of influencers to get
-   * @param {string} start - start timestamp for the requested influencers
-   * @param {string} end - end timestamp for the requested influencers
-   * @param {double} influencer_score - influencer score threshold for the requested influencers
-   * @param {string} sort - sort field for the requested influencers
-   * @param {boolean} desc - whether the results should be sorted in decending order
-   * @param {object} body - Influencer selection criteria
-   */
 
   const acceptedQuerystring = [
     'exclude_interim',
@@ -42,6 +28,10 @@ function buildMlGetInfluencers (opts) {
 
   }
 
+  /**
+   * Perform a ml.get_influencers request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html
+   */
   return function mlGetInfluencers (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -70,10 +60,6 @@ function buildMlGetInfluencers (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -81,6 +67,7 @@ function buildMlGetInfluencers (opts) {
 
     var path = ''
 
+    if (method == null) method = body == null ? 'GET' : 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'results' + '/' + 'influencers'
 
     // build request object

--- a/api/api/ml.get_job_stats.js
+++ b/api/api/ml.get_job_stats.js
@@ -10,12 +10,6 @@
 function buildMlGetJobStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_job_stats](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html) request
-   *
-   * @param {string} job_id - The ID of the jobs stats to fetch
-   * @param {boolean} allow_no_jobs - Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
-   */
 
   const acceptedQuerystring = [
     'allow_no_jobs'
@@ -25,6 +19,10 @@ function buildMlGetJobStats (opts) {
     allowNoJobs: 'allow_no_jobs'
   }
 
+  /**
+   * Perform a ml.get_job_stats request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html
+   */
   return function mlGetJobStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,12 +35,6 @@ function buildMlGetJobStats (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -53,10 +45,6 @@ function buildMlGetJobStats (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -65,8 +53,10 @@ function buildMlGetJobStats (opts) {
     var path = ''
 
     if ((job_id || jobId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + '_stats'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + '_stats'
     }
 

--- a/api/api/ml.get_jobs.js
+++ b/api/api/ml.get_jobs.js
@@ -10,12 +10,6 @@
 function buildMlGetJobs (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_jobs](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html) request
-   *
-   * @param {string} job_id - The ID of the jobs to fetch
-   * @param {boolean} allow_no_jobs - Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
-   */
 
   const acceptedQuerystring = [
     'allow_no_jobs'
@@ -25,6 +19,10 @@ function buildMlGetJobs (opts) {
     allowNoJobs: 'allow_no_jobs'
   }
 
+  /**
+   * Perform a ml.get_jobs request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html
+   */
   return function mlGetJobs (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,12 +35,6 @@ function buildMlGetJobs (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -53,10 +45,6 @@ function buildMlGetJobs (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -65,8 +53,10 @@ function buildMlGetJobs (opts) {
     var path = ''
 
     if ((job_id || jobId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_ml' + '/' + 'anomaly_detectors'
     }
 

--- a/api/api/ml.get_model_snapshots.js
+++ b/api/api/ml.get_model_snapshots.js
@@ -10,19 +10,6 @@
 function buildMlGetModelSnapshots (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_model_snapshots](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html) request
-   *
-   * @param {string} job_id - The ID of the job to fetch
-   * @param {string} snapshot_id - The ID of the snapshot to fetch
-   * @param {int} from - Skips a number of documents
-   * @param {int} size - The default number of documents returned in queries as a string.
-   * @param {date} start - The filter 'start' query parameter
-   * @param {date} end - The filter 'end' query parameter
-   * @param {string} sort - Name of the field to sort on
-   * @param {boolean} desc - True if the results should be sorted in descending order
-   * @param {object} body - Model snapshot selection criteria
-   */
 
   const acceptedQuerystring = [
     'from',
@@ -37,6 +24,10 @@ function buildMlGetModelSnapshots (opts) {
 
   }
 
+  /**
+   * Perform a ml.get_model_snapshots request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html
+   */
   return function mlGetModelSnapshots (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -71,10 +62,6 @@ function buildMlGetModelSnapshots (opts) {
     var { method, body, jobId, job_id, snapshotId, snapshot_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -83,8 +70,10 @@ function buildMlGetModelSnapshots (opts) {
     var path = ''
 
     if ((job_id || jobId) != null && (snapshot_id || snapshotId) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'model_snapshots' + '/' + encodeURIComponent(snapshot_id || snapshotId)
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'model_snapshots'
     }
 

--- a/api/api/ml.get_overall_buckets.js
+++ b/api/api/ml.get_overall_buckets.js
@@ -10,19 +10,6 @@
 function buildMlGetOverallBuckets (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_overall_buckets](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html) request
-   *
-   * @param {string} job_id - The job IDs for which to calculate overall bucket results
-   * @param {int} top_n - The number of top job bucket scores to be used in the overall_score calculation
-   * @param {string} bucket_span - The span of the overall buckets. Defaults to the longest job bucket_span
-   * @param {double} overall_score - Returns overall buckets with overall scores higher than this value
-   * @param {boolean} exclude_interim - If true overall buckets that include interim buckets will be excluded
-   * @param {string} start - Returns overall buckets with timestamps after this time
-   * @param {string} end - Returns overall buckets with timestamps earlier than this time
-   * @param {boolean} allow_no_jobs - Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
-   * @param {object} body - Overall bucket selection details if not provided in URI
-   */
 
   const acceptedQuerystring = [
     'top_n',
@@ -42,6 +29,10 @@ function buildMlGetOverallBuckets (opts) {
     allowNoJobs: 'allow_no_jobs'
   }
 
+  /**
+   * Perform a ml.get_overall_buckets request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html
+   */
   return function mlGetOverallBuckets (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -70,10 +61,6 @@ function buildMlGetOverallBuckets (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -81,6 +68,7 @@ function buildMlGetOverallBuckets (opts) {
 
     var path = ''
 
+    if (method == null) method = body == null ? 'GET' : 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'results' + '/' + 'overall_buckets'
 
     // build request object

--- a/api/api/ml.get_records.js
+++ b/api/api/ml.get_records.js
@@ -10,20 +10,6 @@
 function buildMlGetRecords (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.get_records](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html) request
-   *
-   * @param {string} job_id -
-   * @param {boolean} exclude_interim - Exclude interim results
-   * @param {int} from - skips a number of records
-   * @param {int} size - specifies a max number of records to get
-   * @param {string} start - Start time filter for records
-   * @param {string} end - End time filter for records
-   * @param {double} record_score -
-   * @param {string} sort - Sort records by a particular field
-   * @param {boolean} desc - Set the sort direction
-   * @param {object} body - Record selection criteria
-   */
 
   const acceptedQuerystring = [
     'exclude_interim',
@@ -42,6 +28,10 @@ function buildMlGetRecords (opts) {
 
   }
 
+  /**
+   * Perform a ml.get_records request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html
+   */
   return function mlGetRecords (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -70,10 +60,6 @@ function buildMlGetRecords (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -81,6 +67,7 @@ function buildMlGetRecords (opts) {
 
     var path = ''
 
+    if (method == null) method = body == null ? 'GET' : 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'results' + '/' + 'records'
 
     // build request object

--- a/api/api/ml.info.js
+++ b/api/api/ml.info.js
@@ -10,10 +10,6 @@
 function buildMlInfo (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.info](undefined) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,9 @@ function buildMlInfo (opts) {
 
   }
 
+  /**
+   * Perform a ml.info request
+   */
   return function mlInfo (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -45,10 +44,6 @@ function buildMlInfo (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -56,6 +51,7 @@ function buildMlInfo (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_ml' + '/' + 'info'
 
     // build request object

--- a/api/api/ml.open_job.js
+++ b/api/api/ml.open_job.js
@@ -10,13 +10,6 @@
 function buildMlOpenJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.open_job](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html) request
-   *
-   * @param {string} job_id - The ID of the job to open
-   * @param {boolean} ignore_downtime - Controls if gaps in data are treated as anomalous or as a maintenance window after a job re-start
-   * @param {time} timeout - Controls the time to wait until a job has opened. Default to 30 minutes
-   */
 
   const acceptedQuerystring = [
 
@@ -26,6 +19,10 @@ function buildMlOpenJob (opts) {
 
   }
 
+  /**
+   * Perform a ml.open_job request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html
+   */
   return function mlOpenJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -43,10 +40,6 @@ function buildMlOpenJob (opts) {
       const err = new ConfigurationError('Missing required parameter: job_id or jobId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -55,12 +48,8 @@ function buildMlOpenJob (opts) {
     }
 
     var warnings = []
-    var { method, body, jobId, job_id, ignoreDowntime, ignore_downtime, timeout, ...querystring } = params
+    var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
-
-    if (method == null) {
-      method = 'POST'
-    }
 
     var ignore = options.ignore
     if (typeof ignore === 'number') {
@@ -69,13 +58,14 @@ function buildMlOpenJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + '_open'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.post_calendar_events.js
+++ b/api/api/ml.post_calendar_events.js
@@ -10,12 +10,6 @@
 function buildMlPostCalendarEvents (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.post_calendar_events](undefined) request
-   *
-   * @param {string} calendar_id - The ID of the calendar to modify
-   * @param {object} body - A list of events
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,9 @@ function buildMlPostCalendarEvents (opts) {
 
   }
 
+  /**
+   * Perform a ml.post_calendar_events request
+   */
   return function mlPostCalendarEvents (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +54,6 @@ function buildMlPostCalendarEvents (opts) {
     var { method, body, calendarId, calendar_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +61,7 @@ function buildMlPostCalendarEvents (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'calendars' + '/' + encodeURIComponent(calendar_id || calendarId) + '/' + 'events'
 
     // build request object

--- a/api/api/ml.post_data.js
+++ b/api/api/ml.post_data.js
@@ -10,14 +10,6 @@
 function buildMlPostData (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.post_data](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html) request
-   *
-   * @param {string} job_id - The name of the job receiving the data
-   * @param {string} reset_start - Optional parameter to specify the start of the bucket resetting range
-   * @param {string} reset_end - Optional parameter to specify the end of the bucket resetting range
-   * @param {object} body - The data to process
-   */
 
   const acceptedQuerystring = [
     'reset_start',
@@ -29,6 +21,10 @@ function buildMlPostData (opts) {
     resetEnd: 'reset_end'
   }
 
+  /**
+   * Perform a ml.post_data request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html
+   */
   return function mlPostData (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -61,10 +57,6 @@ function buildMlPostData (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -72,6 +64,7 @@ function buildMlPostData (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + '_data'
 
     // build request object

--- a/api/api/ml.preview_datafeed.js
+++ b/api/api/ml.preview_datafeed.js
@@ -10,11 +10,6 @@
 function buildMlPreviewDatafeed (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.preview_datafeed](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html) request
-   *
-   * @param {string} datafeed_id - The ID of the datafeed to preview
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildMlPreviewDatafeed (opts) {
 
   }
 
+  /**
+   * Perform a ml.preview_datafeed request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html
+   */
   return function mlPreviewDatafeed (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,10 +40,6 @@ function buildMlPreviewDatafeed (opts) {
       const err = new ConfigurationError('Missing required parameter: datafeed_id or datafeedId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -56,10 +51,6 @@ function buildMlPreviewDatafeed (opts) {
     var { method, body, datafeedId, datafeed_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,6 +58,7 @@ function buildMlPreviewDatafeed (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_ml' + '/' + 'datafeeds' + '/' + encodeURIComponent(datafeed_id || datafeedId) + '/' + '_preview'
 
     // build request object

--- a/api/api/ml.put_calendar.js
+++ b/api/api/ml.put_calendar.js
@@ -10,12 +10,6 @@
 function buildMlPutCalendar (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.put_calendar](undefined) request
-   *
-   * @param {string} calendar_id - The ID of the calendar to create
-   * @param {object} body - The calendar details
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,9 @@ function buildMlPutCalendar (opts) {
 
   }
 
+  /**
+   * Perform a ml.put_calendar request
+   */
   return function mlPutCalendar (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,10 +50,6 @@ function buildMlPutCalendar (opts) {
     var { method, body, calendarId, calendar_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,6 +57,7 @@ function buildMlPutCalendar (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_ml' + '/' + 'calendars' + '/' + encodeURIComponent(calendar_id || calendarId)
 
     // build request object

--- a/api/api/ml.put_calendar_job.js
+++ b/api/api/ml.put_calendar_job.js
@@ -10,12 +10,6 @@
 function buildMlPutCalendarJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.put_calendar_job](undefined) request
-   *
-   * @param {string} calendar_id - The ID of the calendar to modify
-   * @param {string} job_id - The ID of the job to add to the calendar
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,9 @@ function buildMlPutCalendarJob (opts) {
 
   }
 
+  /**
+   * Perform a ml.put_calendar_job request
+   */
   return function mlPutCalendarJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,10 +43,6 @@ function buildMlPutCalendarJob (opts) {
       const err = new ConfigurationError('Missing required parameter: job_id or jobId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // check required url components
     if ((params['job_id'] != null || params['jobId'] != null) && ((params['calendar_id'] == null && params['calendarId'] == null))) {
@@ -67,10 +60,6 @@ function buildMlPutCalendarJob (opts) {
     var { method, body, calendarId, calendar_id, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -78,13 +67,14 @@ function buildMlPutCalendarJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_ml' + '/' + 'calendars' + '/' + encodeURIComponent(calendar_id || calendarId) + '/' + 'jobs' + '/' + encodeURIComponent(job_id || jobId)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.put_data_frame_analytics.js
+++ b/api/api/ml.put_data_frame_analytics.js
@@ -10,12 +10,6 @@
 function buildMlPutDataFrameAnalytics (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.put_data_frame_analytics](http://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html) request
-   *
-   * @param {string} id - The ID of the data frame analytics to create
-   * @param {object} body - The data frame analytics configuration
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildMlPutDataFrameAnalytics (opts) {
 
   }
 
+  /**
+   * Perform a ml.put_data_frame_analytics request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html
+   */
   return function mlPutDataFrameAnalytics (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +55,6 @@ function buildMlPutDataFrameAnalytics (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +62,7 @@ function buildMlPutDataFrameAnalytics (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_ml' + '/' + 'data_frame' + '/' + 'analytics' + '/' + encodeURIComponent(id)
 
     // build request object

--- a/api/api/ml.put_datafeed.js
+++ b/api/api/ml.put_datafeed.js
@@ -10,12 +10,6 @@
 function buildMlPutDatafeed (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.put_datafeed](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html) request
-   *
-   * @param {string} datafeed_id - The ID of the datafeed to create
-   * @param {object} body - The datafeed config
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildMlPutDatafeed (opts) {
 
   }
 
+  /**
+   * Perform a ml.put_datafeed request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html
+   */
   return function mlPutDatafeed (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +55,6 @@ function buildMlPutDatafeed (opts) {
     var { method, body, datafeedId, datafeed_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +62,7 @@ function buildMlPutDatafeed (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_ml' + '/' + 'datafeeds' + '/' + encodeURIComponent(datafeed_id || datafeedId)
 
     // build request object

--- a/api/api/ml.put_filter.js
+++ b/api/api/ml.put_filter.js
@@ -10,12 +10,6 @@
 function buildMlPutFilter (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.put_filter](undefined) request
-   *
-   * @param {string} filter_id - The ID of the filter to create
-   * @param {object} body - The filter details
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,9 @@ function buildMlPutFilter (opts) {
 
   }
 
+  /**
+   * Perform a ml.put_filter request
+   */
   return function mlPutFilter (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +54,6 @@ function buildMlPutFilter (opts) {
     var { method, body, filterId, filter_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +61,7 @@ function buildMlPutFilter (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_ml' + '/' + 'filters' + '/' + encodeURIComponent(filter_id || filterId)
 
     // build request object

--- a/api/api/ml.put_job.js
+++ b/api/api/ml.put_job.js
@@ -10,12 +10,6 @@
 function buildMlPutJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.put_job](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html) request
-   *
-   * @param {string} job_id - The ID of the job to create
-   * @param {object} body - The job
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildMlPutJob (opts) {
 
   }
 
+  /**
+   * Perform a ml.put_job request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html
+   */
   return function mlPutJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +55,6 @@ function buildMlPutJob (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +62,7 @@ function buildMlPutJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId)
 
     // build request object

--- a/api/api/ml.revert_model_snapshot.js
+++ b/api/api/ml.revert_model_snapshot.js
@@ -10,14 +10,6 @@
 function buildMlRevertModelSnapshot (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.revert_model_snapshot](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html) request
-   *
-   * @param {string} job_id - The ID of the job to fetch
-   * @param {string} snapshot_id - The ID of the snapshot to revert to
-   * @param {boolean} delete_intervening_results - Should we reset the results back to the time of the snapshot?
-   * @param {object} body - Reversion options
-   */
 
   const acceptedQuerystring = [
     'delete_intervening_results'
@@ -27,6 +19,10 @@ function buildMlRevertModelSnapshot (opts) {
     deleteInterveningResults: 'delete_intervening_results'
   }
 
+  /**
+   * Perform a ml.revert_model_snapshot request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html
+   */
   return function mlRevertModelSnapshot (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -65,10 +61,6 @@ function buildMlRevertModelSnapshot (opts) {
     var { method, body, jobId, job_id, snapshotId, snapshot_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -76,6 +68,7 @@ function buildMlRevertModelSnapshot (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'model_snapshots' + '/' + encodeURIComponent(snapshot_id || snapshotId) + '/' + '_revert'
 
     // build request object

--- a/api/api/ml.set_upgrade_mode.js
+++ b/api/api/ml.set_upgrade_mode.js
@@ -10,12 +10,6 @@
 function buildMlSetUpgradeMode (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.set_upgrade_mode](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html) request
-   *
-   * @param {boolean} enabled - Whether to enable upgrade_mode ML setting or not. Defaults to false.
-   * @param {time} timeout - Controls the time to wait before action times out. Defaults to 30 seconds
-   */
 
   const acceptedQuerystring = [
     'enabled',
@@ -26,6 +20,10 @@ function buildMlSetUpgradeMode (opts) {
 
   }
 
+  /**
+   * Perform a ml.set_upgrade_mode request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html
+   */
   return function mlSetUpgradeMode (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -38,12 +36,6 @@ function buildMlSetUpgradeMode (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -54,10 +46,6 @@ function buildMlSetUpgradeMode (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -65,13 +53,14 @@ function buildMlSetUpgradeMode (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'set_upgrade_mode'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/ml.start_data_frame_analytics.js
+++ b/api/api/ml.start_data_frame_analytics.js
@@ -10,13 +10,6 @@
 function buildMlStartDataFrameAnalytics (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.start_data_frame_analytics](http://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html) request
-   *
-   * @param {string} id - The ID of the data frame analytics to start
-   * @param {time} timeout - Controls the time to wait until the task has started. Defaults to 20 seconds
-   * @param {object} body - The start data frame analytics parameters
-   */
 
   const acceptedQuerystring = [
     'timeout'
@@ -26,6 +19,10 @@ function buildMlStartDataFrameAnalytics (opts) {
 
   }
 
+  /**
+   * Perform a ml.start_data_frame_analytics request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html
+   */
   return function mlStartDataFrameAnalytics (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -54,10 +51,6 @@ function buildMlStartDataFrameAnalytics (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -65,6 +58,7 @@ function buildMlStartDataFrameAnalytics (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'data_frame' + '/' + 'analytics' + '/' + encodeURIComponent(id) + '/' + '_start'
 
     // build request object

--- a/api/api/ml.start_datafeed.js
+++ b/api/api/ml.start_datafeed.js
@@ -10,15 +10,6 @@
 function buildMlStartDatafeed (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.start_datafeed](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html) request
-   *
-   * @param {string} datafeed_id - The ID of the datafeed to start
-   * @param {string} start - The start time from where the datafeed should begin
-   * @param {string} end - The end time when the datafeed should stop. When not set, the datafeed continues in real time
-   * @param {time} timeout - Controls the time to wait until a datafeed has started. Default to 20 seconds
-   * @param {object} body - The start datafeed parameters
-   */
 
   const acceptedQuerystring = [
     'start',
@@ -30,6 +21,10 @@ function buildMlStartDatafeed (opts) {
 
   }
 
+  /**
+   * Perform a ml.start_datafeed request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html
+   */
   return function mlStartDatafeed (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,10 +53,6 @@ function buildMlStartDatafeed (opts) {
     var { method, body, datafeedId, datafeed_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,6 +60,7 @@ function buildMlStartDatafeed (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'datafeeds' + '/' + encodeURIComponent(datafeed_id || datafeedId) + '/' + '_start'
 
     // build request object

--- a/api/api/ml.stop_data_frame_analytics.js
+++ b/api/api/ml.stop_data_frame_analytics.js
@@ -10,15 +10,6 @@
 function buildMlStopDataFrameAnalytics (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.stop_data_frame_analytics](http://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html) request
-   *
-   * @param {string} id - The ID of the data frame analytics to stop
-   * @param {boolean} allow_no_match - Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)
-   * @param {boolean} force - True if the data frame analytics should be forcefully stopped
-   * @param {time} timeout - Controls the time to wait until the task has stopped. Defaults to 20 seconds
-   * @param {object} body - The stop data frame analytics parameters
-   */
 
   const acceptedQuerystring = [
     'allow_no_match',
@@ -31,6 +22,10 @@ function buildMlStopDataFrameAnalytics (opts) {
 
   }
 
+  /**
+   * Perform a ml.stop_data_frame_analytics request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html
+   */
   return function mlStopDataFrameAnalytics (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -59,10 +54,6 @@ function buildMlStopDataFrameAnalytics (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -70,6 +61,7 @@ function buildMlStopDataFrameAnalytics (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'data_frame' + '/' + 'analytics' + '/' + encodeURIComponent(id) + '/' + '_stop'
 
     // build request object

--- a/api/api/ml.stop_datafeed.js
+++ b/api/api/ml.stop_datafeed.js
@@ -10,14 +10,6 @@
 function buildMlStopDatafeed (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.stop_datafeed](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html) request
-   *
-   * @param {string} datafeed_id - The ID of the datafeed to stop
-   * @param {boolean} allow_no_datafeeds - Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
-   * @param {boolean} force - True if the datafeed should be forcefully stopped.
-   * @param {time} timeout - Controls the time to wait until a datafeed has stopped. Default to 20 seconds
-   */
 
   const acceptedQuerystring = [
     'allow_no_datafeeds',
@@ -30,6 +22,10 @@ function buildMlStopDatafeed (opts) {
 
   }
 
+  /**
+   * Perform a ml.stop_datafeed request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html
+   */
   return function mlStopDatafeed (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,10 +54,6 @@ function buildMlStopDatafeed (opts) {
     var { method, body, datafeedId, datafeed_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,6 +61,7 @@ function buildMlStopDatafeed (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'datafeeds' + '/' + encodeURIComponent(datafeed_id || datafeedId) + '/' + '_stop'
 
     // build request object

--- a/api/api/ml.update_datafeed.js
+++ b/api/api/ml.update_datafeed.js
@@ -10,12 +10,6 @@
 function buildMlUpdateDatafeed (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.update_datafeed](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html) request
-   *
-   * @param {string} datafeed_id - The ID of the datafeed to update
-   * @param {object} body - The datafeed update settings
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildMlUpdateDatafeed (opts) {
 
   }
 
+  /**
+   * Perform a ml.update_datafeed request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html
+   */
   return function mlUpdateDatafeed (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +55,6 @@ function buildMlUpdateDatafeed (opts) {
     var { method, body, datafeedId, datafeed_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +62,7 @@ function buildMlUpdateDatafeed (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'datafeeds' + '/' + encodeURIComponent(datafeed_id || datafeedId) + '/' + '_update'
 
     // build request object

--- a/api/api/ml.update_job.js
+++ b/api/api/ml.update_job.js
@@ -10,12 +10,6 @@
 function buildMlUpdateJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.update_job](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html) request
-   *
-   * @param {string} job_id - The ID of the job to create
-   * @param {object} body - The job update settings
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildMlUpdateJob (opts) {
 
   }
 
+  /**
+   * Perform a ml.update_job request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html
+   */
   return function mlUpdateJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +55,6 @@ function buildMlUpdateJob (opts) {
     var { method, body, jobId, job_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +62,7 @@ function buildMlUpdateJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + '_update'
 
     // build request object

--- a/api/api/ml.update_model_snapshot.js
+++ b/api/api/ml.update_model_snapshot.js
@@ -10,13 +10,6 @@
 function buildMlUpdateModelSnapshot (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.update_model_snapshot](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html) request
-   *
-   * @param {string} job_id - The ID of the job to fetch
-   * @param {string} snapshot_id - The ID of the snapshot to update
-   * @param {object} body - The model snapshot properties to update
-   */
 
   const acceptedQuerystring = [
 
@@ -26,6 +19,10 @@ function buildMlUpdateModelSnapshot (opts) {
 
   }
 
+  /**
+   * Perform a ml.update_model_snapshot request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html
+   */
   return function mlUpdateModelSnapshot (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -68,10 +65,6 @@ function buildMlUpdateModelSnapshot (opts) {
     var { method, body, jobId, job_id, snapshotId, snapshot_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -79,6 +72,7 @@ function buildMlUpdateModelSnapshot (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + encodeURIComponent(job_id || jobId) + '/' + 'model_snapshots' + '/' + encodeURIComponent(snapshot_id || snapshotId) + '/' + '_update'
 
     // build request object

--- a/api/api/ml.validate.js
+++ b/api/api/ml.validate.js
@@ -10,11 +10,6 @@
 function buildMlValidate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.validate](undefined) request
-   *
-   * @param {object} body - The job config
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,9 @@ function buildMlValidate (opts) {
 
   }
 
+  /**
+   * Perform a ml.validate request
+   */
   return function mlValidate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +50,6 @@ function buildMlValidate (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +57,7 @@ function buildMlValidate (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + '_validate'
 
     // build request object

--- a/api/api/ml.validate_detector.js
+++ b/api/api/ml.validate_detector.js
@@ -10,11 +10,6 @@
 function buildMlValidateDetector (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ml.validate_detector](undefined) request
-   *
-   * @param {object} body - The detector
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,9 @@ function buildMlValidateDetector (opts) {
 
   }
 
+  /**
+   * Perform a ml.validate_detector request
+   */
   return function mlValidateDetector (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +50,6 @@ function buildMlValidateDetector (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +57,7 @@ function buildMlValidateDetector (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_ml' + '/' + 'anomaly_detectors' + '/' + '_validate' + '/' + 'detector'
 
     // build request object

--- a/api/api/monitoring.bulk.js
+++ b/api/api/monitoring.bulk.js
@@ -10,15 +10,6 @@
 function buildMonitoringBulk (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [monitoring.bulk](https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html) request
-   *
-   * @param {string} type - Default document type for items which don't provide one
-   * @param {string} system_id - Identifier of the monitored system
-   * @param {string} system_api_version - API Version of the monitored system
-   * @param {string} interval - Collection interval (e.g., '10s' or '10000ms') of the payload
-   * @param {object} body - The operation definition and data (action-data pairs), separated by newlines
-   */
 
   const acceptedQuerystring = [
     'system_id',
@@ -32,6 +23,10 @@ function buildMonitoringBulk (opts) {
 
   }
 
+  /**
+   * Perform a monitoring.bulk request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html
+   */
   return function monitoringBulk (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -60,10 +55,6 @@ function buildMonitoringBulk (opts) {
     var { method, body, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -72,8 +63,10 @@ function buildMonitoringBulk (opts) {
     var path = ''
 
     if ((type) != null) {
+      if (method == null) method = 'POST'
       path = '/' + '_monitoring' + '/' + encodeURIComponent(type) + '/' + 'bulk'
     } else {
+      if (method == null) method = 'POST'
       path = '/' + '_monitoring' + '/' + 'bulk'
     }
 

--- a/api/api/msearch.js
+++ b/api/api/msearch.js
@@ -10,19 +10,6 @@
 function buildMsearch (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [msearch](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to use as default
-   * @param {enum} search_type - Search operation type
-   * @param {number} max_concurrent_searches - Controls the maximum number of concurrent searches the multi search api will execute
-   * @param {boolean} typed_keys - Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-   * @param {number} pre_filter_shard_size - A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on it's rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
-   * @param {number} max_concurrent_shard_requests - The number of concurrent shard requests each sub search executes concurrently per node. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
-   * @param {boolean} rest_total_hits_as_int - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-   * @param {boolean} ccs_minimize_roundtrips - Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-   * @param {object} body - The request definitions (metadata-search request definition pairs), separated by newlines
-   */
 
   const acceptedQuerystring = [
     'search_type',
@@ -51,6 +38,11 @@ function buildMsearch (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a msearch request
+   * Allows to execute several search operations in one request.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html
+   */
   return function msearch (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -79,10 +71,6 @@ function buildMsearch (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -91,8 +79,10 @@ function buildMsearch (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_msearch'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_msearch'
     }
 

--- a/api/api/msearch_template.js
+++ b/api/api/msearch_template.js
@@ -10,17 +10,6 @@
 function buildMsearchTemplate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [msearch_template](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to use as default
-   * @param {enum} search_type - Search operation type
-   * @param {boolean} typed_keys - Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-   * @param {number} max_concurrent_searches - Controls the maximum number of concurrent searches the multi search api will execute
-   * @param {boolean} rest_total_hits_as_int - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-   * @param {boolean} ccs_minimize_roundtrips - Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-   * @param {object} body - The request definitions (metadata-search request definition pairs), separated by newlines
-   */
 
   const acceptedQuerystring = [
     'search_type',
@@ -45,6 +34,11 @@ function buildMsearchTemplate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a msearch_template request
+   * Allows to execute several search template operations in one request.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html
+   */
   return function msearchTemplate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -73,10 +67,6 @@ function buildMsearchTemplate (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -85,8 +75,10 @@ function buildMsearchTemplate (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_msearch' + '/' + 'template'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_msearch' + '/' + 'template'
     }
 

--- a/api/api/mtermvectors.js
+++ b/api/api/mtermvectors.js
@@ -10,24 +10,6 @@
 function buildMtermvectors (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [mtermvectors](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html) request
-   *
-   * @param {string} index - The index in which the document resides.
-   * @param {list} ids - A comma-separated list of documents ids. You must define ids as parameter or set "ids" or "docs" in the request body
-   * @param {boolean} term_statistics - Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-   * @param {boolean} field_statistics - Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-   * @param {list} fields - A comma-separated list of fields to return. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-   * @param {boolean} offsets - Specifies if term offsets should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-   * @param {boolean} positions - Specifies if term positions should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-   * @param {boolean} payloads - Specifies if term payloads should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random) .Applies to all returned documents unless otherwise specified in body "params" or "docs".
-   * @param {string} routing - Specific routing value. Applies to all returned documents unless otherwise specified in body "params" or "docs".
-   * @param {boolean} realtime - Specifies if requests are real-time as opposed to near-real-time (default: true).
-   * @param {number} version - Explicit version number for concurrency control
-   * @param {enum} version_type - Specific version type
-   * @param {object} body - Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.
-   */
 
   const acceptedQuerystring = [
     'ids',
@@ -57,6 +39,11 @@ function buildMtermvectors (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a mtermvectors request
+   * Returns multiple termvectors in one request.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html
+   */
   return function mtermvectors (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -79,10 +66,6 @@ function buildMtermvectors (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -91,8 +74,10 @@ function buildMtermvectors (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_mtermvectors'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_mtermvectors'
     }
 

--- a/api/api/nodes.hot_threads.js
+++ b/api/api/nodes.hot_threads.js
@@ -10,17 +10,6 @@
 function buildNodesHotThreads (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [nodes.hot_threads](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html) request
-   *
-   * @param {list} node_id - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
-   * @param {time} interval - The interval for the second sampling of threads
-   * @param {number} snapshots - Number of samples of thread stacktrace (default: 10)
-   * @param {number} threads - Specify the number of threads to provide information for (default: 3)
-   * @param {boolean} ignore_idle_threads - Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue (default: true)
-   * @param {enum} type - The type to sample (default: cpu)
-   * @param {time} timeout - Explicit operation timeout
-   */
 
   const acceptedQuerystring = [
     'interval',
@@ -42,6 +31,11 @@ function buildNodesHotThreads (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a nodes.hot_threads request
+   * Returns information about hot threads on each node in the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html
+   */
   return function nodesHotThreads (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -54,12 +48,6 @@ function buildNodesHotThreads (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -70,10 +58,6 @@ function buildNodesHotThreads (opts) {
     var { method, body, nodeId, node_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -82,14 +66,19 @@ function buildNodesHotThreads (opts) {
     var path = ''
 
     if ((node_id || nodeId) != null) {
-      path = '/' + '_cluster' + '/' + 'nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'hotthreads'
-    } else if ((node_id || nodeId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_cluster' + '/' + 'nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'hot_threads'
     } else if ((node_id || nodeId) != null) {
-      path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'hot_threads'
-    } else if ((node_id || nodeId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'hotthreads'
+    } else if ((node_id || nodeId) != null) {
+      if (method == null) method = 'GET'
+      path = '/' + '_cluster' + '/' + 'nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'hotthreads'
+    } else if ((node_id || nodeId) != null) {
+      if (method == null) method = 'GET'
+      path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'hot_threads'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + 'hot_threads'
     }
 

--- a/api/api/nodes.info.js
+++ b/api/api/nodes.info.js
@@ -10,14 +10,6 @@
 function buildNodesInfo (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [nodes.info](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html) request
-   *
-   * @param {list} node_id - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
-   * @param {list} metric - A comma-separated list of metrics you wish returned. Leave empty to return all.
-   * @param {boolean} flat_settings - Return settings in flat format (default: false)
-   * @param {time} timeout - Explicit operation timeout
-   */
 
   const acceptedQuerystring = [
     'flat_settings',
@@ -35,6 +27,11 @@ function buildNodesInfo (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a nodes.info request
+   * Returns information about nodes in the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html
+   */
   return function nodesInfo (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -47,12 +44,6 @@ function buildNodesInfo (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -63,10 +54,6 @@ function buildNodesInfo (opts) {
     var { method, body, nodeId, node_id, metric, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -75,12 +62,16 @@ function buildNodesInfo (opts) {
     var path = ''
 
     if ((node_id || nodeId) != null && (metric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + encodeURIComponent(metric)
     } else if ((node_id || nodeId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId)
     } else if ((metric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + encodeURIComponent(metric)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes'
     }
 

--- a/api/api/nodes.reload_secure_settings.js
+++ b/api/api/nodes.reload_secure_settings.js
@@ -10,12 +10,6 @@
 function buildNodesReloadSecureSettings (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [nodes.reload_secure_settings](https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings) request
-   *
-   * @param {list} node_id - A comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.
-   * @param {time} timeout - Explicit operation timeout
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -31,6 +25,11 @@ function buildNodesReloadSecureSettings (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a nodes.reload_secure_settings request
+   * Reloads secure settings.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings
+   */
   return function nodesReloadSecureSettings (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -43,12 +42,6 @@ function buildNodesReloadSecureSettings (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -59,10 +52,6 @@ function buildNodesReloadSecureSettings (opts) {
     var { method, body, nodeId, node_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -71,8 +60,10 @@ function buildNodesReloadSecureSettings (opts) {
     var path = ''
 
     if ((node_id || nodeId) != null) {
+      if (method == null) method = 'POST'
       path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'reload_secure_settings'
     } else {
+      if (method == null) method = 'POST'
       path = '/' + '_nodes' + '/' + 'reload_secure_settings'
     }
 
@@ -80,7 +71,7 @@ function buildNodesReloadSecureSettings (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/nodes.stats.js
+++ b/api/api/nodes.stats.js
@@ -10,21 +10,6 @@
 function buildNodesStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [nodes.stats](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html) request
-   *
-   * @param {list} metric - Limit the information returned to the specified metrics
-   * @param {list} index_metric - Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified.
-   * @param {list} node_id - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
-   * @param {list} completion_fields - A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)
-   * @param {list} fielddata_fields - A comma-separated list of fields for `fielddata` index metric (supports wildcards)
-   * @param {list} fields - A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)
-   * @param {boolean} groups - A comma-separated list of search groups for `search` index metric
-   * @param {enum} level - Return indices stats aggregated at index, node or shard level
-   * @param {list} types - A comma-separated list of document types for the `indexing` index metric
-   * @param {time} timeout - Explicit operation timeout
-   * @param {boolean} include_segment_file_sizes - Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)
-   */
 
   const acceptedQuerystring = [
     'completion_fields',
@@ -50,6 +35,11 @@ function buildNodesStats (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a nodes.stats request
+   * Returns statistical information about nodes in the cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html
+   */
   return function nodesStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -62,12 +52,6 @@ function buildNodesStats (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -75,12 +59,8 @@ function buildNodesStats (opts) {
     }
 
     var warnings = []
-    var { method, body, metric, indexMetric, index_metric, nodeId, node_id, ...querystring } = params
+    var { method, body, nodeId, node_id, metric, indexMetric, index_metric, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
-
-    if (method == null) {
-      method = 'GET'
-    }
 
     var ignore = options.ignore
     if (typeof ignore === 'number') {
@@ -90,16 +70,22 @@ function buildNodesStats (opts) {
     var path = ''
 
     if ((node_id || nodeId) != null && (metric) != null && (index_metric || indexMetric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'stats' + '/' + encodeURIComponent(metric) + '/' + encodeURIComponent(index_metric || indexMetric)
     } else if ((node_id || nodeId) != null && (metric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'stats' + '/' + encodeURIComponent(metric)
     } else if ((metric) != null && (index_metric || indexMetric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + 'stats' + '/' + encodeURIComponent(metric) + '/' + encodeURIComponent(index_metric || indexMetric)
     } else if ((node_id || nodeId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'stats'
     } else if ((metric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + 'stats' + '/' + encodeURIComponent(metric)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + 'stats'
     }
 

--- a/api/api/nodes.usage.js
+++ b/api/api/nodes.usage.js
@@ -10,13 +10,6 @@
 function buildNodesUsage (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [nodes.usage](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html) request
-   *
-   * @param {list} metric - Limit the information returned to the specified metrics
-   * @param {list} node_id - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
-   * @param {time} timeout - Explicit operation timeout
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -32,6 +25,11 @@ function buildNodesUsage (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a nodes.usage request
+   * Returns low-level information about REST actions usage on nodes.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html
+   */
   return function nodesUsage (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -44,12 +42,6 @@ function buildNodesUsage (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -57,12 +49,8 @@ function buildNodesUsage (opts) {
     }
 
     var warnings = []
-    var { method, body, metric, nodeId, node_id, ...querystring } = params
+    var { method, body, nodeId, node_id, metric, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
-
-    if (method == null) {
-      method = 'GET'
-    }
 
     var ignore = options.ignore
     if (typeof ignore === 'number') {
@@ -72,12 +60,16 @@ function buildNodesUsage (opts) {
     var path = ''
 
     if ((node_id || nodeId) != null && (metric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'usage' + '/' + encodeURIComponent(metric)
     } else if ((node_id || nodeId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + encodeURIComponent(node_id || nodeId) + '/' + 'usage'
     } else if ((metric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + 'usage' + '/' + encodeURIComponent(metric)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_nodes' + '/' + 'usage'
     }
 

--- a/api/api/ping.js
+++ b/api/api/ping.js
@@ -10,10 +10,6 @@
 function buildPing (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ping](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html) request
-   *
-   */
 
   const acceptedQuerystring = [
     'pretty',
@@ -28,6 +24,11 @@ function buildPing (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a ping request
+   * Returns whether the cluster is running.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+   */
   return function ping (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -40,12 +41,6 @@ function buildPing (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -56,10 +51,6 @@ function buildPing (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'HEAD'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,6 +58,7 @@ function buildPing (opts) {
 
     var path = ''
 
+    if (method == null) method = 'HEAD'
     path = '/'
 
     // build request object

--- a/api/api/put_script.js
+++ b/api/api/put_script.js
@@ -10,16 +10,6 @@
 function buildPutScript (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [put_script](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html) request
-   *
-   * @param {string} id - Script ID
-   * @param {string} context - Script context
-   * @param {time} timeout - Explicit operation timeout
-   * @param {time} master_timeout - Specify timeout for connection to master
-   * @param {string} context - Context name to compile script against
-   * @param {object} body - The document
-   */
 
   const acceptedQuerystring = [
     'timeout',
@@ -38,6 +28,11 @@ function buildPutScript (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a put_script request
+   * Creates or updates a script.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
+   */
   return function putScript (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -76,10 +71,6 @@ function buildPutScript (opts) {
     var { method, body, id, context, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -88,8 +79,10 @@ function buildPutScript (opts) {
     var path = ''
 
     if ((id) != null && (context) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + '_scripts' + '/' + encodeURIComponent(id) + '/' + encodeURIComponent(context)
     } else {
+      if (method == null) method = 'PUT'
       path = '/' + '_scripts' + '/' + encodeURIComponent(id)
     }
 

--- a/api/api/rank_eval.js
+++ b/api/api/rank_eval.js
@@ -10,15 +10,6 @@
 function buildRankEval (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [rank_eval](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {object} body - The ranking evaluation search definition, including search requests, document ratings and ranking metric definition.
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -39,6 +30,11 @@ function buildRankEval (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a rank_eval request
+   * Allows to evaluate the quality of ranked search results over a set of typical search queries
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html
+   */
   return function rankEval (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -67,10 +63,6 @@ function buildRankEval (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -79,8 +71,10 @@ function buildRankEval (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_rank_eval'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_rank_eval'
     }
 

--- a/api/api/reindex.js
+++ b/api/api/reindex.js
@@ -10,19 +10,6 @@
 function buildReindex (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [reindex](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html) request
-   *
-   * @param {boolean} refresh - Should the effected indexes be refreshed?
-   * @param {time} timeout - Time each individual bulk request should wait for shards that are unavailable.
-   * @param {string} wait_for_active_shards - Sets the number of shard copies that must be active before proceeding with the reindex operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-   * @param {boolean} wait_for_completion - Should the request should block until the reindex is complete.
-   * @param {number} requests_per_second - The throttle to set on this request in sub-requests per second. -1 means no throttle.
-   * @param {time} scroll - Control how long to keep the search context alive
-   * @param {number} slices - The number of slices this task should be divided into. Defaults to 1 meaning the task isn't sliced into subtasks.
-   * @param {number} max_docs - Maximum number of documents to process (default: all documents)
-   * @param {object} body - The search definition using the Query DSL and the prototype for the index request.
-   */
 
   const acceptedQuerystring = [
     'refresh',
@@ -49,6 +36,13 @@ function buildReindex (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a reindex request
+   * Allows to copy documents from one index to another, optionally filtering the source
+documents by a query, changing the destination index settings, or fetching the
+documents from a remote cluster.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html
+   */
   return function reindex (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -77,10 +71,6 @@ function buildReindex (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -88,6 +78,7 @@ function buildReindex (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_reindex'
 
     // build request object

--- a/api/api/reindex_rethrottle.js
+++ b/api/api/reindex_rethrottle.js
@@ -10,12 +10,6 @@
 function buildReindexRethrottle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [reindex_rethrottle](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html) request
-   *
-   * @param {string} task_id - The task id to rethrottle
-   * @param {number} requests_per_second - The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
-   */
 
   const acceptedQuerystring = [
     'requests_per_second',
@@ -32,6 +26,11 @@ function buildReindexRethrottle (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a reindex_rethrottle request
+   * Changes the number of requests per second for a particular Reindex operation.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html
+   */
   return function reindexRethrottle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,10 +52,6 @@ function buildReindexRethrottle (opts) {
       const err = new ConfigurationError('Missing required parameter: requests_per_second or requestsPerSecond')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -68,10 +63,6 @@ function buildReindexRethrottle (opts) {
     var { method, body, taskId, task_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -79,13 +70,14 @@ function buildReindexRethrottle (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_reindex' + '/' + encodeURIComponent(task_id || taskId) + '/' + '_rethrottle'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/render_search_template.js
+++ b/api/api/render_search_template.js
@@ -10,12 +10,6 @@
 function buildRenderSearchTemplate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [render_search_template](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#_validating_templates) request
-   *
-   * @param {string} id - The id of the stored search template
-   * @param {object} body - The search definition template and its params
-   */
 
   const acceptedQuerystring = [
     'pretty',
@@ -30,6 +24,11 @@ function buildRenderSearchTemplate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a render_search_template request
+   * Allows to use the Mustache language to pre-render a search definition.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#_validating_templates
+   */
   return function renderSearchTemplate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildRenderSearchTemplate (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,8 +59,10 @@ function buildRenderSearchTemplate (opts) {
     var path = ''
 
     if ((id) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_render' + '/' + 'template' + '/' + encodeURIComponent(id)
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_render' + '/' + 'template'
     }
 

--- a/api/api/rollup.delete_job.js
+++ b/api/api/rollup.delete_job.js
@@ -10,11 +10,6 @@
 function buildRollupDeleteJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [rollup.delete_job]() request
-   *
-   * @param {string} id - The ID of the job to delete
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,9 @@ function buildRollupDeleteJob (opts) {
 
   }
 
+  /**
+   * Perform a rollup.delete_job request
+   */
   return function rollupDeleteJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +50,6 @@ function buildRollupDeleteJob (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +57,7 @@ function buildRollupDeleteJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_rollup' + '/' + 'job' + '/' + encodeURIComponent(id)
 
     // build request object

--- a/api/api/rollup.get_jobs.js
+++ b/api/api/rollup.get_jobs.js
@@ -10,11 +10,6 @@
 function buildRollupGetJobs (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [rollup.get_jobs]() request
-   *
-   * @param {string} id - The ID of the job(s) to fetch. Accepts glob patterns, or left blank for all jobs
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,9 @@ function buildRollupGetJobs (opts) {
 
   }
 
+  /**
+   * Perform a rollup.get_jobs request
+   */
   return function rollupGetJobs (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,10 +44,6 @@ function buildRollupGetJobs (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -58,8 +52,10 @@ function buildRollupGetJobs (opts) {
     var path = ''
 
     if ((id) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_rollup' + '/' + 'job' + '/' + encodeURIComponent(id)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_rollup' + '/' + 'job'
     }
 

--- a/api/api/rollup.get_rollup_caps.js
+++ b/api/api/rollup.get_rollup_caps.js
@@ -10,11 +10,6 @@
 function buildRollupGetRollupCaps (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [rollup.get_rollup_caps]() request
-   *
-   * @param {string} id - The ID of the index to check rollup capabilities on, or left blank for all jobs
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,9 @@ function buildRollupGetRollupCaps (opts) {
 
   }
 
+  /**
+   * Perform a rollup.get_rollup_caps request
+   */
   return function rollupGetRollupCaps (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,10 +44,6 @@ function buildRollupGetRollupCaps (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -58,8 +52,10 @@ function buildRollupGetRollupCaps (opts) {
     var path = ''
 
     if ((id) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_rollup' + '/' + 'data' + '/' + encodeURIComponent(id)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_rollup' + '/' + 'data'
     }
 

--- a/api/api/rollup.get_rollup_index_caps.js
+++ b/api/api/rollup.get_rollup_index_caps.js
@@ -10,11 +10,6 @@
 function buildRollupGetRollupIndexCaps (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [rollup.get_rollup_index_caps]() request
-   *
-   * @param {string} index - The rollup index or index pattern to obtain rollup capabilities from.
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,9 @@ function buildRollupGetRollupIndexCaps (opts) {
 
   }
 
+  /**
+   * Perform a rollup.get_rollup_index_caps request
+   */
   return function rollupGetRollupIndexCaps (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +50,6 @@ function buildRollupGetRollupIndexCaps (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +57,7 @@ function buildRollupGetRollupIndexCaps (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + encodeURIComponent(index) + '/' + '_rollup' + '/' + 'data'
 
     // build request object

--- a/api/api/rollup.put_job.js
+++ b/api/api/rollup.put_job.js
@@ -10,12 +10,6 @@
 function buildRollupPutJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [rollup.put_job]() request
-   *
-   * @param {string} id - The ID of the job to create
-   * @param {object} body - The job configuration
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,9 @@ function buildRollupPutJob (opts) {
 
   }
 
+  /**
+   * Perform a rollup.put_job request
+   */
   return function rollupPutJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,10 +54,6 @@ function buildRollupPutJob (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,6 +61,7 @@ function buildRollupPutJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_rollup' + '/' + 'job' + '/' + encodeURIComponent(id)
 
     // build request object

--- a/api/api/rollup.rollup_search.js
+++ b/api/api/rollup.rollup_search.js
@@ -10,15 +10,6 @@
 function buildRollupRollupSearch (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [rollup.rollup_search]() request
-   *
-   * @param {list} index - The indices or index-pattern(s) (containing rollup or regular data) that should be searched
-   * @param {string} type - The doc type inside the index
-   * @param {boolean} typed_keys - Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-   * @param {boolean} rest_total_hits_as_int - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-   * @param {object} body - The search request body
-   */
 
   const acceptedQuerystring = [
     'typed_keys',
@@ -30,6 +21,9 @@ function buildRollupRollupSearch (opts) {
     restTotalHitsAsInt: 'rest_total_hits_as_int'
   }
 
+  /**
+   * Perform a rollup.rollup_search request
+   */
   return function rollupRollupSearch (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -68,10 +62,6 @@ function buildRollupRollupSearch (opts) {
     var { method, body, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -80,8 +70,10 @@ function buildRollupRollupSearch (opts) {
     var path = ''
 
     if ((index) != null && (type) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + '_rollup_search'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_rollup_search'
     }
 

--- a/api/api/rollup.start_job.js
+++ b/api/api/rollup.start_job.js
@@ -10,11 +10,6 @@
 function buildRollupStartJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [rollup.start_job]() request
-   *
-   * @param {string} id - The ID of the job to start
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,9 @@ function buildRollupStartJob (opts) {
 
   }
 
+  /**
+   * Perform a rollup.start_job request
+   */
   return function rollupStartJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +50,6 @@ function buildRollupStartJob (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +57,7 @@ function buildRollupStartJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_rollup' + '/' + 'job' + '/' + encodeURIComponent(id) + '/' + '_start'
 
     // build request object

--- a/api/api/rollup.stop_job.js
+++ b/api/api/rollup.stop_job.js
@@ -10,13 +10,6 @@
 function buildRollupStopJob (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [rollup.stop_job]() request
-   *
-   * @param {string} id - The ID of the job to stop
-   * @param {boolean} wait_for_completion - True if the API should block until the job has fully stopped, false if should be executed async. Defaults to false.
-   * @param {time} timeout - Block for (at maximum) the specified duration while waiting for the job to stop.  Defaults to 30s.
-   */
 
   const acceptedQuerystring = [
     'wait_for_completion',
@@ -28,6 +21,9 @@ function buildRollupStopJob (opts) {
 
   }
 
+  /**
+   * Perform a rollup.stop_job request
+   */
   return function rollupStopJob (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -56,10 +52,6 @@ function buildRollupStopJob (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,6 +59,7 @@ function buildRollupStopJob (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_rollup' + '/' + 'job' + '/' + encodeURIComponent(id) + '/' + '_stop'
 
     // build request object

--- a/api/api/scripts_painless_execute.js
+++ b/api/api/scripts_painless_execute.js
@@ -10,11 +10,6 @@
 function buildScriptsPainlessExecute (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [scripts_painless_execute](https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html) request
-   *
-   * @param {object} body - The script to execute
-   */
 
   const acceptedQuerystring = [
     'pretty',
@@ -29,6 +24,11 @@ function buildScriptsPainlessExecute (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a scripts_painless_execute request
+   * Allows an arbitrary script to be executed and a result to be returned
+   * https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html
+   */
   return function scriptsPainlessExecute (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -51,10 +51,6 @@ function buildScriptsPainlessExecute (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,6 +58,7 @@ function buildScriptsPainlessExecute (opts) {
 
     var path = ''
 
+    if (method == null) method = body == null ? 'GET' : 'POST'
     path = '/' + '_scripts' + '/' + 'painless' + '/' + '_execute'
 
     // build request object

--- a/api/api/scroll.js
+++ b/api/api/scroll.js
@@ -10,15 +10,6 @@
 function buildScroll (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [scroll](http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll) request
-   *
-   * @param {string} scroll_id - The scroll ID
-   * @param {time} scroll - Specify how long a consistent view of the index should be maintained for scrolled search
-   * @param {string} scroll_id - The scroll ID for scrolled search
-   * @param {boolean} rest_total_hits_as_int - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-   * @param {object} body - The scroll ID if not passed by URL or query parameter.
-   */
 
   const acceptedQuerystring = [
     'scroll',
@@ -38,6 +29,11 @@ function buildScroll (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a scroll request
+   * Allows to retrieve a large numbers of results from a single search request.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll
+   */
   return function scroll (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -60,10 +56,6 @@ function buildScroll (opts) {
     var { method, body, scrollId, scroll_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -72,8 +64,10 @@ function buildScroll (opts) {
     var path = ''
 
     if ((scroll_id || scrollId) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_search' + '/' + 'scroll' + '/' + encodeURIComponent(scroll_id || scrollId)
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_search' + '/' + 'scroll'
     }
 

--- a/api/api/search.js
+++ b/api/api/search.js
@@ -10,54 +10,6 @@
 function buildSearch (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [search](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-   * @param {string} analyzer - The analyzer to use for the query string
-   * @param {boolean} analyze_wildcard - Specify whether wildcard and prefix queries should be analyzed (default: false)
-   * @param {boolean} ccs_minimize_roundtrips - Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-   * @param {enum} default_operator - The default operator for query string query (AND or OR)
-   * @param {string} df - The field to use as default where no field prefix is given in the query string
-   * @param {boolean} explain - Specify whether to return detailed information about score computation as part of a hit
-   * @param {list} stored_fields - A comma-separated list of stored fields to return as part of a hit
-   * @param {list} docvalue_fields - A comma-separated list of fields to return as the docvalue representation of a field for each hit
-   * @param {number} from - Starting offset (default: 0)
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} ignore_throttled - Whether specified concrete, expanded or aliased indices should be ignored when throttled
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} lenient - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {string} q - Query in the Lucene query string syntax
-   * @param {list} routing - A comma-separated list of specific routing values
-   * @param {time} scroll - Specify how long a consistent view of the index should be maintained for scrolled search
-   * @param {enum} search_type - Search operation type
-   * @param {number} size - Number of hits to return (default: 10)
-   * @param {list} sort - A comma-separated list of <field>:<direction> pairs
-   * @param {list} _source - True or false to return the _source field or not, or a list of fields to return
-   * @param {list} _source_excludes - A list of fields to exclude from the returned _source field
-   * @param {list} _source_includes - A list of fields to extract and return from the _source field
-   * @param {number} terminate_after - The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
-   * @param {list} stats - Specific 'tag' of the request for logging and statistical purposes
-   * @param {string} suggest_field - Specify which field to use for suggestions
-   * @param {enum} suggest_mode - Specify suggest mode
-   * @param {number} suggest_size - How many suggestions to return in response
-   * @param {string} suggest_text - The source text for which the suggestions should be returned
-   * @param {time} timeout - Explicit operation timeout
-   * @param {boolean} track_scores - Whether to calculate and return scores even if they are not used for sorting
-   * @param {boolean} track_total_hits - Indicate if the number of documents that match the query should be tracked
-   * @param {boolean} allow_partial_search_results - Indicate if an error should be returned if there is a partial search failure or timeout
-   * @param {boolean} typed_keys - Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-   * @param {boolean} version - Specify whether to return document version as part of a hit
-   * @param {boolean} seq_no_primary_term - Specify whether to return sequence number and primary term of the last modification of each hit
-   * @param {boolean} request_cache - Specify if request cache should be used for this request or not, defaults to index level setting
-   * @param {number} batched_reduce_size - The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.
-   * @param {number} max_concurrent_shard_requests - The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
-   * @param {number} pre_filter_shard_size - A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on it's rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
-   * @param {boolean} rest_total_hits_as_int - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-   * @param {object} body - The search definition using the Query DSL
-   */
 
   const acceptedQuerystring = [
     'analyzer',
@@ -145,6 +97,11 @@ function buildSearch (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a search request
+   * Returns results matching a query.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html
+   */
   return function search (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -167,10 +124,6 @@ function buildSearch (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -179,8 +132,10 @@ function buildSearch (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_search'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_search'
     }
 

--- a/api/api/search_shards.js
+++ b/api/api/search_shards.js
@@ -10,17 +10,6 @@
 function buildSearchShards (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [search_shards](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {string} routing - Specific routing value
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   */
 
   const acceptedQuerystring = [
     'preference',
@@ -44,6 +33,11 @@ function buildSearchShards (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a search_shards request
+   * Returns information about the indices and shards that a search request would be executed against.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html
+   */
   return function searchShards (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -56,12 +50,6 @@ function buildSearchShards (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -72,10 +60,6 @@ function buildSearchShards (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -84,8 +68,10 @@ function buildSearchShards (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_search_shards'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_search_shards'
     }
 
@@ -93,7 +79,7 @@ function buildSearchShards (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/search_template.js
+++ b/api/api/search_template.js
@@ -10,25 +10,6 @@
 function buildSearchTemplate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [search_template](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} ignore_throttled - Whether specified concrete, expanded or aliased indices should be ignored when throttled
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {list} routing - A comma-separated list of specific routing values
-   * @param {time} scroll - Specify how long a consistent view of the index should be maintained for scrolled search
-   * @param {enum} search_type - Search operation type
-   * @param {boolean} explain - Specify whether to return detailed information about score computation as part of a hit
-   * @param {boolean} profile - Specify whether to profile the query execution
-   * @param {boolean} typed_keys - Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-   * @param {boolean} rest_total_hits_as_int - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-   * @param {boolean} ccs_minimize_roundtrips - Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-   * @param {object} body - The search definition template and its params
-   */
 
   const acceptedQuerystring = [
     'ignore_unavailable',
@@ -64,6 +45,11 @@ function buildSearchTemplate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a search_template request
+   * Allows to use the Mustache language to pre-render a search definition.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html
+   */
   return function searchTemplate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -92,10 +78,6 @@ function buildSearchTemplate (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -104,8 +86,10 @@ function buildSearchTemplate (opts) {
     var path = ''
 
     if ((index) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_search' + '/' + 'template'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_search' + '/' + 'template'
     }
 

--- a/api/api/security.authenticate.js
+++ b/api/api/security.authenticate.js
@@ -10,10 +10,6 @@
 function buildSecurityAuthenticate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.authenticate](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildSecurityAuthenticate (opts) {
 
   }
 
+  /**
+   * Perform a security.authenticate request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html
+   */
   return function securityAuthenticate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildSecurityAuthenticate (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildSecurityAuthenticate (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,6 +52,7 @@ function buildSecurityAuthenticate (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_security' + '/' + '_authenticate'
 
     // build request object

--- a/api/api/security.change_password.js
+++ b/api/api/security.change_password.js
@@ -10,13 +10,6 @@
 function buildSecurityChangePassword (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.change_password](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html) request
-   *
-   * @param {string} username - The username of the user to change the password for
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   * @param {object} body - the new password for the user
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -26,6 +19,10 @@ function buildSecurityChangePassword (opts) {
 
   }
 
+  /**
+   * Perform a security.change_password request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html
+   */
   return function securityChangePassword (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -54,10 +51,6 @@ function buildSecurityChangePassword (opts) {
     var { method, body, username, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -66,8 +59,10 @@ function buildSecurityChangePassword (opts) {
     var path = ''
 
     if ((username) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + '_security' + '/' + 'user' + '/' + encodeURIComponent(username) + '/' + '_password'
     } else {
+      if (method == null) method = 'PUT'
       path = '/' + '_security' + '/' + 'user' + '/' + '_password'
     }
 

--- a/api/api/security.clear_cached_realms.js
+++ b/api/api/security.clear_cached_realms.js
@@ -10,12 +10,6 @@
 function buildSecurityClearCachedRealms (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.clear_cached_realms](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html) request
-   *
-   * @param {list} realms - Comma-separated list of realms to clear
-   * @param {list} usernames - Comma-separated list of usernames to clear from the cache
-   */
 
   const acceptedQuerystring = [
     'usernames'
@@ -25,6 +19,10 @@ function buildSecurityClearCachedRealms (opts) {
 
   }
 
+  /**
+   * Perform a security.clear_cached_realms request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html
+   */
   return function securityClearCachedRealms (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,10 +40,6 @@ function buildSecurityClearCachedRealms (opts) {
       const err = new ConfigurationError('Missing required parameter: realms')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -57,10 +51,6 @@ function buildSecurityClearCachedRealms (opts) {
     var { method, body, realms, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,13 +58,14 @@ function buildSecurityClearCachedRealms (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_security' + '/' + 'realm' + '/' + encodeURIComponent(realms) + '/' + '_clear_cache'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/security.clear_cached_roles.js
+++ b/api/api/security.clear_cached_roles.js
@@ -10,11 +10,6 @@
 function buildSecurityClearCachedRoles (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.clear_cached_roles](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html) request
-   *
-   * @param {list} name - Role name
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSecurityClearCachedRoles (opts) {
 
   }
 
+  /**
+   * Perform a security.clear_cached_roles request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html
+   */
   return function securityClearCachedRoles (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,10 +40,6 @@ function buildSecurityClearCachedRoles (opts) {
       const err = new ConfigurationError('Missing required parameter: name')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -56,10 +51,6 @@ function buildSecurityClearCachedRoles (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,13 +58,14 @@ function buildSecurityClearCachedRoles (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_security' + '/' + 'role' + '/' + encodeURIComponent(name) + '/' + '_clear_cache'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/security.create_api_key.js
+++ b/api/api/security.create_api_key.js
@@ -10,12 +10,6 @@
 function buildSecurityCreateApiKey (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.create_api_key](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html) request
-   *
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   * @param {object} body - The api key request to create an API key
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -25,6 +19,10 @@ function buildSecurityCreateApiKey (opts) {
 
   }
 
+  /**
+   * Perform a security.create_api_key request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
+   */
   return function securityCreateApiKey (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,10 +51,6 @@ function buildSecurityCreateApiKey (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,6 +58,7 @@ function buildSecurityCreateApiKey (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_security' + '/' + 'api_key'
 
     // build request object

--- a/api/api/security.delete_privileges.js
+++ b/api/api/security.delete_privileges.js
@@ -10,13 +10,6 @@
 function buildSecurityDeletePrivileges (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.delete_privileges](TODO) request
-   *
-   * @param {string} application - Application name
-   * @param {string} name - Privilege name
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -26,6 +19,10 @@ function buildSecurityDeletePrivileges (opts) {
 
   }
 
+  /**
+   * Perform a security.delete_privileges request
+   * TODO
+   */
   return function securityDeletePrivileges (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -47,10 +44,6 @@ function buildSecurityDeletePrivileges (opts) {
       const err = new ConfigurationError('Missing required parameter: name')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // check required url components
     if (params['name'] != null && (params['application'] == null)) {
@@ -68,10 +61,6 @@ function buildSecurityDeletePrivileges (opts) {
     var { method, body, application, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -79,13 +68,14 @@ function buildSecurityDeletePrivileges (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_security' + '/' + 'privilege' + '/' + encodeURIComponent(application) + '/' + encodeURIComponent(name)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/security.delete_role.js
+++ b/api/api/security.delete_role.js
@@ -10,12 +10,6 @@
 function buildSecurityDeleteRole (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.delete_role](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html) request
-   *
-   * @param {string} name - Role name
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -25,6 +19,10 @@ function buildSecurityDeleteRole (opts) {
 
   }
 
+  /**
+   * Perform a security.delete_role request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html
+   */
   return function securityDeleteRole (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,10 +40,6 @@ function buildSecurityDeleteRole (opts) {
       const err = new ConfigurationError('Missing required parameter: name')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -57,10 +51,6 @@ function buildSecurityDeleteRole (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,13 +58,14 @@ function buildSecurityDeleteRole (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_security' + '/' + 'role' + '/' + encodeURIComponent(name)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/security.delete_role_mapping.js
+++ b/api/api/security.delete_role_mapping.js
@@ -10,12 +10,6 @@
 function buildSecurityDeleteRoleMapping (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.delete_role_mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html) request
-   *
-   * @param {string} name - Role-mapping name
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -25,6 +19,10 @@ function buildSecurityDeleteRoleMapping (opts) {
 
   }
 
+  /**
+   * Perform a security.delete_role_mapping request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html
+   */
   return function securityDeleteRoleMapping (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,10 +40,6 @@ function buildSecurityDeleteRoleMapping (opts) {
       const err = new ConfigurationError('Missing required parameter: name')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -57,10 +51,6 @@ function buildSecurityDeleteRoleMapping (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,13 +58,14 @@ function buildSecurityDeleteRoleMapping (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_security' + '/' + 'role_mapping' + '/' + encodeURIComponent(name)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/security.delete_user.js
+++ b/api/api/security.delete_user.js
@@ -10,12 +10,6 @@
 function buildSecurityDeleteUser (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.delete_user](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html) request
-   *
-   * @param {string} username - username
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -25,6 +19,10 @@ function buildSecurityDeleteUser (opts) {
 
   }
 
+  /**
+   * Perform a security.delete_user request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html
+   */
   return function securityDeleteUser (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,10 +40,6 @@ function buildSecurityDeleteUser (opts) {
       const err = new ConfigurationError('Missing required parameter: username')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -57,10 +51,6 @@ function buildSecurityDeleteUser (opts) {
     var { method, body, username, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,13 +58,14 @@ function buildSecurityDeleteUser (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_security' + '/' + 'user' + '/' + encodeURIComponent(username)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/security.disable_user.js
+++ b/api/api/security.disable_user.js
@@ -10,12 +10,6 @@
 function buildSecurityDisableUser (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.disable_user](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html) request
-   *
-   * @param {string} username - The username of the user to disable
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -25,6 +19,10 @@ function buildSecurityDisableUser (opts) {
 
   }
 
+  /**
+   * Perform a security.disable_user request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html
+   */
   return function securityDisableUser (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,10 +40,6 @@ function buildSecurityDisableUser (opts) {
       const err = new ConfigurationError('Missing required parameter: username')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -57,10 +51,6 @@ function buildSecurityDisableUser (opts) {
     var { method, body, username, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,13 +58,14 @@ function buildSecurityDisableUser (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_security' + '/' + 'user' + '/' + encodeURIComponent(username) + '/' + '_disable'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/security.enable_user.js
+++ b/api/api/security.enable_user.js
@@ -10,12 +10,6 @@
 function buildSecurityEnableUser (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.enable_user](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html) request
-   *
-   * @param {string} username - The username of the user to enable
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -25,6 +19,10 @@ function buildSecurityEnableUser (opts) {
 
   }
 
+  /**
+   * Perform a security.enable_user request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html
+   */
   return function securityEnableUser (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,10 +40,6 @@ function buildSecurityEnableUser (opts) {
       const err = new ConfigurationError('Missing required parameter: username')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -57,10 +51,6 @@ function buildSecurityEnableUser (opts) {
     var { method, body, username, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -68,13 +58,14 @@ function buildSecurityEnableUser (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_security' + '/' + 'user' + '/' + encodeURIComponent(username) + '/' + '_enable'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/security.get_api_key.js
+++ b/api/api/security.get_api_key.js
@@ -10,14 +10,6 @@
 function buildSecurityGetApiKey (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.get_api_key](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html) request
-   *
-   * @param {string} id - API key id of the API key to be retrieved
-   * @param {string} name - API key name of the API key to be retrieved
-   * @param {string} username - user name of the user who created this API key to be retrieved
-   * @param {string} realm_name - realm name of the user who created this API key to be retrieved
-   */
 
   const acceptedQuerystring = [
     'id',
@@ -30,6 +22,10 @@ function buildSecurityGetApiKey (opts) {
     realmName: 'realm_name'
   }
 
+  /**
+   * Perform a security.get_api_key request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html
+   */
   return function securityGetApiKey (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -42,12 +38,6 @@ function buildSecurityGetApiKey (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -58,10 +48,6 @@ function buildSecurityGetApiKey (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,6 +55,7 @@ function buildSecurityGetApiKey (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_security' + '/' + 'api_key'
 
     // build request object

--- a/api/api/security.get_builtin_privileges.js
+++ b/api/api/security.get_builtin_privileges.js
@@ -10,10 +10,6 @@
 function buildSecurityGetBuiltinPrivileges (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.get_builtin_privileges](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildSecurityGetBuiltinPrivileges (opts) {
 
   }
 
+  /**
+   * Perform a security.get_builtin_privileges request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html
+   */
   return function securityGetBuiltinPrivileges (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildSecurityGetBuiltinPrivileges (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildSecurityGetBuiltinPrivileges (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,6 +52,7 @@ function buildSecurityGetBuiltinPrivileges (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_security' + '/' + 'privilege' + '/' + '_builtin'
 
     // build request object

--- a/api/api/security.get_privileges.js
+++ b/api/api/security.get_privileges.js
@@ -10,12 +10,6 @@
 function buildSecurityGetPrivileges (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.get_privileges](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html) request
-   *
-   * @param {string} application - Application name
-   * @param {string} name - Privilege name
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildSecurityGetPrivileges (opts) {
 
   }
 
+  /**
+   * Perform a security.get_privileges request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html
+   */
   return function securityGetPrivileges (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +33,6 @@ function buildSecurityGetPrivileges (opts) {
       callback = params
       params = {}
       options = {}
-    }
-
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
     }
 
     // check required url components
@@ -59,10 +51,6 @@ function buildSecurityGetPrivileges (opts) {
     var { method, body, application, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -71,10 +59,13 @@ function buildSecurityGetPrivileges (opts) {
     var path = ''
 
     if ((application) != null && (name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_security' + '/' + 'privilege' + '/' + encodeURIComponent(application) + '/' + encodeURIComponent(name)
     } else if ((application) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_security' + '/' + 'privilege' + '/' + encodeURIComponent(application)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_security' + '/' + 'privilege'
     }
 

--- a/api/api/security.get_role.js
+++ b/api/api/security.get_role.js
@@ -10,11 +10,6 @@
 function buildSecurityGetRole (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.get_role](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html) request
-   *
-   * @param {string} name - Role name
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSecurityGetRole (opts) {
 
   }
 
+  /**
+   * Perform a security.get_role request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html
+   */
   return function securityGetRole (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,12 +35,6 @@ function buildSecurityGetRole (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -52,10 +45,6 @@ function buildSecurityGetRole (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,8 +53,10 @@ function buildSecurityGetRole (opts) {
     var path = ''
 
     if ((name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_security' + '/' + 'role' + '/' + encodeURIComponent(name)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_security' + '/' + 'role'
     }
 

--- a/api/api/security.get_role_mapping.js
+++ b/api/api/security.get_role_mapping.js
@@ -10,11 +10,6 @@
 function buildSecurityGetRoleMapping (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.get_role_mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html) request
-   *
-   * @param {string} name - Role-Mapping name
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSecurityGetRoleMapping (opts) {
 
   }
 
+  /**
+   * Perform a security.get_role_mapping request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html
+   */
   return function securityGetRoleMapping (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,12 +35,6 @@ function buildSecurityGetRoleMapping (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -52,10 +45,6 @@ function buildSecurityGetRoleMapping (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,8 +53,10 @@ function buildSecurityGetRoleMapping (opts) {
     var path = ''
 
     if ((name) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_security' + '/' + 'role_mapping' + '/' + encodeURIComponent(name)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_security' + '/' + 'role_mapping'
     }
 

--- a/api/api/security.get_token.js
+++ b/api/api/security.get_token.js
@@ -10,11 +10,6 @@
 function buildSecurityGetToken (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.get_token](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html) request
-   *
-   * @param {object} body - The token request to get
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSecurityGetToken (opts) {
 
   }
 
+  /**
+   * Perform a security.get_token request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html
+   */
   return function securityGetToken (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildSecurityGetToken (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildSecurityGetToken (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_security' + '/' + 'oauth2' + '/' + 'token'
 
     // build request object

--- a/api/api/security.get_user.js
+++ b/api/api/security.get_user.js
@@ -10,11 +10,6 @@
 function buildSecurityGetUser (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.get_user](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html) request
-   *
-   * @param {list} username - A comma-separated list of usernames
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSecurityGetUser (opts) {
 
   }
 
+  /**
+   * Perform a security.get_user request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html
+   */
   return function securityGetUser (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,12 +35,6 @@ function buildSecurityGetUser (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -52,10 +45,6 @@ function buildSecurityGetUser (opts) {
     var { method, body, username, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,8 +53,10 @@ function buildSecurityGetUser (opts) {
     var path = ''
 
     if ((username) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_security' + '/' + 'user' + '/' + encodeURIComponent(username)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_security' + '/' + 'user'
     }
 

--- a/api/api/security.get_user_privileges.js
+++ b/api/api/security.get_user_privileges.js
@@ -10,10 +10,6 @@
 function buildSecurityGetUserPrivileges (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.get_user_privileges](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildSecurityGetUserPrivileges (opts) {
 
   }
 
+  /**
+   * Perform a security.get_user_privileges request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html
+   */
   return function securityGetUserPrivileges (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildSecurityGetUserPrivileges (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildSecurityGetUserPrivileges (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,6 +52,7 @@ function buildSecurityGetUserPrivileges (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_security' + '/' + 'user' + '/' + '_privileges'
 
     // build request object

--- a/api/api/security.has_privileges.js
+++ b/api/api/security.has_privileges.js
@@ -10,12 +10,6 @@
 function buildSecurityHasPrivileges (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.has_privileges](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html) request
-   *
-   * @param {string} user - Username
-   * @param {object} body - The privileges to test
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildSecurityHasPrivileges (opts) {
 
   }
 
+  /**
+   * Perform a security.has_privileges request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html
+   */
   return function securityHasPrivileges (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,10 +51,6 @@ function buildSecurityHasPrivileges (opts) {
     var { method, body, user, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -65,8 +59,10 @@ function buildSecurityHasPrivileges (opts) {
     var path = ''
 
     if ((user) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_security' + '/' + 'user' + '/' + encodeURIComponent(user) + '/' + '_has_privileges'
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + '_security' + '/' + 'user' + '/' + '_has_privileges'
     }
 

--- a/api/api/security.invalidate_api_key.js
+++ b/api/api/security.invalidate_api_key.js
@@ -10,11 +10,6 @@
 function buildSecurityInvalidateApiKey (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.invalidate_api_key](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html) request
-   *
-   * @param {object} body - The api key request to invalidate API key(s)
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSecurityInvalidateApiKey (opts) {
 
   }
 
+  /**
+   * Perform a security.invalidate_api_key request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html
+   */
   return function securityInvalidateApiKey (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildSecurityInvalidateApiKey (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildSecurityInvalidateApiKey (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_security' + '/' + 'api_key'
 
     // build request object

--- a/api/api/security.invalidate_token.js
+++ b/api/api/security.invalidate_token.js
@@ -10,11 +10,6 @@
 function buildSecurityInvalidateToken (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.invalidate_token](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html) request
-   *
-   * @param {object} body - The token to invalidate
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSecurityInvalidateToken (opts) {
 
   }
 
+  /**
+   * Perform a security.invalidate_token request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html
+   */
   return function securityInvalidateToken (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildSecurityInvalidateToken (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildSecurityInvalidateToken (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_security' + '/' + 'oauth2' + '/' + 'token'
 
     // build request object

--- a/api/api/security.put_privileges.js
+++ b/api/api/security.put_privileges.js
@@ -10,12 +10,6 @@
 function buildSecurityPutPrivileges (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.put_privileges](TODO) request
-   *
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   * @param {object} body - The privilege(s) to add
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -25,6 +19,10 @@ function buildSecurityPutPrivileges (opts) {
 
   }
 
+  /**
+   * Perform a security.put_privileges request
+   * TODO
+   */
   return function securityPutPrivileges (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,10 +51,6 @@ function buildSecurityPutPrivileges (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,6 +58,7 @@ function buildSecurityPutPrivileges (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_security' + '/' + 'privilege'
 
     // build request object

--- a/api/api/security.put_role.js
+++ b/api/api/security.put_role.js
@@ -10,13 +10,6 @@
 function buildSecurityPutRole (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.put_role](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html) request
-   *
-   * @param {string} name - Role name
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   * @param {object} body - The role to add
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -26,6 +19,10 @@ function buildSecurityPutRole (opts) {
 
   }
 
+  /**
+   * Perform a security.put_role request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html
+   */
   return function securityPutRole (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,10 +55,6 @@ function buildSecurityPutRole (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,6 +62,7 @@ function buildSecurityPutRole (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_security' + '/' + 'role' + '/' + encodeURIComponent(name)
 
     // build request object

--- a/api/api/security.put_role_mapping.js
+++ b/api/api/security.put_role_mapping.js
@@ -10,13 +10,6 @@
 function buildSecurityPutRoleMapping (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.put_role_mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html) request
-   *
-   * @param {string} name - Role-mapping name
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   * @param {object} body - The role mapping to add
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -26,6 +19,10 @@ function buildSecurityPutRoleMapping (opts) {
 
   }
 
+  /**
+   * Perform a security.put_role_mapping request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html
+   */
   return function securityPutRoleMapping (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,10 +55,6 @@ function buildSecurityPutRoleMapping (opts) {
     var { method, body, name, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,6 +62,7 @@ function buildSecurityPutRoleMapping (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_security' + '/' + 'role_mapping' + '/' + encodeURIComponent(name)
 
     // build request object

--- a/api/api/security.put_user.js
+++ b/api/api/security.put_user.js
@@ -10,13 +10,6 @@
 function buildSecurityPutUser (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [security.put_user](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html) request
-   *
-   * @param {string} username - The username of the User
-   * @param {enum} refresh - If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
-   * @param {object} body - The user to add
-   */
 
   const acceptedQuerystring = [
     'refresh'
@@ -26,6 +19,10 @@ function buildSecurityPutUser (opts) {
 
   }
 
+  /**
+   * Perform a security.put_user request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html
+   */
   return function securityPutUser (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -58,10 +55,6 @@ function buildSecurityPutUser (opts) {
     var { method, body, username, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -69,6 +62,7 @@ function buildSecurityPutUser (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_security' + '/' + 'user' + '/' + encodeURIComponent(username)
 
     // build request object

--- a/api/api/slm.delete_lifecycle.js
+++ b/api/api/slm.delete_lifecycle.js
@@ -10,11 +10,6 @@
 function buildSlmDeleteLifecycle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [slm.delete_lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete.html) request
-   *
-   * @param {string} policy_id - The id of the snapshot lifecycle policy to remove
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSlmDeleteLifecycle (opts) {
 
   }
 
+  /**
+   * Perform a slm.delete_lifecycle request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete.html
+   */
   return function slmDeleteLifecycle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,8 +36,8 @@ function buildSlmDeleteLifecycle (opts) {
     }
 
     // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
+    if (params['policy_id'] == null && params['policyId'] == null) {
+      const err = new ConfigurationError('Missing required parameter: policy_id or policyId')
       return handleError(err, callback)
     }
 
@@ -52,10 +51,6 @@ function buildSlmDeleteLifecycle (opts) {
     var { method, body, policyId, policy_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,13 +58,14 @@ function buildSlmDeleteLifecycle (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_slm' + '/' + 'policy' + '/' + encodeURIComponent(policy_id || policyId)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/slm.execute_lifecycle.js
+++ b/api/api/slm.execute_lifecycle.js
@@ -10,11 +10,6 @@
 function buildSlmExecuteLifecycle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [slm.execute_lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html) request
-   *
-   * @param {string} policy_id - The id of the snapshot lifecycle policy to be executed
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSlmExecuteLifecycle (opts) {
 
   }
 
+  /**
+   * Perform a slm.execute_lifecycle request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html
+   */
   return function slmExecuteLifecycle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,8 +36,8 @@ function buildSlmExecuteLifecycle (opts) {
     }
 
     // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
+    if (params['policy_id'] == null && params['policyId'] == null) {
+      const err = new ConfigurationError('Missing required parameter: policy_id or policyId')
       return handleError(err, callback)
     }
 
@@ -52,10 +51,6 @@ function buildSlmExecuteLifecycle (opts) {
     var { method, body, policyId, policy_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,13 +58,14 @@ function buildSlmExecuteLifecycle (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_slm' + '/' + 'policy' + '/' + encodeURIComponent(policy_id || policyId) + '/' + '_execute'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/slm.get_lifecycle.js
+++ b/api/api/slm.get_lifecycle.js
@@ -10,11 +10,6 @@
 function buildSlmGetLifecycle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [slm.get_lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get.html) request
-   *
-   * @param {string} policy_id - Comma-separated list of snapshot lifecycle policies to retrieve
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSlmGetLifecycle (opts) {
 
   }
 
+  /**
+   * Perform a slm.get_lifecycle request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get.html
+   */
   return function slmGetLifecycle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,12 +35,6 @@ function buildSlmGetLifecycle (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -52,10 +45,6 @@ function buildSlmGetLifecycle (opts) {
     var { method, body, policyId, policy_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,8 +53,10 @@ function buildSlmGetLifecycle (opts) {
     var path = ''
 
     if ((policy_id || policyId) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_slm' + '/' + 'policy' + '/' + encodeURIComponent(policy_id || policyId)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_slm' + '/' + 'policy'
     }
 

--- a/api/api/slm.get_stats.js
+++ b/api/api/slm.get_stats.js
@@ -7,7 +7,7 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
-function buildMlUpdateFilter (opts) {
+function buildSlmGetStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
 
@@ -20,9 +20,10 @@ function buildMlUpdateFilter (opts) {
   }
 
   /**
-   * Perform a ml.update_filter request
+   * Perform a slm.get_stats request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api.html
    */
-  return function mlUpdateFilter (params, options, callback) {
+  return function slmGetStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
       callback = options
@@ -34,16 +35,6 @@ function buildMlUpdateFilter (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params['filter_id'] == null && params['filterId'] == null) {
-      const err = new ConfigurationError('Missing required parameter: filter_id or filterId')
-      return handleError(err, callback)
-    }
-    if (params['body'] == null) {
-      const err = new ConfigurationError('Missing required parameter: body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,7 +42,7 @@ function buildMlUpdateFilter (opts) {
     }
 
     var warnings = []
-    var { method, body, filterId, filter_id, ...querystring } = params
+    var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
     var ignore = options.ignore
@@ -61,14 +52,14 @@ function buildMlUpdateFilter (opts) {
 
     var path = ''
 
-    if (method == null) method = 'POST'
-    path = '/' + '_ml' + '/' + 'filters' + '/' + encodeURIComponent(filter_id || filterId) + '/' + '_update'
+    if (method == null) method = 'GET'
+    path = '/' + '_slm' + '/' + 'stats'
 
     // build request object
     const request = {
       method,
       path,
-      body: body || '',
+      body: null,
       querystring
     }
 
@@ -77,4 +68,4 @@ function buildMlUpdateFilter (opts) {
   }
 }
 
-module.exports = buildMlUpdateFilter
+module.exports = buildSlmGetStats

--- a/api/api/slm.put_lifecycle.js
+++ b/api/api/slm.put_lifecycle.js
@@ -10,12 +10,6 @@
 function buildSlmPutLifecycle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [slm.put_lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-put.html) request
-   *
-   * @param {string} policy_id - The id of the snapshot lifecycle policy
-   * @param {object} body - The snapshot lifecycle policy definition to register
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildSlmPutLifecycle (opts) {
 
   }
 
+  /**
+   * Perform a slm.put_lifecycle request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-put.html
+   */
   return function slmPutLifecycle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -37,6 +35,12 @@ function buildSlmPutLifecycle (opts) {
       options = {}
     }
 
+    // check required parameters
+    if (params['policy_id'] == null && params['policyId'] == null) {
+      const err = new ConfigurationError('Missing required parameter: policy_id or policyId')
+      return handleError(err, callback)
+    }
+
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -47,10 +51,6 @@ function buildSlmPutLifecycle (opts) {
     var { method, body, policyId, policy_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -58,6 +58,7 @@ function buildSlmPutLifecycle (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_slm' + '/' + 'policy' + '/' + encodeURIComponent(policy_id || policyId)
 
     // build request object

--- a/api/api/snapshot.cleanup_repository.js
+++ b/api/api/snapshot.cleanup_repository.js
@@ -7,22 +7,32 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
-function buildMlUpdateFilter (opts) {
+function buildSnapshotCleanupRepository (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
 
   const acceptedQuerystring = [
-
+    'master_timeout',
+    'timeout',
+    'pretty',
+    'human',
+    'error_trace',
+    'source',
+    'filter_path'
   ]
 
   const snakeCase = {
-
+    masterTimeout: 'master_timeout',
+    errorTrace: 'error_trace',
+    filterPath: 'filter_path'
   }
 
   /**
-   * Perform a ml.update_filter request
+   * Perform a snapshot.cleanup_repository request
+   * Removes stale data from repository.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
    */
-  return function mlUpdateFilter (params, options, callback) {
+  return function snapshotCleanupRepository (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
       callback = options
@@ -35,12 +45,8 @@ function buildMlUpdateFilter (opts) {
     }
 
     // check required parameters
-    if (params['filter_id'] == null && params['filterId'] == null) {
-      const err = new ConfigurationError('Missing required parameter: filter_id or filterId')
-      return handleError(err, callback)
-    }
-    if (params['body'] == null) {
-      const err = new ConfigurationError('Missing required parameter: body')
+    if (params['repository'] == null) {
+      const err = new ConfigurationError('Missing required parameter: repository')
       return handleError(err, callback)
     }
 
@@ -51,7 +57,7 @@ function buildMlUpdateFilter (opts) {
     }
 
     var warnings = []
-    var { method, body, filterId, filter_id, ...querystring } = params
+    var { method, body, repository, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
     var ignore = options.ignore
@@ -62,7 +68,7 @@ function buildMlUpdateFilter (opts) {
     var path = ''
 
     if (method == null) method = 'POST'
-    path = '/' + '_ml' + '/' + 'filters' + '/' + encodeURIComponent(filter_id || filterId) + '/' + '_update'
+    path = '/' + '_snapshot' + '/' + encodeURIComponent(repository) + '/' + '_cleanup'
 
     // build request object
     const request = {
@@ -77,4 +83,4 @@ function buildMlUpdateFilter (opts) {
   }
 }
 
-module.exports = buildMlUpdateFilter
+module.exports = buildSnapshotCleanupRepository

--- a/api/api/snapshot.create.js
+++ b/api/api/snapshot.create.js
@@ -10,15 +10,6 @@
 function buildSnapshotCreate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [snapshot.create](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html) request
-   *
-   * @param {string} repository - A repository name
-   * @param {string} snapshot - A snapshot name
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {boolean} wait_for_completion - Should this request wait until the operation has completed before returning
-   * @param {object} body - The snapshot definition
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -37,6 +28,11 @@ function buildSnapshotCreate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a snapshot.create request
+   * Creates a snapshot in a repository.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
+   */
   return function snapshotCreate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -75,10 +71,6 @@ function buildSnapshotCreate (opts) {
     var { method, body, repository, snapshot, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -86,6 +78,7 @@ function buildSnapshotCreate (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_snapshot' + '/' + encodeURIComponent(repository) + '/' + encodeURIComponent(snapshot)
 
     // build request object

--- a/api/api/snapshot.create_repository.js
+++ b/api/api/snapshot.create_repository.js
@@ -10,15 +10,6 @@
 function buildSnapshotCreateRepository (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [snapshot.create_repository](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html) request
-   *
-   * @param {string} repository - A repository name
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {time} timeout - Explicit operation timeout
-   * @param {boolean} verify - Whether to verify the repository after creation
-   * @param {object} body - The repository definition
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -37,6 +28,11 @@ function buildSnapshotCreateRepository (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a snapshot.create_repository request
+   * Creates a repository.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
+   */
   return function snapshotCreateRepository (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -69,10 +65,6 @@ function buildSnapshotCreateRepository (opts) {
     var { method, body, repository, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -80,6 +72,7 @@ function buildSnapshotCreateRepository (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_snapshot' + '/' + encodeURIComponent(repository)
 
     // build request object

--- a/api/api/snapshot.delete.js
+++ b/api/api/snapshot.delete.js
@@ -10,13 +10,6 @@
 function buildSnapshotDelete (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [snapshot.delete](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html) request
-   *
-   * @param {string} repository - A repository name
-   * @param {string} snapshot - A snapshot name
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -33,6 +26,11 @@ function buildSnapshotDelete (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a snapshot.delete request
+   * Deletes a snapshot.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
+   */
   return function snapshotDelete (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -54,10 +52,6 @@ function buildSnapshotDelete (opts) {
       const err = new ConfigurationError('Missing required parameter: snapshot')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // check required url components
     if (params['snapshot'] != null && (params['repository'] == null)) {
@@ -75,10 +69,6 @@ function buildSnapshotDelete (opts) {
     var { method, body, repository, snapshot, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -86,13 +76,14 @@ function buildSnapshotDelete (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_snapshot' + '/' + encodeURIComponent(repository) + '/' + encodeURIComponent(snapshot)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/snapshot.delete_repository.js
+++ b/api/api/snapshot.delete_repository.js
@@ -10,13 +10,6 @@
 function buildSnapshotDeleteRepository (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [snapshot.delete_repository](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html) request
-   *
-   * @param {list} repository - A comma-separated list of repository names
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {time} timeout - Explicit operation timeout
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -34,6 +27,11 @@ function buildSnapshotDeleteRepository (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a snapshot.delete_repository request
+   * Deletes a repository.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
+   */
   return function snapshotDeleteRepository (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -51,10 +49,6 @@ function buildSnapshotDeleteRepository (opts) {
       const err = new ConfigurationError('Missing required parameter: repository')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -66,10 +60,6 @@ function buildSnapshotDeleteRepository (opts) {
     var { method, body, repository, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -77,13 +67,14 @@ function buildSnapshotDeleteRepository (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_snapshot' + '/' + encodeURIComponent(repository)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/snapshot.get.js
+++ b/api/api/snapshot.get.js
@@ -10,15 +10,6 @@
 function buildSnapshotGet (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [snapshot.get](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html) request
-   *
-   * @param {string} repository - A repository name
-   * @param {list} snapshot - A comma-separated list of snapshot names
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {boolean} ignore_unavailable - Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown
-   * @param {boolean} verbose - Whether to show verbose snapshot info or only show the basic info found in the repository index blob
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -38,6 +29,11 @@ function buildSnapshotGet (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a snapshot.get request
+   * Returns information about a snapshot.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
+   */
   return function snapshotGet (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -59,10 +55,6 @@ function buildSnapshotGet (opts) {
       const err = new ConfigurationError('Missing required parameter: snapshot')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // check required url components
     if (params['snapshot'] != null && (params['repository'] == null)) {
@@ -80,10 +72,6 @@ function buildSnapshotGet (opts) {
     var { method, body, repository, snapshot, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -91,6 +79,7 @@ function buildSnapshotGet (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_snapshot' + '/' + encodeURIComponent(repository) + '/' + encodeURIComponent(snapshot)
 
     // build request object

--- a/api/api/snapshot.get_repository.js
+++ b/api/api/snapshot.get_repository.js
@@ -10,13 +10,6 @@
 function buildSnapshotGetRepository (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [snapshot.get_repository](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html) request
-   *
-   * @param {list} repository - A comma-separated list of repository names
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {boolean} local - Return local information, do not retrieve the state from master node (default: false)
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -34,6 +27,11 @@ function buildSnapshotGetRepository (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a snapshot.get_repository request
+   * Returns information about a repository.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
+   */
   return function snapshotGetRepository (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,12 +44,6 @@ function buildSnapshotGetRepository (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -62,10 +54,6 @@ function buildSnapshotGetRepository (opts) {
     var { method, body, repository, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -74,8 +62,10 @@ function buildSnapshotGetRepository (opts) {
     var path = ''
 
     if ((repository) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_snapshot' + '/' + encodeURIComponent(repository)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_snapshot'
     }
 

--- a/api/api/snapshot.restore.js
+++ b/api/api/snapshot.restore.js
@@ -10,15 +10,6 @@
 function buildSnapshotRestore (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [snapshot.restore](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html) request
-   *
-   * @param {string} repository - A repository name
-   * @param {string} snapshot - A snapshot name
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {boolean} wait_for_completion - Should this request wait until the operation has completed before returning
-   * @param {object} body - Details of what to restore
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -37,6 +28,11 @@ function buildSnapshotRestore (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a snapshot.restore request
+   * Restores a snapshot.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
+   */
   return function snapshotRestore (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -75,10 +71,6 @@ function buildSnapshotRestore (opts) {
     var { method, body, repository, snapshot, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -86,6 +78,7 @@ function buildSnapshotRestore (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_snapshot' + '/' + encodeURIComponent(repository) + '/' + encodeURIComponent(snapshot) + '/' + '_restore'
 
     // build request object

--- a/api/api/snapshot.status.js
+++ b/api/api/snapshot.status.js
@@ -10,14 +10,6 @@
 function buildSnapshotStatus (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [snapshot.status](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html) request
-   *
-   * @param {string} repository - A repository name
-   * @param {list} snapshot - A comma-separated list of snapshot names
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {boolean} ignore_unavailable - Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -36,6 +28,11 @@ function buildSnapshotStatus (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a snapshot.status request
+   * Returns information about the status of a snapshot.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
+   */
   return function snapshotStatus (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -46,12 +43,6 @@ function buildSnapshotStatus (opts) {
       callback = params
       params = {}
       options = {}
-    }
-
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
     }
 
     // check required url components
@@ -70,10 +61,6 @@ function buildSnapshotStatus (opts) {
     var { method, body, repository, snapshot, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -82,10 +69,13 @@ function buildSnapshotStatus (opts) {
     var path = ''
 
     if ((repository) != null && (snapshot) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_snapshot' + '/' + encodeURIComponent(repository) + '/' + encodeURIComponent(snapshot) + '/' + '_status'
     } else if ((repository) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_snapshot' + '/' + encodeURIComponent(repository) + '/' + '_status'
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_snapshot' + '/' + '_status'
     }
 

--- a/api/api/snapshot.verify_repository.js
+++ b/api/api/snapshot.verify_repository.js
@@ -10,13 +10,6 @@
 function buildSnapshotVerifyRepository (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [snapshot.verify_repository](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html) request
-   *
-   * @param {string} repository - A repository name
-   * @param {time} master_timeout - Explicit operation timeout for connection to master node
-   * @param {time} timeout - Explicit operation timeout
-   */
 
   const acceptedQuerystring = [
     'master_timeout',
@@ -34,6 +27,11 @@ function buildSnapshotVerifyRepository (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a snapshot.verify_repository request
+   * Verifies a repository.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
+   */
   return function snapshotVerifyRepository (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -51,10 +49,6 @@ function buildSnapshotVerifyRepository (opts) {
       const err = new ConfigurationError('Missing required parameter: repository')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -66,10 +60,6 @@ function buildSnapshotVerifyRepository (opts) {
     var { method, body, repository, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -77,13 +67,14 @@ function buildSnapshotVerifyRepository (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_snapshot' + '/' + encodeURIComponent(repository) + '/' + '_verify'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/sql.clear_cursor.js
+++ b/api/api/sql.clear_cursor.js
@@ -10,11 +10,6 @@
 function buildSqlClearCursor (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [sql.clear_cursor](Clear SQL cursor) request
-   *
-   * @param {object} body - Specify the cursor value in the `cursor` element to clean the cursor.
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSqlClearCursor (opts) {
 
   }
 
+  /**
+   * Perform a sql.clear_cursor request
+   * Clear SQL cursor
+   */
   return function sqlClearCursor (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildSqlClearCursor (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildSqlClearCursor (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_sql' + '/' + 'close'
 
     // build request object

--- a/api/api/sql.query.js
+++ b/api/api/sql.query.js
@@ -10,12 +10,6 @@
 function buildSqlQuery (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [sql.query](Execute SQL) request
-   *
-   * @param {string} format - a short version of the Accept header, e.g. json, yaml
-   * @param {object} body - Use the `query` element to start a query. Use the `cursor` element to continue a query.
-   */
 
   const acceptedQuerystring = [
     'format'
@@ -25,6 +19,10 @@ function buildSqlQuery (opts) {
 
   }
 
+  /**
+   * Perform a sql.query request
+   * Execute SQL
+   */
   return function sqlQuery (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,10 +51,6 @@ function buildSqlQuery (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -64,6 +58,7 @@ function buildSqlQuery (opts) {
 
     var path = ''
 
+    if (method == null) method = body == null ? 'GET' : 'POST'
     path = '/' + '_sql'
 
     // build request object

--- a/api/api/sql.translate.js
+++ b/api/api/sql.translate.js
@@ -10,11 +10,6 @@
 function buildSqlTranslate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [sql.translate](Translate SQL into Elasticsearch queries) request
-   *
-   * @param {object} body - Specify the query in the `query` element.
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildSqlTranslate (opts) {
 
   }
 
+  /**
+   * Perform a sql.translate request
+   * Translate SQL into Elasticsearch queries
+   */
   return function sqlTranslate (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -52,10 +51,6 @@ function buildSqlTranslate (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +58,7 @@ function buildSqlTranslate (opts) {
 
     var path = ''
 
+    if (method == null) method = body == null ? 'GET' : 'POST'
     path = '/' + '_sql' + '/' + 'translate'
 
     // build request object

--- a/api/api/ssl.certificates.js
+++ b/api/api/ssl.certificates.js
@@ -10,10 +10,6 @@
 function buildSslCertificates (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [ssl.certificates](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildSslCertificates (opts) {
 
   }
 
+  /**
+   * Perform a ssl.certificates request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html
+   */
   return function sslCertificates (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildSslCertificates (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildSslCertificates (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,6 +52,7 @@ function buildSslCertificates (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_ssl' + '/' + 'certificates'
 
     // build request object

--- a/api/api/tasks.cancel.js
+++ b/api/api/tasks.cancel.js
@@ -10,14 +10,6 @@
 function buildTasksCancel (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [tasks.cancel](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html) request
-   *
-   * @param {string} task_id - Cancel the task with specified task id (node_id:task_number)
-   * @param {list} nodes - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
-   * @param {list} actions - A comma-separated list of actions that should be cancelled. Leave empty to cancel all.
-   * @param {string} parent_task_id - Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all.
-   */
 
   const acceptedQuerystring = [
     'nodes',
@@ -36,6 +28,11 @@ function buildTasksCancel (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a tasks.cancel request
+   * Cancels a task, if it can be cancelled through an API.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
+   */
   return function tasksCancel (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -48,12 +45,6 @@ function buildTasksCancel (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -64,10 +55,6 @@ function buildTasksCancel (opts) {
     var { method, body, taskId, task_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -76,8 +63,10 @@ function buildTasksCancel (opts) {
     var path = ''
 
     if ((task_id || taskId) != null) {
+      if (method == null) method = 'POST'
       path = '/' + '_tasks' + '/' + encodeURIComponent(task_id || taskId) + '/' + '_cancel'
     } else {
+      if (method == null) method = 'POST'
       path = '/' + '_tasks' + '/' + '_cancel'
     }
 
@@ -85,7 +74,7 @@ function buildTasksCancel (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/tasks.get.js
+++ b/api/api/tasks.get.js
@@ -10,13 +10,6 @@
 function buildTasksGet (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [tasks.get](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html) request
-   *
-   * @param {string} task_id - Return the task with specified id (node_id:task_number)
-   * @param {boolean} wait_for_completion - Wait for the matching tasks to complete (default: false)
-   * @param {time} timeout - Explicit operation timeout
-   */
 
   const acceptedQuerystring = [
     'wait_for_completion',
@@ -34,6 +27,11 @@ function buildTasksGet (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a tasks.get request
+   * Returns information about a task.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
+   */
   return function tasksGet (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -51,10 +49,6 @@ function buildTasksGet (opts) {
       const err = new ConfigurationError('Missing required parameter: task_id or taskId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -66,10 +60,6 @@ function buildTasksGet (opts) {
     var { method, body, taskId, task_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -77,6 +67,7 @@ function buildTasksGet (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_tasks' + '/' + encodeURIComponent(task_id || taskId)
 
     // build request object

--- a/api/api/tasks.list.js
+++ b/api/api/tasks.list.js
@@ -10,17 +10,6 @@
 function buildTasksList (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [tasks.list](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html) request
-   *
-   * @param {list} nodes - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
-   * @param {list} actions - A comma-separated list of actions that should be returned. Leave empty to return all.
-   * @param {boolean} detailed - Return detailed task information (default: false)
-   * @param {string} parent_task_id - Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all.
-   * @param {boolean} wait_for_completion - Wait for the matching tasks to complete (default: false)
-   * @param {enum} group_by - Group tasks by nodes or parent/child relationships
-   * @param {time} timeout - Explicit operation timeout
-   */
 
   const acceptedQuerystring = [
     'nodes',
@@ -45,6 +34,11 @@ function buildTasksList (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a tasks.list request
+   * Returns a list of tasks.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
+   */
   return function tasksList (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -57,12 +51,6 @@ function buildTasksList (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -73,10 +61,6 @@ function buildTasksList (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -84,6 +68,7 @@ function buildTasksList (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_tasks'
 
     // build request object

--- a/api/api/termvectors.js
+++ b/api/api/termvectors.js
@@ -10,24 +10,6 @@
 function buildTermvectors (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [termvectors](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html) request
-   *
-   * @param {string} index - The index in which the document resides.
-   * @param {string} id - The id of the document, when not specified a doc param should be supplied.
-   * @param {boolean} term_statistics - Specifies if total term frequency and document frequency should be returned.
-   * @param {boolean} field_statistics - Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.
-   * @param {list} fields - A comma-separated list of fields to return.
-   * @param {boolean} offsets - Specifies if term offsets should be returned.
-   * @param {boolean} positions - Specifies if term positions should be returned.
-   * @param {boolean} payloads - Specifies if term payloads should be returned.
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random).
-   * @param {string} routing - Specific routing value.
-   * @param {boolean} realtime - Specifies if request is real-time as opposed to near-real-time (default: true).
-   * @param {number} version - Explicit version number for concurrency control
-   * @param {enum} version_type - Specific version type
-   * @param {object} body - Define parameters and or supply a document to get termvectors for. See documentation.
-   */
 
   const acceptedQuerystring = [
     'term_statistics',
@@ -56,6 +38,11 @@ function buildTermvectors (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a termvectors request
+   * Returns information and statistics about terms in the fields of a particular document.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html
+   */
   return function termvectors (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -84,10 +71,6 @@ function buildTermvectors (opts) {
     var { method, body, index, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = body == null ? 'GET' : 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -96,8 +79,10 @@ function buildTermvectors (opts) {
     var path = ''
 
     if ((index) != null && (id) != null) {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_termvectors' + '/' + encodeURIComponent(id)
     } else {
+      if (method == null) method = body == null ? 'GET' : 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_termvectors'
     }
 

--- a/api/api/update.js
+++ b/api/api/update.js
@@ -10,25 +10,6 @@
 function buildUpdate (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [update](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html) request
-   *
-   * @param {string} id - Document ID
-   * @param {string} index - The name of the index
-   * @param {string} type - The type of the document
-   * @param {string} wait_for_active_shards - Sets the number of shard copies that must be active before proceeding with the update operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-   * @param {list} _source - True or false to return the _source field or not, or a list of fields to return
-   * @param {list} _source_excludes - A list of fields to exclude from the returned _source field
-   * @param {list} _source_includes - A list of fields to extract and return from the _source field
-   * @param {string} lang - The script language (default: painless)
-   * @param {enum} refresh - If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
-   * @param {number} retry_on_conflict - Specify how many times should the operation be retried when a conflict occurs (default: 0)
-   * @param {string} routing - Specific routing value
-   * @param {time} timeout - Explicit operation timeout
-   * @param {number} if_seq_no - only perform the update operation if the last operation that has changed the document has the specified sequence number
-   * @param {number} if_primary_term - only perform the update operation if the last operation that has changed the document has the specified primary term
-   * @param {object} body - The request definition requires either `script` or partial `doc`
-   */
 
   const acceptedQuerystring = [
     'wait_for_active_shards',
@@ -64,6 +45,11 @@ function buildUpdate (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a update request
+   * Updates a document with a script or partial document.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html
+   */
   return function update (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -100,10 +86,6 @@ function buildUpdate (opts) {
     var { method, body, id, index, type, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -112,8 +94,10 @@ function buildUpdate (opts) {
     var path = ''
 
     if ((index) != null && (type) != null && (id) != null) {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + encodeURIComponent(type) + '/' + encodeURIComponent(id) + '/' + '_update'
     } else {
+      if (method == null) method = 'POST'
       path = '/' + encodeURIComponent(index) + '/' + '_update' + '/' + encodeURIComponent(id)
     }
 

--- a/api/api/update_by_query.js
+++ b/api/api/update_by_query.js
@@ -10,46 +10,6 @@
 function buildUpdateByQuery (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [update_by_query](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html) request
-   *
-   * @param {list} index - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-   * @param {string} analyzer - The analyzer to use for the query string
-   * @param {boolean} analyze_wildcard - Specify whether wildcard and prefix queries should be analyzed (default: false)
-   * @param {enum} default_operator - The default operator for query string query (AND or OR)
-   * @param {string} df - The field to use as default where no field prefix is given in the query string
-   * @param {number} from - Starting offset (default: 0)
-   * @param {boolean} ignore_unavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)
-   * @param {boolean} allow_no_indices - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-   * @param {enum} conflicts - What to do when the update by query hits version conflicts?
-   * @param {enum} expand_wildcards - Whether to expand wildcard expression to concrete indices that are open, closed or both.
-   * @param {boolean} lenient - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-   * @param {string} pipeline - Ingest pipeline to set on index requests made by this action. (default: none)
-   * @param {string} preference - Specify the node or shard the operation should be performed on (default: random)
-   * @param {string} q - Query in the Lucene query string syntax
-   * @param {list} routing - A comma-separated list of specific routing values
-   * @param {time} scroll - Specify how long a consistent view of the index should be maintained for scrolled search
-   * @param {enum} search_type - Search operation type
-   * @param {time} search_timeout - Explicit timeout for each search request. Defaults to no timeout.
-   * @param {number} max_docs - Maximum number of documents to process (default: all documents)
-   * @param {list} sort - A comma-separated list of <field>:<direction> pairs
-   * @param {list} _source - True or false to return the _source field or not, or a list of fields to return
-   * @param {list} _source_excludes - A list of fields to exclude from the returned _source field
-   * @param {list} _source_includes - A list of fields to extract and return from the _source field
-   * @param {number} terminate_after - The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
-   * @param {list} stats - Specific 'tag' of the request for logging and statistical purposes
-   * @param {boolean} version - Specify whether to return document version as part of a hit
-   * @param {boolean} version_type - Should the document increment the version number (internal) on hit or not (reindex)
-   * @param {boolean} request_cache - Specify if request cache should be used for this request or not, defaults to index level setting
-   * @param {boolean} refresh - Should the effected indexes be refreshed?
-   * @param {time} timeout - Time each individual bulk request should wait for shards that are unavailable.
-   * @param {string} wait_for_active_shards - Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
-   * @param {number} scroll_size - Size on the scroll request powering the update by query
-   * @param {boolean} wait_for_completion - Should the request should block until the update by query operation is complete.
-   * @param {number} requests_per_second - The throttle to set on this request in sub-requests per second. -1 means no throttle.
-   * @param {number} slices - The number of slices this task should be divided into. Defaults to 1 meaning the task isn't sliced into subtasks.
-   * @param {object} body - The search definition using the Query DSL
-   */
 
   const acceptedQuerystring = [
     'analyzer',
@@ -119,6 +79,12 @@ function buildUpdateByQuery (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a update_by_query request
+   * Performs an update on every document in the index without changing the source,
+for example to pick up a mapping change.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html
+   */
   return function updateByQuery (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -147,10 +113,6 @@ function buildUpdateByQuery (opts) {
     var { method, body, index, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -158,6 +120,7 @@ function buildUpdateByQuery (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + encodeURIComponent(index) + '/' + '_update_by_query'
 
     // build request object

--- a/api/api/update_by_query_rethrottle.js
+++ b/api/api/update_by_query_rethrottle.js
@@ -10,12 +10,6 @@
 function buildUpdateByQueryRethrottle (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [update_by_query_rethrottle](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html) request
-   *
-   * @param {string} task_id - The task id to rethrottle
-   * @param {number} requests_per_second - The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
-   */
 
   const acceptedQuerystring = [
     'requests_per_second',
@@ -32,6 +26,11 @@ function buildUpdateByQueryRethrottle (opts) {
     filterPath: 'filter_path'
   }
 
+  /**
+   * Perform a update_by_query_rethrottle request
+   * Changes the number of requests per second for a particular Update By Query operation.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html
+   */
   return function updateByQueryRethrottle (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -53,10 +52,6 @@ function buildUpdateByQueryRethrottle (opts) {
       const err = new ConfigurationError('Missing required parameter: requests_per_second or requestsPerSecond')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -68,10 +63,6 @@ function buildUpdateByQueryRethrottle (opts) {
     var { method, body, taskId, task_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -79,13 +70,14 @@ function buildUpdateByQueryRethrottle (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_update_by_query' + '/' + encodeURIComponent(task_id || taskId) + '/' + '_rethrottle'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/watcher.ack_watch.js
+++ b/api/api/watcher.ack_watch.js
@@ -10,12 +10,6 @@
 function buildWatcherAckWatch (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [watcher.ack_watch](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html) request
-   *
-   * @param {string} watch_id - Watch ID
-   * @param {list} action_id - A comma-separated list of the action ids to be acked
-   */
 
   const acceptedQuerystring = [
 
@@ -25,6 +19,10 @@ function buildWatcherAckWatch (opts) {
 
   }
 
+  /**
+   * Perform a watcher.ack_watch request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html
+   */
   return function watcherAckWatch (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -40,10 +38,6 @@ function buildWatcherAckWatch (opts) {
     // check required parameters
     if (params['watch_id'] == null && params['watchId'] == null) {
       const err = new ConfigurationError('Missing required parameter: watch_id or watchId')
-      return handleError(err, callback)
-    }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
       return handleError(err, callback)
     }
 
@@ -63,10 +57,6 @@ function buildWatcherAckWatch (opts) {
     var { method, body, watchId, watch_id, actionId, action_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -75,8 +65,10 @@ function buildWatcherAckWatch (opts) {
     var path = ''
 
     if ((watch_id || watchId) != null && (action_id || actionId) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + '_watcher' + '/' + 'watch' + '/' + encodeURIComponent(watch_id || watchId) + '/' + '_ack' + '/' + encodeURIComponent(action_id || actionId)
     } else {
+      if (method == null) method = 'PUT'
       path = '/' + '_watcher' + '/' + 'watch' + '/' + encodeURIComponent(watch_id || watchId) + '/' + '_ack'
     }
 
@@ -84,7 +76,7 @@ function buildWatcherAckWatch (opts) {
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/watcher.activate_watch.js
+++ b/api/api/watcher.activate_watch.js
@@ -10,11 +10,6 @@
 function buildWatcherActivateWatch (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [watcher.activate_watch](https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html) request
-   *
-   * @param {string} watch_id - Watch ID
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildWatcherActivateWatch (opts) {
 
   }
 
+  /**
+   * Perform a watcher.activate_watch request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html
+   */
   return function watcherActivateWatch (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,10 +40,6 @@ function buildWatcherActivateWatch (opts) {
       const err = new ConfigurationError('Missing required parameter: watch_id or watchId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -56,10 +51,6 @@ function buildWatcherActivateWatch (opts) {
     var { method, body, watchId, watch_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,13 +58,14 @@ function buildWatcherActivateWatch (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_watcher' + '/' + 'watch' + '/' + encodeURIComponent(watch_id || watchId) + '/' + '_activate'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/watcher.deactivate_watch.js
+++ b/api/api/watcher.deactivate_watch.js
@@ -10,11 +10,6 @@
 function buildWatcherDeactivateWatch (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [watcher.deactivate_watch](https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html) request
-   *
-   * @param {string} watch_id - Watch ID
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildWatcherDeactivateWatch (opts) {
 
   }
 
+  /**
+   * Perform a watcher.deactivate_watch request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html
+   */
   return function watcherDeactivateWatch (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,10 +40,6 @@ function buildWatcherDeactivateWatch (opts) {
       const err = new ConfigurationError('Missing required parameter: watch_id or watchId')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -56,10 +51,6 @@ function buildWatcherDeactivateWatch (opts) {
     var { method, body, watchId, watch_id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,13 +58,14 @@ function buildWatcherDeactivateWatch (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_watcher' + '/' + 'watch' + '/' + encodeURIComponent(watch_id || watchId) + '/' + '_deactivate'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/watcher.delete_watch.js
+++ b/api/api/watcher.delete_watch.js
@@ -10,11 +10,6 @@
 function buildWatcherDeleteWatch (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [watcher.delete_watch](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html) request
-   *
-   * @param {string} id - Watch ID
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildWatcherDeleteWatch (opts) {
 
   }
 
+  /**
+   * Perform a watcher.delete_watch request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html
+   */
   return function watcherDeleteWatch (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,10 +40,6 @@ function buildWatcherDeleteWatch (opts) {
       const err = new ConfigurationError('Missing required parameter: id')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -56,10 +51,6 @@ function buildWatcherDeleteWatch (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'DELETE'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,13 +58,14 @@ function buildWatcherDeleteWatch (opts) {
 
     var path = ''
 
+    if (method == null) method = 'DELETE'
     path = '/' + '_watcher' + '/' + 'watch' + '/' + encodeURIComponent(id)
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/watcher.execute_watch.js
+++ b/api/api/watcher.execute_watch.js
@@ -10,13 +10,6 @@
 function buildWatcherExecuteWatch (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [watcher.execute_watch](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html) request
-   *
-   * @param {string} id - Watch ID
-   * @param {boolean} debug - indicates whether the watch should execute in debug mode
-   * @param {object} body - Execution control
-   */
 
   const acceptedQuerystring = [
     'debug'
@@ -26,6 +19,10 @@ function buildWatcherExecuteWatch (opts) {
 
   }
 
+  /**
+   * Perform a watcher.execute_watch request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html
+   */
   return function watcherExecuteWatch (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -48,10 +45,6 @@ function buildWatcherExecuteWatch (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -60,8 +53,10 @@ function buildWatcherExecuteWatch (opts) {
     var path = ''
 
     if ((id) != null) {
+      if (method == null) method = 'PUT'
       path = '/' + '_watcher' + '/' + 'watch' + '/' + encodeURIComponent(id) + '/' + '_execute'
     } else {
+      if (method == null) method = 'PUT'
       path = '/' + '_watcher' + '/' + 'watch' + '/' + '_execute'
     }
 

--- a/api/api/watcher.get_watch.js
+++ b/api/api/watcher.get_watch.js
@@ -10,11 +10,6 @@
 function buildWatcherGetWatch (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [watcher.get_watch](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html) request
-   *
-   * @param {string} id - Watch ID
-   */
 
   const acceptedQuerystring = [
 
@@ -24,6 +19,10 @@ function buildWatcherGetWatch (opts) {
 
   }
 
+  /**
+   * Perform a watcher.get_watch request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html
+   */
   return function watcherGetWatch (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -41,10 +40,6 @@ function buildWatcherGetWatch (opts) {
       const err = new ConfigurationError('Missing required parameter: id')
       return handleError(err, callback)
     }
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
 
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
@@ -56,10 +51,6 @@ function buildWatcherGetWatch (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,6 +58,7 @@ function buildWatcherGetWatch (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_watcher' + '/' + 'watch' + '/' + encodeURIComponent(id)
 
     // build request object

--- a/api/api/watcher.put_watch.js
+++ b/api/api/watcher.put_watch.js
@@ -10,16 +10,6 @@
 function buildWatcherPutWatch (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [watcher.put_watch](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html) request
-   *
-   * @param {string} id - Watch ID
-   * @param {boolean} active - Specify whether the watch is in/active by default
-   * @param {number} version - Explicit version number for concurrency control
-   * @param {number} if_seq_no - only update the watch if the last operation that has changed the watch has the specified sequence number
-   * @param {number} if_primary_term - only update the watch if the last operation that has changed the watch has the specified primary term
-   * @param {object} body - The watch
-   */
 
   const acceptedQuerystring = [
     'active',
@@ -33,6 +23,10 @@ function buildWatcherPutWatch (opts) {
     ifPrimaryTerm: 'if_primary_term'
   }
 
+  /**
+   * Perform a watcher.put_watch request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html
+   */
   return function watcherPutWatch (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -61,10 +55,6 @@ function buildWatcherPutWatch (opts) {
     var { method, body, id, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'PUT'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -72,6 +62,7 @@ function buildWatcherPutWatch (opts) {
 
     var path = ''
 
+    if (method == null) method = 'PUT'
     path = '/' + '_watcher' + '/' + 'watch' + '/' + encodeURIComponent(id)
 
     // build request object

--- a/api/api/watcher.start.js
+++ b/api/api/watcher.start.js
@@ -10,10 +10,6 @@
 function buildWatcherStart (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [watcher.start](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildWatcherStart (opts) {
 
   }
 
+  /**
+   * Perform a watcher.start request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html
+   */
   return function watcherStart (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildWatcherStart (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildWatcherStart (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,13 +52,14 @@ function buildWatcherStart (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_watcher' + '/' + '_start'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/watcher.stats.js
+++ b/api/api/watcher.stats.js
@@ -10,13 +10,6 @@
 function buildWatcherStats (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [watcher.stats](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html) request
-   *
-   * @param {list} metric - Controls what additional stat metrics should be include in the response
-   * @param {list} metric - Controls what additional stat metrics should be include in the response
-   * @param {boolean} emit_stacktraces - Emits stack traces of currently running watches
-   */
 
   const acceptedQuerystring = [
     'metric',
@@ -27,6 +20,10 @@ function buildWatcherStats (opts) {
     emitStacktraces: 'emit_stacktraces'
   }
 
+  /**
+   * Perform a watcher.stats request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html
+   */
   return function watcherStats (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -39,12 +36,6 @@ function buildWatcherStats (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -55,10 +46,6 @@ function buildWatcherStats (opts) {
     var { method, body, metric, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -67,8 +54,10 @@ function buildWatcherStats (opts) {
     var path = ''
 
     if ((metric) != null) {
+      if (method == null) method = 'GET'
       path = '/' + '_watcher' + '/' + 'stats' + '/' + encodeURIComponent(metric)
     } else {
+      if (method == null) method = 'GET'
       path = '/' + '_watcher' + '/' + 'stats'
     }
 

--- a/api/api/watcher.stop.js
+++ b/api/api/watcher.stop.js
@@ -10,10 +10,6 @@
 function buildWatcherStop (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [watcher.stop](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html) request
-   *
-   */
 
   const acceptedQuerystring = [
 
@@ -23,6 +19,10 @@ function buildWatcherStop (opts) {
 
   }
 
+  /**
+   * Perform a watcher.stop request
+   * http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html
+   */
   return function watcherStop (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -35,12 +35,6 @@ function buildWatcherStop (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -51,10 +45,6 @@ function buildWatcherStop (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'POST'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -62,13 +52,14 @@ function buildWatcherStop (opts) {
 
     var path = ''
 
+    if (method == null) method = 'POST'
     path = '/' + '_watcher' + '/' + '_stop'
 
     // build request object
     const request = {
       method,
       path,
-      body: '',
+      body: body || '',
       querystring
     }
 

--- a/api/api/xpack.info.js
+++ b/api/api/xpack.info.js
@@ -10,11 +10,6 @@
 function buildXpackInfo (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [xpack.info](https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html) request
-   *
-   * @param {list} categories - Comma-separated list of info categories. Can be any of: build, license, features
-   */
 
   const acceptedQuerystring = [
     'categories'
@@ -24,6 +19,10 @@ function buildXpackInfo (opts) {
 
   }
 
+  /**
+   * Perform a xpack.info request
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html
+   */
   return function xpackInfo (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,12 +35,6 @@ function buildXpackInfo (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -52,10 +45,6 @@ function buildXpackInfo (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +52,7 @@ function buildXpackInfo (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_xpack'
 
     // build request object

--- a/api/api/xpack.usage.js
+++ b/api/api/xpack.usage.js
@@ -10,11 +10,6 @@
 function buildXpackUsage (opts) {
   // eslint-disable-next-line no-unused-vars
   const { makeRequest, ConfigurationError, handleError, snakeCaseKeys } = opts
-  /**
-   * Perform a [xpack.usage](Retrieve information about xpack features usage) request
-   *
-   * @param {time} master_timeout - Specify timeout for watch write operation
-   */
 
   const acceptedQuerystring = [
     'master_timeout'
@@ -24,6 +19,10 @@ function buildXpackUsage (opts) {
     masterTimeout: 'master_timeout'
   }
 
+  /**
+   * Perform a xpack.usage request
+   * Retrieve information about xpack features usage
+   */
   return function xpackUsage (params, options, callback) {
     options = options || {}
     if (typeof options === 'function') {
@@ -36,12 +35,6 @@ function buildXpackUsage (opts) {
       options = {}
     }
 
-    // check required parameters
-    if (params.body != null) {
-      const err = new ConfigurationError('This API does not require a body')
-      return handleError(err, callback)
-    }
-
     // validate headers object
     if (options.headers != null && typeof options.headers !== 'object') {
       const err = new ConfigurationError(`Headers should be an object, instead got: ${typeof options.headers}`)
@@ -52,10 +45,6 @@ function buildXpackUsage (opts) {
     var { method, body, ...querystring } = params
     querystring = snakeCaseKeys(acceptedQuerystring, snakeCase, querystring, warnings)
 
-    if (method == null) {
-      method = 'GET'
-    }
-
     var ignore = options.ignore
     if (typeof ignore === 'number') {
       options.ignore = [ignore]
@@ -63,6 +52,7 @@ function buildXpackUsage (opts) {
 
     var path = ''
 
+    if (method == null) method = 'GET'
     path = '/' + '_xpack' + '/' + 'usage'
 
     // build request object

--- a/api/index.js
+++ b/api/index.js
@@ -471,10 +471,14 @@ function ESAPI (opts) {
       executeLifecycle: lazyLoad('slm.execute_lifecycle', opts),
       get_lifecycle: lazyLoad('slm.get_lifecycle', opts),
       getLifecycle: lazyLoad('slm.get_lifecycle', opts),
+      get_stats: lazyLoad('slm.get_stats', opts),
+      getStats: lazyLoad('slm.get_stats', opts),
       put_lifecycle: lazyLoad('slm.put_lifecycle', opts),
       putLifecycle: lazyLoad('slm.put_lifecycle', opts)
     },
     snapshot: {
+      cleanup_repository: lazyLoad('snapshot.cleanup_repository', opts),
+      cleanupRepository: lazyLoad('snapshot.cleanup_repository', opts),
       create: lazyLoad('snapshot.create', opts),
       create_repository: lazyLoad('snapshot.create_repository', opts),
       createRepository: lazyLoad('snapshot.create_repository', opts),

--- a/api/requestParams.d.ts
+++ b/api/requestParams.d.ts
@@ -324,7 +324,6 @@ export interface ClusterStats extends Generic {
 
 export interface Count<T = any> extends Generic {
   index?: string | string[];
-  type?: string | string[];
   ignore_unavailable?: boolean;
   ignore_throttled?: boolean;
   allow_no_indices?: boolean;
@@ -619,8 +618,8 @@ export interface IndicesExists extends Generic {
 }
 
 export interface IndicesExistsAlias extends Generic {
-  index?: string | string[];
   name: string | string[];
+  index?: string | string[];
   ignore_unavailable?: boolean;
   allow_no_indices?: boolean;
   expand_wildcards?: 'open' | 'closed' | 'none' | 'all';
@@ -682,8 +681,8 @@ export interface IndicesGet extends Generic {
 }
 
 export interface IndicesGetAlias extends Generic {
-  index?: string | string[];
   name?: string | string[];
+  index?: string | string[];
   ignore_unavailable?: boolean;
   allow_no_indices?: boolean;
   expand_wildcards?: 'open' | 'closed' | 'none' | 'all';
@@ -691,9 +690,9 @@ export interface IndicesGetAlias extends Generic {
 }
 
 export interface IndicesGetFieldMapping extends Generic {
+  fields: string | string[];
   index?: string | string[];
   type?: string | string[];
-  fields: string | string[];
   include_type_name?: boolean;
   include_defaults?: boolean;
   ignore_unavailable?: boolean;
@@ -852,8 +851,8 @@ export interface IndicesSplit<T = any> extends Generic {
 }
 
 export interface IndicesStats extends Generic {
-  index?: string | string[];
   metric?: string | string[];
+  index?: string | string[];
   completion_fields?: string | string[];
   fielddata_fields?: string | string[];
   fields?: string | string[];
@@ -1007,9 +1006,9 @@ export interface NodesReloadSecureSettings extends Generic {
 }
 
 export interface NodesStats extends Generic {
+  node_id?: string | string[];
   metric?: string | string[];
   index_metric?: string | string[];
-  node_id?: string | string[];
   completion_fields?: string | string[];
   fielddata_fields?: string | string[];
   fields?: string | string[];
@@ -1021,8 +1020,8 @@ export interface NodesStats extends Generic {
 }
 
 export interface NodesUsage extends Generic {
-  metric?: string | string[];
   node_id?: string | string[];
+  metric?: string | string[];
   timeout?: string;
 }
 
@@ -1153,6 +1152,13 @@ export interface SearchTemplate<T = any> extends Generic {
   rest_total_hits_as_int?: boolean;
   ccs_minimize_roundtrips?: boolean;
   body: T;
+}
+
+export interface SnapshotCleanupRepository<T = any> extends Generic {
+  repository: string;
+  master_timeout?: string;
+  timeout?: string;
+  body?: T;
 }
 
 export interface SnapshotCreate<T = any> extends Generic {
@@ -1335,7 +1341,7 @@ export interface CcrFollow<T = any> extends Generic {
 }
 
 export interface CcrFollowInfo extends Generic {
-  index?: string | string[];
+  index: string | string[];
 }
 
 export interface CcrFollowStats extends Generic {
@@ -1385,7 +1391,7 @@ export interface DataFrameGetDataFrameTransform extends Generic {
 }
 
 export interface DataFrameGetDataFrameTransformStats extends Generic {
-  transform_id?: string;
+  transform_id: string;
   from?: number;
   size?: number;
   allow_no_match?: boolean;
@@ -1420,7 +1426,7 @@ export interface DataFrameUpdateDataFrameTransform<T = any> extends Generic {
 }
 
 export interface GraphExplore<T = any> extends Generic {
-  index?: string | string[];
+  index: string | string[];
   type?: string | string[];
   routing?: string;
   timeout?: string;
@@ -1428,11 +1434,11 @@ export interface GraphExplore<T = any> extends Generic {
 }
 
 export interface IlmDeleteLifecycle extends Generic {
-  policy?: string;
+  policy: string;
 }
 
 export interface IlmExplainLifecycle extends Generic {
-  index?: string;
+  index: string;
   only_managed?: boolean;
   only_errors?: boolean;
 }
@@ -1445,21 +1451,21 @@ export interface IlmGetStatus extends Generic {
 }
 
 export interface IlmMoveToStep<T = any> extends Generic {
-  index?: string;
+  index: string;
   body?: T;
 }
 
 export interface IlmPutLifecycle<T = any> extends Generic {
-  policy?: string;
+  policy: string;
   body?: T;
 }
 
 export interface IlmRemovePolicy extends Generic {
-  index?: string;
+  index: string;
 }
 
 export interface IlmRetry extends Generic {
-  index?: string;
+  index: string;
 }
 
 export interface IlmStart extends Generic {
@@ -1479,7 +1485,7 @@ export interface IndicesFreeze extends Generic {
 }
 
 export interface IndicesReloadSearchAnalyzers extends Generic {
-  index?: string | string[];
+  index: string | string[];
   ignore_unavailable?: boolean;
   allow_no_indices?: boolean;
   expand_wildcards?: 'open' | 'closed' | 'none' | 'all';
@@ -1758,8 +1764,6 @@ export interface MlInfo extends Generic {
 
 export interface MlOpenJob extends Generic {
   job_id: string;
-  ignore_downtime?: boolean;
-  timeout?: string;
 }
 
 export interface MlPostCalendarEvents<T = any> extends Generic {
@@ -2050,19 +2054,22 @@ export interface SecurityPutUser<T = any> extends Generic {
 }
 
 export interface SlmDeleteLifecycle extends Generic {
-  policy_id?: string;
+  policy_id: string;
 }
 
 export interface SlmExecuteLifecycle extends Generic {
-  policy_id?: string;
+  policy_id: string;
 }
 
 export interface SlmGetLifecycle extends Generic {
   policy_id?: string;
 }
 
+export interface SlmGetStats extends Generic {
+}
+
 export interface SlmPutLifecycle<T = any> extends Generic {
-  policy_id?: string;
+  policy_id: string;
   body?: T;
 }
 

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -8218,7 +8218,7 @@ link:{ref}/slm-api-get.html[Reference]
 ----
 client.slm.getStats()
 ----
-link:{ref}/slm-api.html[Reference]
+link:{ref}/slm-get-stats.html[Reference]
 
 
 === slm.putLifecycle

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -34,6 +34,7 @@ link:{ref}/common-options.html[Reference]
 
 |===
 === bulk
+
 [source,ts]
 ----
 client.bulk({
@@ -43,7 +44,6 @@ client.bulk({
   refresh: 'true' | 'false' | 'wait_for',
   routing: string,
   timeout: string,
-  type: string,
   _source: string | string[],
   _source_excludes: string | string[],
   _source_includes: string | string[],
@@ -72,9 +72,6 @@ link:{ref}/docs-bulk.html[Reference]
 |`timeout`
 |`string` - Explicit operation timeout
 
-|`type`
-|`string` - Default document type for items which don't provide one
-
 |`_source`
 |`string \| string[]` - True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request
 
@@ -93,6 +90,7 @@ link:{ref}/docs-bulk.html[Reference]
 |===
 
 === cat.aliases
+
 [source,ts]
 ----
 client.cat.aliases({
@@ -136,6 +134,7 @@ link:{ref}/cat-alias.html[Reference]
 |===
 
 === cat.allocation
+
 [source,ts]
 ----
 client.cat.allocation({
@@ -183,6 +182,7 @@ link:{ref}/cat-allocation.html[Reference]
 |===
 
 === cat.count
+
 [source,ts]
 ----
 client.cat.count({
@@ -226,6 +226,7 @@ link:{ref}/cat-count.html[Reference]
 |===
 
 === cat.fielddata
+
 [source,ts]
 ----
 client.cat.fielddata({
@@ -237,8 +238,7 @@ client.cat.fielddata({
   h: string | string[],
   help: boolean,
   s: string | string[],
-  v: boolean,
-  fields: string | string[]
+  v: boolean
 })
 ----
 link:{ref}/cat-fielddata.html[Reference]
@@ -271,12 +271,10 @@ link:{ref}/cat-fielddata.html[Reference]
 |`v`
 |`boolean` - Verbose mode. Display column headers
 
-|`fields`
-|`string \| string[]` - A comma-separated list of fields to return in the output
-
 |===
 
 === cat.health
+
 [source,ts]
 ----
 client.cat.health({
@@ -321,6 +319,7 @@ _Default:_ `true`
 |===
 
 === cat.help
+
 [source,ts]
 ----
 client.cat.help({
@@ -340,6 +339,7 @@ link:{ref}/cat.html[Reference]
 |===
 
 === cat.indices
+
 [source,ts]
 ----
 client.cat.indices({
@@ -399,6 +399,7 @@ link:{ref}/cat-indices.html[Reference]
 |===
 
 === cat.master
+
 [source,ts]
 ----
 client.cat.master({
@@ -438,6 +439,7 @@ link:{ref}/cat-master.html[Reference]
 |===
 
 === cat.nodeattrs
+
 [source,ts]
 ----
 client.cat.nodeattrs({
@@ -477,6 +479,7 @@ link:{ref}/cat-nodeattrs.html[Reference]
 |===
 
 === cat.nodes
+
 [source,ts]
 ----
 client.cat.nodes({
@@ -520,6 +523,7 @@ link:{ref}/cat-nodes.html[Reference]
 |===
 
 === cat.pendingTasks
+
 [source,ts]
 ----
 client.cat.pendingTasks({
@@ -559,6 +563,7 @@ link:{ref}/cat-pending-tasks.html[Reference]
 |===
 
 === cat.plugins
+
 [source,ts]
 ----
 client.cat.plugins({
@@ -598,6 +603,7 @@ link:{ref}/cat-plugins.html[Reference]
 |===
 
 === cat.recovery
+
 [source,ts]
 ----
 client.cat.recovery({
@@ -641,6 +647,7 @@ link:{ref}/cat-recovery.html[Reference]
 |===
 
 === cat.repositories
+
 [source,ts]
 ----
 client.cat.repositories({
@@ -680,6 +687,7 @@ link:{ref}/cat-repositories.html[Reference]
 |===
 
 === cat.segments
+
 [source,ts]
 ----
 client.cat.segments({
@@ -719,6 +727,7 @@ link:{ref}/cat-segments.html[Reference]
 |===
 
 === cat.shards
+
 [source,ts]
 ----
 client.cat.shards({
@@ -766,6 +775,7 @@ link:{ref}/cat-shards.html[Reference]
 |===
 
 === cat.snapshots
+
 [source,ts]
 ----
 client.cat.snapshots({
@@ -809,6 +819,7 @@ link:{ref}/cat-snapshots.html[Reference]
 |===
 
 === cat.tasks
+
 [source,ts]
 ----
 client.cat.tasks({
@@ -856,6 +867,7 @@ link:{ref}/tasks.html[Reference]
 |===
 
 === cat.templates
+
 [source,ts]
 ----
 client.cat.templates({
@@ -899,6 +911,7 @@ link:{ref}/cat-templates.html[Reference]
 |===
 
 === cat.threadPool
+
 [source,ts]
 ----
 client.cat.threadPool({
@@ -946,6 +959,7 @@ link:{ref}/cat-thread-pool.html[Reference]
 |===
 
 === clearScroll
+
 [source,ts]
 ----
 client.clearScroll({
@@ -957,7 +971,9 @@ link:{ref}/search-request-body.html#_clear_scroll_api[Reference]
 [cols=2*]
 |===
 |`scroll_id` or `scrollId`
-|`string \| string[]` - A comma-separated list of scroll IDs to clear
+|`string \| string[]` - A comma-separated list of scroll IDs to clear +
+
+WARNING: This parameter has been deprecated.
 
 |`body`
 |`object` - A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter
@@ -965,6 +981,7 @@ link:{ref}/search-request-body.html#_clear_scroll_api[Reference]
 |===
 
 === cluster.allocationExplain
+
 [source,ts]
 ----
 client.cluster.allocationExplain({
@@ -988,6 +1005,7 @@ link:{ref}/cluster-allocation-explain.html[Reference]
 |===
 
 === cluster.getSettings
+
 [source,ts]
 ----
 client.cluster.getSettings({
@@ -1015,6 +1033,7 @@ link:{ref}/cluster-update-settings.html[Reference]
 |===
 
 === cluster.health
+
 [source,ts]
 ----
 client.cluster.health({
@@ -1076,6 +1095,7 @@ _Default:_ `cluster`
 |===
 
 === cluster.pendingTasks
+
 [source,ts]
 ----
 client.cluster.pendingTasks({
@@ -1095,6 +1115,7 @@ link:{ref}/cluster-pending.html[Reference]
 |===
 
 === cluster.putSettings
+
 [source,ts]
 ----
 client.cluster.putSettings({
@@ -1122,6 +1143,7 @@ link:{ref}/cluster-update-settings.html[Reference]
 |===
 
 === cluster.remoteInfo
+
 [source,ts]
 ----
 client.cluster.remoteInfo()
@@ -1130,6 +1152,7 @@ link:{ref}/cluster-remote-info.html[Reference]
 
 
 === cluster.reroute
+
 [source,ts]
 ----
 client.cluster.reroute({
@@ -1169,6 +1192,7 @@ link:{ref}/cluster-reroute.html[Reference]
 |===
 
 === cluster.state
+
 [source,ts]
 ----
 client.cluster.state({
@@ -1221,6 +1245,7 @@ _Default:_ `open`
 |===
 
 === cluster.stats
+
 [source,ts]
 ----
 client.cluster.stats({
@@ -1244,11 +1269,11 @@ link:{ref}/cluster-stats.html[Reference]
 |===
 
 === count
+
 [source,ts]
 ----
 client.count({
   index: string | string[],
-  type: string | string[],
   ignore_unavailable: boolean,
   ignore_throttled: boolean,
   allow_no_indices: boolean,
@@ -1271,9 +1296,6 @@ link:{ref}/search-count.html[Reference]
 |===
 |`index`
 |`string \| string[]` - A comma-separated list of indices to restrict the results
-
-|`type`
-|`string \| string[]` - A comma-separated list of types to restrict the results
 
 |`ignore_unavailable` or `ignoreUnavailable`
 |`boolean` - Whether specified concrete indices should be ignored when unavailable (missing or closed)
@@ -1325,6 +1347,7 @@ _Default:_ `OR`
 |===
 
 === create
+
 [source,ts]
 ----
 client.create({
@@ -1351,7 +1374,9 @@ link:{ref}/docs-index_.html[Reference]
 |`string` - The name of the index
 
 |`type`
-|`string` - The type of the document
+|`string` - The type of the document +
+
+WARNING: This parameter has been deprecated.
 
 |`wait_for_active_shards` or `waitForActiveShards`
 |`string` - Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
@@ -1380,6 +1405,7 @@ link:{ref}/docs-index_.html[Reference]
 |===
 
 === delete
+
 [source,ts]
 ----
 client.delete({
@@ -1406,7 +1432,9 @@ link:{ref}/docs-delete.html[Reference]
 |`string` - The name of the index
 
 |`type`
-|`string` - The type of the document
+|`string` - The type of the document +
+
+WARNING: This parameter has been deprecated.
 
 |`wait_for_active_shards` or `waitForActiveShards`
 |`string` - Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
@@ -1435,6 +1463,7 @@ link:{ref}/docs-delete.html[Reference]
 |===
 
 === deleteByQuery
+
 [source,ts]
 ----
 client.deleteByQuery({
@@ -1588,6 +1617,7 @@ _Default:_ `1`
 |===
 
 === deleteByQueryRethrottle
+
 [source,ts]
 ----
 client.deleteByQueryRethrottle({
@@ -1607,6 +1637,7 @@ link:{ref}/docs-delete-by-query.html[Reference]
 |===
 
 === deleteScript
+
 [source,ts]
 ----
 client.deleteScript({
@@ -1630,6 +1661,7 @@ link:{ref}/modules-scripting.html[Reference]
 |===
 
 === exists
+
 [source,ts]
 ----
 client.exists({
@@ -1658,7 +1690,9 @@ link:{ref}/docs-get.html[Reference]
 |`string` - The name of the index
 
 |`type`
-|`string` - The type of the document (use `_all` to fetch the first document matching the ID across all types)
+|`string` - The type of the document (use `_all` to fetch the first document matching the ID across all types) +
+
+WARNING: This parameter has been deprecated.
 
 |`stored_fields` or `storedFields`
 |`string \| string[]` - A comma-separated list of stored fields to return in the response
@@ -1693,6 +1727,7 @@ link:{ref}/docs-get.html[Reference]
 |===
 
 === existsSource
+
 [source,ts]
 ----
 client.existsSource({
@@ -1720,7 +1755,9 @@ link:{ref}/docs-get.html[Reference]
 |`string` - The name of the index
 
 |`type`
-|`string` - The type of the document; deprecated and optional starting with 7.0
+|`string` - The type of the document; deprecated and optional starting with 7.0 +
+
+WARNING: This parameter has been deprecated.
 
 |`preference`
 |`string` - Specify the node or shard the operation should be performed on (default: random)
@@ -1752,6 +1789,7 @@ link:{ref}/docs-get.html[Reference]
 |===
 
 === explain
+
 [source,ts]
 ----
 client.explain({
@@ -1783,7 +1821,9 @@ link:{ref}/search-explain.html[Reference]
 |`string` - The name of the index
 
 |`type`
-|`string` - The type of the document
+|`string` - The type of the document +
+
+WARNING: This parameter has been deprecated.
 
 |`analyze_wildcard` or `analyzeWildcard`
 |`boolean` - Specify whether wildcards and prefix queries in the query string query should be analyzed (default: false)
@@ -1828,6 +1868,7 @@ _Default:_ `OR`
 |===
 
 === fieldCaps
+
 [source,ts]
 ----
 client.fieldCaps({
@@ -1864,6 +1905,7 @@ _Default:_ `open`
 |===
 
 === get
+
 [source,ts]
 ----
 client.get({
@@ -1892,7 +1934,9 @@ link:{ref}/docs-get.html[Reference]
 |`string` - The name of the index
 
 |`type`
-|`string` - The type of the document (use `_all` to fetch the first document matching the ID across all types)
+|`string` - The type of the document (use `_all` to fetch the first document matching the ID across all types) +
+
+WARNING: This parameter has been deprecated.
 
 |`stored_fields` or `storedFields`
 |`string \| string[]` - A comma-separated list of stored fields to return in the response
@@ -1927,6 +1971,7 @@ link:{ref}/docs-get.html[Reference]
 |===
 
 === getScript
+
 [source,ts]
 ----
 client.getScript({
@@ -1946,6 +1991,7 @@ link:{ref}/modules-scripting.html[Reference]
 |===
 
 === getSource
+
 [source,ts]
 ----
 client.getSource({
@@ -1973,7 +2019,9 @@ link:{ref}/docs-get.html[Reference]
 |`string` - The name of the index
 
 |`type`
-|`string` - The type of the document; deprecated and optional starting with 7.0
+|`string` - The type of the document; deprecated and optional starting with 7.0 +
+
+WARNING: This parameter has been deprecated.
 
 |`preference`
 |`string` - Specify the node or shard the operation should be performed on (default: random)
@@ -2005,6 +2053,7 @@ link:{ref}/docs-get.html[Reference]
 |===
 
 === index
+
 [source,ts]
 ----
 client.index({
@@ -2034,7 +2083,9 @@ link:{ref}/docs-index_.html[Reference]
 |`string` - The name of the index
 
 |`type`
-|`string` - The type of the document
+|`string` - The type of the document +
+
+WARNING: This parameter has been deprecated.
 
 |`wait_for_active_shards` or `waitForActiveShards`
 |`string` - Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
@@ -2073,10 +2124,10 @@ _Default:_ `index`
 |===
 
 === indices.analyze
+
 [source,ts]
 ----
 client.indices.analyze({
-  index: string,
   index: string,
   body: object
 })
@@ -2087,15 +2138,13 @@ link:{ref}/indices-analyze.html[Reference]
 |`index`
 |`string` - The name of the index to scope the operation
 
-|`index`
-|`string` - The name of the index to scope the operation
-
 |`body`
 |`object` - Define analyzer/tokenizer parameters and the text on which the analysis should be performed
 
 |===
 
 === indices.clearCache
+
 [source,ts]
 ----
 client.indices.clearCache({
@@ -2106,7 +2155,6 @@ client.indices.clearCache({
   ignore_unavailable: boolean,
   allow_no_indices: boolean,
   expand_wildcards: 'open' | 'closed' | 'none' | 'all',
-  index: string | string[],
   request: boolean
 })
 ----
@@ -2135,15 +2183,13 @@ link:{ref}/indices-clearcache.html[Reference]
 |`'open' \| 'closed' \| 'none' \| 'all'` - Whether to expand wildcard expression to concrete indices that are open, closed or both. +
 _Default:_ `open`
 
-|`index`
-|`string \| string[]` - A comma-separated list of index name to limit the operation
-
 |`request`
 |`boolean` - Clear request cache
 
 |===
 
 === indices.clone
+
 [source,ts]
 ----
 client.indices.clone({
@@ -2179,6 +2225,7 @@ link:{ref}/indices-clone-index.html[Reference]
 |===
 
 === indices.close
+
 [source,ts]
 ----
 client.indices.close({
@@ -2219,6 +2266,7 @@ _Default:_ `open`
 |===
 
 === indices.create
+
 [source,ts]
 ----
 client.indices.create({
@@ -2254,6 +2302,7 @@ link:{ref}/indices-create-index.html[Reference]
 |===
 
 === indices.delete
+
 [source,ts]
 ----
 client.indices.delete({
@@ -2290,6 +2339,7 @@ _Default:_ `open`
 |===
 
 === indices.deleteAlias
+
 [source,ts]
 ----
 client.indices.deleteAlias({
@@ -2317,6 +2367,7 @@ link:{ref}/indices-aliases.html[Reference]
 |===
 
 === indices.deleteTemplate
+
 [source,ts]
 ----
 client.indices.deleteTemplate({
@@ -2340,6 +2391,7 @@ link:{ref}/indices-templates.html[Reference]
 |===
 
 === indices.exists
+
 [source,ts]
 ----
 client.indices.exists({
@@ -2380,11 +2432,12 @@ _Default:_ `open`
 |===
 
 === indices.existsAlias
+
 [source,ts]
 ----
 client.indices.existsAlias({
-  index: string | string[],
   name: string | string[],
+  index: string | string[],
   ignore_unavailable: boolean,
   allow_no_indices: boolean,
   expand_wildcards: 'open' | 'closed' | 'none' | 'all',
@@ -2394,11 +2447,11 @@ client.indices.existsAlias({
 link:{ref}/indices-aliases.html[Reference]
 [cols=2*]
 |===
-|`index`
-|`string \| string[]` - A comma-separated list of index names to filter aliases
-
 |`name`
 |`string \| string[]` - A comma-separated list of alias names to return
+
+|`index`
+|`string \| string[]` - A comma-separated list of index names to filter aliases
 
 |`ignore_unavailable` or `ignoreUnavailable`
 |`boolean` - Whether specified concrete indices should be ignored when unavailable (missing or closed)
@@ -2416,6 +2469,7 @@ _Default:_ `all`
 |===
 
 === indices.existsTemplate
+
 [source,ts]
 ----
 client.indices.existsTemplate({
@@ -2443,6 +2497,7 @@ link:{ref}/indices-templates.html[Reference]
 |===
 
 === indices.existsType
+
 [source,ts]
 ----
 client.indices.existsType({
@@ -2479,6 +2534,7 @@ _Default:_ `open`
 |===
 
 === indices.flush
+
 [source,ts]
 ----
 client.indices.flush({
@@ -2515,6 +2571,7 @@ _Default:_ `open`
 |===
 
 === indices.flushSynced
+
 [source,ts]
 ----
 client.indices.flushSynced({
@@ -2543,6 +2600,7 @@ _Default:_ `open`
 |===
 
 === indices.forcemerge
+
 [source,ts]
 ----
 client.indices.forcemerge({
@@ -2583,6 +2641,7 @@ _Default:_ `open`
 |===
 
 === indices.get
+
 [source,ts]
 ----
 client.indices.get({
@@ -2631,11 +2690,12 @@ _Default:_ `open`
 |===
 
 === indices.getAlias
+
 [source,ts]
 ----
 client.indices.getAlias({
-  index: string | string[],
   name: string | string[],
+  index: string | string[],
   ignore_unavailable: boolean,
   allow_no_indices: boolean,
   expand_wildcards: 'open' | 'closed' | 'none' | 'all',
@@ -2645,11 +2705,11 @@ client.indices.getAlias({
 link:{ref}/indices-aliases.html[Reference]
 [cols=2*]
 |===
-|`index`
-|`string \| string[]` - A comma-separated list of index names to filter aliases
-
 |`name`
 |`string \| string[]` - A comma-separated list of alias names to return
+
+|`index`
+|`string \| string[]` - A comma-separated list of index names to filter aliases
 
 |`ignore_unavailable` or `ignoreUnavailable`
 |`boolean` - Whether specified concrete indices should be ignored when unavailable (missing or closed)
@@ -2667,12 +2727,13 @@ _Default:_ `all`
 |===
 
 === indices.getFieldMapping
+
 [source,ts]
 ----
 client.indices.getFieldMapping({
+  fields: string | string[],
   index: string | string[],
   type: string | string[],
-  fields: string | string[],
   include_type_name: boolean,
   include_defaults: boolean,
   ignore_unavailable: boolean,
@@ -2684,14 +2745,16 @@ client.indices.getFieldMapping({
 link:{ref}/indices-get-field-mapping.html[Reference]
 [cols=2*]
 |===
+|`fields`
+|`string \| string[]` - A comma-separated list of fields
+
 |`index`
 |`string \| string[]` - A comma-separated list of index names
 
 |`type`
-|`string \| string[]` - A comma-separated list of document types
+|`string \| string[]` - A comma-separated list of document types +
 
-|`fields`
-|`string \| string[]` - A comma-separated list of fields
+WARNING: This parameter has been deprecated.
 
 |`include_type_name` or `includeTypeName`
 |`boolean` - Whether a type should be returned in the body of the mappings.
@@ -2715,6 +2778,7 @@ _Default:_ `open`
 |===
 
 === indices.getMapping
+
 [source,ts]
 ----
 client.indices.getMapping({
@@ -2735,7 +2799,9 @@ link:{ref}/indices-get-mapping.html[Reference]
 |`string \| string[]` - A comma-separated list of index names
 
 |`type`
-|`string \| string[]` - A comma-separated list of document types
+|`string \| string[]` - A comma-separated list of document types +
+
+WARNING: This parameter has been deprecated.
 
 |`include_type_name` or `includeTypeName`
 |`boolean` - Whether to add the type name to the response (default: false)
@@ -2759,6 +2825,7 @@ _Default:_ `open`
 |===
 
 === indices.getSettings
+
 [source,ts]
 ----
 client.indices.getSettings({
@@ -2807,6 +2874,7 @@ _Default:_ `open,closed`
 |===
 
 === indices.getTemplate
+
 [source,ts]
 ----
 client.indices.getTemplate({
@@ -2838,6 +2906,7 @@ link:{ref}/indices-templates.html[Reference]
 |===
 
 === indices.getUpgrade
+
 [source,ts]
 ----
 client.indices.getUpgrade({
@@ -2866,6 +2935,7 @@ _Default:_ `open`
 |===
 
 === indices.open
+
 [source,ts]
 ----
 client.indices.open({
@@ -2906,6 +2976,7 @@ _Default:_ `closed`
 |===
 
 === indices.putAlias
+
 [source,ts]
 ----
 client.indices.putAlias({
@@ -2937,6 +3008,7 @@ link:{ref}/indices-aliases.html[Reference]
 |===
 
 === indices.putMapping
+
 [source,ts]
 ----
 client.indices.putMapping({
@@ -2958,7 +3030,9 @@ link:{ref}/indices-put-mapping.html[Reference]
 |`string \| string[]` - A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.
 
 |`type`
-|`string` - The name of the document type
+|`string` - The name of the document type +
+
+WARNING: This parameter has been deprecated.
 
 |`include_type_name` or `includeTypeName`
 |`boolean` - Whether a type should be expected in the body of the mappings.
@@ -2985,6 +3059,7 @@ _Default:_ `open`
 |===
 
 === indices.putSettings
+
 [source,ts]
 ----
 client.indices.putSettings({
@@ -3033,6 +3108,7 @@ _Default:_ `open`
 |===
 
 === indices.putTemplate
+
 [source,ts]
 ----
 client.indices.putTemplate({
@@ -3076,6 +3152,7 @@ link:{ref}/indices-templates.html[Reference]
 |===
 
 === indices.recovery
+
 [source,ts]
 ----
 client.indices.recovery({
@@ -3099,6 +3176,7 @@ link:{ref}/indices-recovery.html[Reference]
 |===
 
 === indices.refresh
+
 [source,ts]
 ----
 client.indices.refresh({
@@ -3127,6 +3205,7 @@ _Default:_ `open`
 |===
 
 === indices.rollover
+
 [source,ts]
 ----
 client.indices.rollover({
@@ -3170,6 +3249,7 @@ link:{ref}/indices-rollover-index.html[Reference]
 |===
 
 === indices.segments
+
 [source,ts]
 ----
 client.indices.segments({
@@ -3202,6 +3282,7 @@ _Default:_ `open`
 |===
 
 === indices.shardStores
+
 [source,ts]
 ----
 client.indices.shardStores({
@@ -3234,6 +3315,7 @@ _Default:_ `open`
 |===
 
 === indices.shrink
+
 [source,ts]
 ----
 client.indices.shrink({
@@ -3269,6 +3351,7 @@ link:{ref}/indices-shrink-index.html[Reference]
 |===
 
 === indices.split
+
 [source,ts]
 ----
 client.indices.split({
@@ -3304,11 +3387,12 @@ link:{ref}/indices-split-index.html[Reference]
 |===
 
 === indices.stats
+
 [source,ts]
 ----
 client.indices.stats({
-  index: string | string[],
   metric: string | string[],
+  index: string | string[],
   completion_fields: string | string[],
   fielddata_fields: string | string[],
   fields: string | string[],
@@ -3324,11 +3408,11 @@ client.indices.stats({
 link:{ref}/indices-stats.html[Reference]
 [cols=2*]
 |===
-|`index`
-|`string \| string[]` - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-
 |`metric`
 |`string \| string[]` - Limit the information returned the specific metrics.
+
+|`index`
+|`string \| string[]` - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
 
 |`completion_fields` or `completionFields`
 |`string \| string[]` - A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)
@@ -3366,6 +3450,7 @@ _Default:_ `true`
 |===
 
 === indices.updateAliases
+
 [source,ts]
 ----
 client.indices.updateAliases({
@@ -3389,6 +3474,7 @@ link:{ref}/indices-aliases.html[Reference]
 |===
 
 === indices.upgrade
+
 [source,ts]
 ----
 client.indices.upgrade({
@@ -3425,6 +3511,7 @@ _Default:_ `open`
 |===
 
 === indices.validateQuery
+
 [source,ts]
 ----
 client.indices.validateQuery({
@@ -3452,7 +3539,9 @@ link:{ref}/search-validate.html[Reference]
 |`string \| string[]` - A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices
 
 |`type`
-|`string \| string[]` - A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types
+|`string \| string[]` - A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types +
+
+WARNING: This parameter has been deprecated.
 
 |`explain`
 |`boolean` - Return detailed information about the error
@@ -3498,6 +3587,7 @@ _Default:_ `OR`
 |===
 
 === info
+
 [source,ts]
 ----
 client.info()
@@ -3506,6 +3596,7 @@ link:{ref}/index.html[Reference]
 
 
 === ingest.deletePipeline
+
 [source,ts]
 ----
 client.ingest.deletePipeline({
@@ -3529,6 +3620,7 @@ link:{ref}/delete-pipeline-api.html[Reference]
 |===
 
 === ingest.getPipeline
+
 [source,ts]
 ----
 client.ingest.getPipeline({
@@ -3548,6 +3640,7 @@ link:{ref}/get-pipeline-api.html[Reference]
 |===
 
 === ingest.processorGrok
+
 [source,ts]
 ----
 client.ingest.processorGrok()
@@ -3556,6 +3649,7 @@ link:{ref}/grok-processor.html#grok-processor-rest-get[Reference]
 
 
 === ingest.putPipeline
+
 [source,ts]
 ----
 client.ingest.putPipeline({
@@ -3583,6 +3677,7 @@ link:{ref}/put-pipeline-api.html[Reference]
 |===
 
 === ingest.simulate
+
 [source,ts]
 ----
 client.ingest.simulate({
@@ -3606,6 +3701,7 @@ link:{ref}/simulate-pipeline-api.html[Reference]
 |===
 
 === mget
+
 [source,ts]
 ----
 client.mget({
@@ -3629,7 +3725,9 @@ link:{ref}/docs-multi-get.html[Reference]
 |`string` - The name of the index
 
 |`type`
-|`string` - The type of the document
+|`string` - The type of the document +
+
+WARNING: This parameter has been deprecated.
 
 |`stored_fields` or `storedFields`
 |`string \| string[]` - A comma-separated list of stored fields to return in the response
@@ -3661,6 +3759,7 @@ link:{ref}/docs-multi-get.html[Reference]
 |===
 
 === msearch
+
 [source,ts]
 ----
 client.msearch({
@@ -3711,6 +3810,7 @@ _Default:_ `true`
 |===
 
 === msearchTemplate
+
 [source,ts]
 ----
 client.msearchTemplate({
@@ -3751,6 +3851,7 @@ _Default:_ `true`
 |===
 
 === mtermvectors
+
 [source,ts]
 ----
 client.mtermvectors({
@@ -3822,6 +3923,7 @@ _Default:_ `true`
 |===
 
 === nodes.hotThreads
+
 [source,ts]
 ----
 client.nodes.hotThreads({
@@ -3861,6 +3963,7 @@ link:{ref}/cluster-nodes-hot-threads.html[Reference]
 |===
 
 === nodes.info
+
 [source,ts]
 ----
 client.nodes.info({
@@ -3888,6 +3991,7 @@ link:{ref}/cluster-nodes-info.html[Reference]
 |===
 
 === nodes.reloadSecureSettings
+
 [source,ts]
 ----
 client.nodes.reloadSecureSettings({
@@ -3907,12 +4011,13 @@ link:{ref}/secure-settings.html#reloadable-secure-settings[Reference]
 |===
 
 === nodes.stats
+
 [source,ts]
 ----
 client.nodes.stats({
+  node_id: string | string[],
   metric: string | string[],
   index_metric: string | string[],
-  node_id: string | string[],
   completion_fields: string | string[],
   fielddata_fields: string | string[],
   fields: string | string[],
@@ -3926,14 +4031,14 @@ client.nodes.stats({
 link:{ref}/cluster-nodes-stats.html[Reference]
 [cols=2*]
 |===
+|`node_id` or `nodeId`
+|`string \| string[]` - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
+
 |`metric`
 |`string \| string[]` - Limit the information returned to the specified metrics
 
 |`index_metric` or `indexMetric`
 |`string \| string[]` - Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified.
-
-|`node_id` or `nodeId`
-|`string \| string[]` - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
 
 |`completion_fields` or `completionFields`
 |`string \| string[]` - A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)
@@ -3963,22 +4068,23 @@ _Default:_ `node`
 |===
 
 === nodes.usage
+
 [source,ts]
 ----
 client.nodes.usage({
-  metric: string | string[],
   node_id: string | string[],
+  metric: string | string[],
   timeout: string
 })
 ----
 link:{ref}/cluster-nodes-usage.html[Reference]
 [cols=2*]
 |===
-|`metric`
-|`string \| string[]` - Limit the information returned to the specified metrics
-
 |`node_id` or `nodeId`
 |`string \| string[]` - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
+
+|`metric`
+|`string \| string[]` - Limit the information returned to the specified metrics
 
 |`timeout`
 |`string` - Explicit operation timeout
@@ -3986,6 +4092,7 @@ link:{ref}/cluster-nodes-usage.html[Reference]
 |===
 
 === ping
+
 [source,ts]
 ----
 client.ping()
@@ -3994,6 +4101,7 @@ link:{ref}/index.html[Reference]
 
 
 === putScript
+
 [source,ts]
 ----
 client.putScript({
@@ -4001,7 +4109,6 @@ client.putScript({
   context: string,
   timeout: string,
   master_timeout: string,
-  context: string,
   body: object
 })
 ----
@@ -4020,15 +4127,13 @@ link:{ref}/modules-scripting.html[Reference]
 |`master_timeout` or `masterTimeout`
 |`string` - Specify timeout for connection to master
 
-|`context`
-|`string` - Context name to compile script against
-
 |`body`
 |`object` - The document
 
 |===
 
 === rankEval
+*Stability:* experimental
 [source,ts]
 ----
 client.rankEval({
@@ -4061,6 +4166,7 @@ _Default:_ `open`
 |===
 
 === reindex
+
 [source,ts]
 ----
 client.reindex({
@@ -4112,6 +4218,7 @@ _Default:_ `1`
 |===
 
 === reindexRethrottle
+
 [source,ts]
 ----
 client.reindexRethrottle({
@@ -4131,6 +4238,7 @@ link:{ref}/docs-reindex.html[Reference]
 |===
 
 === renderSearchTemplate
+
 [source,ts]
 ----
 client.renderSearchTemplate({
@@ -4150,6 +4258,7 @@ link:{ref}/search-template.html#_validating_templates[Reference]
 |===
 
 === scriptsPainlessExecute
+*Stability:* experimental
 [source,ts]
 ----
 client.scriptsPainlessExecute({
@@ -4165,12 +4274,12 @@ link:https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-exec
 |===
 
 === scroll
+
 [source,ts]
 ----
 client.scroll({
   scroll_id: string,
   scroll: string,
-  scroll_id: string,
   rest_total_hits_as_int: boolean,
   body: object
 })
@@ -4179,13 +4288,12 @@ link:{ref}/search-request-body.html#request-body-search-scroll[Reference]
 [cols=2*]
 |===
 |`scroll_id` or `scrollId`
-|`string` - The scroll ID
+|`string` - The scroll ID +
+
+WARNING: This parameter has been deprecated.
 
 |`scroll`
 |`string` - Specify how long a consistent view of the index should be maintained for scrolled search
-
-|`scroll_id` or `scrollId`
-|`string` - The scroll ID for scrolled search
 
 |`rest_total_hits_as_int` or `restTotalHitsAsInt`
 |`boolean` - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
@@ -4196,6 +4304,7 @@ link:{ref}/search-request-body.html#request-body-search-scroll[Reference]
 |===
 
 === search
+
 [source,ts]
 ----
 client.search({
@@ -4391,6 +4500,7 @@ _Default:_ `128`
 |===
 
 === searchShards
+
 [source,ts]
 ----
 client.searchShards({
@@ -4431,6 +4541,7 @@ _Default:_ `open`
 |===
 
 === searchTemplate
+
 [source,ts]
 ----
 client.searchTemplate({
@@ -4503,7 +4614,36 @@ _Default:_ `true`
 
 |===
 
+=== snapshot.cleanupRepository
+
+[source,ts]
+----
+client.snapshot.cleanupRepository({
+  repository: string,
+  master_timeout: string,
+  timeout: string,
+  body: object
+})
+----
+link:{ref}/modules-snapshots.html[Reference]
+[cols=2*]
+|===
+|`repository`
+|`string` - A repository name
+
+|`master_timeout` or `masterTimeout`
+|`string` - Explicit operation timeout for connection to master node
+
+|`timeout`
+|`string` - Explicit operation timeout
+
+|`body`
+|`object` - undefined
+
+|===
+
 === snapshot.create
+
 [source,ts]
 ----
 client.snapshot.create({
@@ -4535,6 +4675,7 @@ link:{ref}/modules-snapshots.html[Reference]
 |===
 
 === snapshot.createRepository
+
 [source,ts]
 ----
 client.snapshot.createRepository({
@@ -4566,6 +4707,7 @@ link:{ref}/modules-snapshots.html[Reference]
 |===
 
 === snapshot.delete
+
 [source,ts]
 ----
 client.snapshot.delete({
@@ -4589,6 +4731,7 @@ link:{ref}/modules-snapshots.html[Reference]
 |===
 
 === snapshot.deleteRepository
+
 [source,ts]
 ----
 client.snapshot.deleteRepository({
@@ -4612,6 +4755,7 @@ link:{ref}/modules-snapshots.html[Reference]
 |===
 
 === snapshot.get
+
 [source,ts]
 ----
 client.snapshot.get({
@@ -4643,6 +4787,7 @@ link:{ref}/modules-snapshots.html[Reference]
 |===
 
 === snapshot.getRepository
+
 [source,ts]
 ----
 client.snapshot.getRepository({
@@ -4666,6 +4811,7 @@ link:{ref}/modules-snapshots.html[Reference]
 |===
 
 === snapshot.restore
+
 [source,ts]
 ----
 client.snapshot.restore({
@@ -4697,6 +4843,7 @@ link:{ref}/modules-snapshots.html[Reference]
 |===
 
 === snapshot.status
+
 [source,ts]
 ----
 client.snapshot.status({
@@ -4724,6 +4871,7 @@ link:{ref}/modules-snapshots.html[Reference]
 |===
 
 === snapshot.verifyRepository
+
 [source,ts]
 ----
 client.snapshot.verifyRepository({
@@ -4747,6 +4895,7 @@ link:{ref}/modules-snapshots.html[Reference]
 |===
 
 === tasks.cancel
+
 [source,ts]
 ----
 client.tasks.cancel({
@@ -4774,6 +4923,7 @@ link:{ref}/tasks.html[Reference]
 |===
 
 === tasks.get
+
 [source,ts]
 ----
 client.tasks.get({
@@ -4797,6 +4947,7 @@ link:{ref}/tasks.html[Reference]
 |===
 
 === tasks.list
+
 [source,ts]
 ----
 client.tasks.list({
@@ -4837,6 +4988,7 @@ _Default:_ `nodes`
 |===
 
 === termvectors
+
 [source,ts]
 ----
 client.termvectors({
@@ -4908,6 +5060,7 @@ _Default:_ `true`
 |===
 
 === update
+
 [source,ts]
 ----
 client.update({
@@ -4938,7 +5091,9 @@ link:{ref}/docs-update.html[Reference]
 |`string` - The name of the index
 
 |`type`
-|`string` - The type of the document
+|`string` - The type of the document +
+
+WARNING: This parameter has been deprecated.
 
 |`wait_for_active_shards` or `waitForActiveShards`
 |`string` - Sets the number of shard copies that must be active before proceeding with the update operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
@@ -4979,6 +5134,7 @@ link:{ref}/docs-update.html[Reference]
 |===
 
 === updateByQuery
+
 [source,ts]
 ----
 client.updateByQuery({
@@ -5140,6 +5296,7 @@ _Default:_ `1`
 |===
 
 === updateByQueryRethrottle
+
 [source,ts]
 ----
 client.updateByQueryRethrottle({
@@ -5159,6 +5316,7 @@ link:{ref}/docs-update-by-query.html[Reference]
 |===
 
 === ccr.deleteAutoFollowPattern
+
 [source,ts]
 ----
 client.ccr.deleteAutoFollowPattern({
@@ -5174,6 +5332,7 @@ link:{ref}/ccr-delete-auto-follow-pattern.html[Reference]
 |===
 
 === ccr.follow
+
 [source,ts]
 ----
 client.ccr.follow({
@@ -5198,6 +5357,7 @@ _Default:_ `0`
 |===
 
 === ccr.followInfo
+
 [source,ts]
 ----
 client.ccr.followInfo({
@@ -5213,6 +5373,7 @@ link:{ref}/ccr-get-follow-info.html[Reference]
 |===
 
 === ccr.followStats
+
 [source,ts]
 ----
 client.ccr.followStats({
@@ -5228,6 +5389,7 @@ link:{ref}/ccr-get-follow-stats.html[Reference]
 |===
 
 === ccr.forgetFollower
+
 [source,ts]
 ----
 client.ccr.forgetFollower({
@@ -5247,6 +5409,7 @@ link:http://www.elastic.co/guide/en/elasticsearch/reference/current[Reference]
 |===
 
 === ccr.getAutoFollowPattern
+
 [source,ts]
 ----
 client.ccr.getAutoFollowPattern({
@@ -5262,6 +5425,7 @@ link:{ref}/ccr-get-auto-follow-pattern.html[Reference]
 |===
 
 === ccr.pauseFollow
+
 [source,ts]
 ----
 client.ccr.pauseFollow({
@@ -5277,6 +5441,7 @@ link:{ref}/ccr-post-pause-follow.html[Reference]
 |===
 
 === ccr.putAutoFollowPattern
+
 [source,ts]
 ----
 client.ccr.putAutoFollowPattern({
@@ -5296,6 +5461,7 @@ link:{ref}/ccr-put-auto-follow-pattern.html[Reference]
 |===
 
 === ccr.resumeFollow
+
 [source,ts]
 ----
 client.ccr.resumeFollow({
@@ -5315,6 +5481,7 @@ link:{ref}/ccr-post-resume-follow.html[Reference]
 |===
 
 === ccr.stats
+
 [source,ts]
 ----
 client.ccr.stats()
@@ -5323,6 +5490,7 @@ link:{ref}/ccr-get-stats.html[Reference]
 
 
 === ccr.unfollow
+
 [source,ts]
 ----
 client.ccr.unfollow({
@@ -5338,6 +5506,7 @@ link:http://www.elastic.co/guide/en/elasticsearch/reference/current[Reference]
 |===
 
 === dataFrame.deleteDataFrameTransform
+*Stability:* beta
 [source,ts]
 ----
 client.dataFrame.deleteDataFrameTransform({
@@ -5357,6 +5526,7 @@ link:{ref}/delete-data-frame-transform.html[Reference]
 |===
 
 === dataFrame.getDataFrameTransform
+*Stability:* beta
 [source,ts]
 ----
 client.dataFrame.getDataFrameTransform({
@@ -5384,6 +5554,7 @@ link:{ref}/get-data-frame-transform.html[Reference]
 |===
 
 === dataFrame.getDataFrameTransformStats
+*Stability:* beta
 [source,ts]
 ----
 client.dataFrame.getDataFrameTransformStats({
@@ -5411,6 +5582,7 @@ link:{ref}/get-data-frame-transform-stats.html[Reference]
 |===
 
 === dataFrame.previewDataFrameTransform
+*Stability:* beta
 [source,ts]
 ----
 client.dataFrame.previewDataFrameTransform({
@@ -5426,6 +5598,7 @@ link:{ref}/preview-data-frame-transform.html[Reference]
 |===
 
 === dataFrame.putDataFrameTransform
+*Stability:* beta
 [source,ts]
 ----
 client.dataFrame.putDataFrameTransform({
@@ -5449,6 +5622,7 @@ link:{ref}/put-data-frame-transform.html[Reference]
 |===
 
 === dataFrame.startDataFrameTransform
+*Stability:* beta
 [source,ts]
 ----
 client.dataFrame.startDataFrameTransform({
@@ -5468,6 +5642,7 @@ link:{ref}/start-data-frame-transform.html[Reference]
 |===
 
 === dataFrame.stopDataFrameTransform
+*Stability:* beta
 [source,ts]
 ----
 client.dataFrame.stopDataFrameTransform({
@@ -5495,6 +5670,7 @@ link:{ref}/stop-data-frame-transform.html[Reference]
 |===
 
 === dataFrame.updateDataFrameTransform
+*Stability:* beta
 [source,ts]
 ----
 client.dataFrame.updateDataFrameTransform({
@@ -5518,6 +5694,7 @@ link:{ref}/update-data-frame-transform.html[Reference]
 |===
 
 === graph.explore
+
 [source,ts]
 ----
 client.graph.explore({
@@ -5535,7 +5712,9 @@ link:{ref}/graph-explore-api.html[Reference]
 |`string \| string[]` - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
 
 |`type`
-|`string \| string[]` - A comma-separated list of document types to search; leave empty to perform the operation on all types
+|`string \| string[]` - A comma-separated list of document types to search; leave empty to perform the operation on all types +
+
+WARNING: This parameter has been deprecated.
 
 |`routing`
 |`string` - Specific routing value
@@ -5549,6 +5728,7 @@ link:{ref}/graph-explore-api.html[Reference]
 |===
 
 === ilm.deleteLifecycle
+
 [source,ts]
 ----
 client.ilm.deleteLifecycle({
@@ -5564,6 +5744,7 @@ link:{ref}/ilm-delete-lifecycle.html[Reference]
 |===
 
 === ilm.explainLifecycle
+
 [source,ts]
 ----
 client.ilm.explainLifecycle({
@@ -5587,6 +5768,7 @@ link:{ref}/ilm-explain-lifecycle.html[Reference]
 |===
 
 === ilm.getLifecycle
+
 [source,ts]
 ----
 client.ilm.getLifecycle({
@@ -5602,6 +5784,7 @@ link:{ref}/ilm-get-lifecycle.html[Reference]
 |===
 
 === ilm.getStatus
+
 [source,ts]
 ----
 client.ilm.getStatus()
@@ -5610,6 +5793,7 @@ link:{ref}/ilm-get-status.html[Reference]
 
 
 === ilm.moveToStep
+
 [source,ts]
 ----
 client.ilm.moveToStep({
@@ -5629,6 +5813,7 @@ link:{ref}/ilm-move-to-step.html[Reference]
 |===
 
 === ilm.putLifecycle
+
 [source,ts]
 ----
 client.ilm.putLifecycle({
@@ -5648,6 +5833,7 @@ link:{ref}/ilm-put-lifecycle.html[Reference]
 |===
 
 === ilm.removePolicy
+
 [source,ts]
 ----
 client.ilm.removePolicy({
@@ -5663,6 +5849,7 @@ link:{ref}/ilm-remove-policy.html[Reference]
 |===
 
 === ilm.retry
+
 [source,ts]
 ----
 client.ilm.retry({
@@ -5678,6 +5865,7 @@ link:{ref}/ilm-retry-policy.html[Reference]
 |===
 
 === ilm.start
+
 [source,ts]
 ----
 client.ilm.start()
@@ -5686,6 +5874,7 @@ link:{ref}/ilm-start.html[Reference]
 
 
 === ilm.stop
+
 [source,ts]
 ----
 client.ilm.stop()
@@ -5694,6 +5883,7 @@ link:{ref}/ilm-stop.html[Reference]
 
 
 === indices.freeze
+
 [source,ts]
 ----
 client.indices.freeze({
@@ -5734,6 +5924,7 @@ _Default:_ `closed`
 |===
 
 === indices.reloadSearchAnalyzers
+*Stability:* experimental
 [source,ts]
 ----
 client.indices.reloadSearchAnalyzers({
@@ -5762,6 +5953,7 @@ _Default:_ `open`
 |===
 
 === indices.unfreeze
+
 [source,ts]
 ----
 client.indices.unfreeze({
@@ -5802,6 +5994,7 @@ _Default:_ `closed`
 |===
 
 === license.delete
+
 [source,ts]
 ----
 client.license.delete()
@@ -5810,6 +6003,7 @@ link:{ref}/delete-license.html[Reference]
 
 
 === license.get
+
 [source,ts]
 ----
 client.license.get({
@@ -5825,6 +6019,7 @@ link:{ref}/get-license.html[Reference]
 |===
 
 === license.getBasicStatus
+
 [source,ts]
 ----
 client.license.getBasicStatus()
@@ -5833,6 +6028,7 @@ link:{ref}/get-basic-status.html[Reference]
 
 
 === license.getTrialStatus
+
 [source,ts]
 ----
 client.license.getTrialStatus()
@@ -5841,6 +6037,7 @@ link:{ref}/get-trial-status.html[Reference]
 
 
 === license.post
+
 [source,ts]
 ----
 client.license.post({
@@ -5860,6 +6057,7 @@ link:{ref}/update-license.html[Reference]
 |===
 
 === license.postStartBasic
+
 [source,ts]
 ----
 client.license.postStartBasic({
@@ -5875,6 +6073,7 @@ link:{ref}/start-basic.html[Reference]
 |===
 
 === license.postStartTrial
+
 [source,ts]
 ----
 client.license.postStartTrial({
@@ -5894,6 +6093,7 @@ link:{ref}/start-trial.html[Reference]
 |===
 
 === migration.deprecations
+
 [source,ts]
 ----
 client.migration.deprecations({
@@ -5909,6 +6109,7 @@ link:{ref}/migration-api-deprecation.html[Reference]
 |===
 
 === ml.closeJob
+
 [source,ts]
 ----
 client.ml.closeJob({
@@ -5940,6 +6141,7 @@ link:{ref}/ml-close-job.html[Reference]
 |===
 
 === ml.deleteCalendar
+
 [source,ts]
 ----
 client.ml.deleteCalendar({
@@ -5954,6 +6156,7 @@ client.ml.deleteCalendar({
 |===
 
 === ml.deleteCalendarEvent
+
 [source,ts]
 ----
 client.ml.deleteCalendarEvent({
@@ -5972,6 +6175,7 @@ client.ml.deleteCalendarEvent({
 |===
 
 === ml.deleteCalendarJob
+
 [source,ts]
 ----
 client.ml.deleteCalendarJob({
@@ -5990,6 +6194,7 @@ client.ml.deleteCalendarJob({
 |===
 
 === ml.deleteDataFrameAnalytics
+*Stability:* experimental
 [source,ts]
 ----
 client.ml.deleteDataFrameAnalytics({
@@ -6005,6 +6210,7 @@ link:{ref}/delete-dfanalytics.html[Reference]
 |===
 
 === ml.deleteDatafeed
+
 [source,ts]
 ----
 client.ml.deleteDatafeed({
@@ -6024,6 +6230,7 @@ link:{ref}/ml-delete-datafeed.html[Reference]
 |===
 
 === ml.deleteExpiredData
+
 [source,ts]
 ----
 client.ml.deleteExpiredData()
@@ -6031,6 +6238,7 @@ client.ml.deleteExpiredData()
 
 
 === ml.deleteFilter
+
 [source,ts]
 ----
 client.ml.deleteFilter({
@@ -6045,6 +6253,7 @@ client.ml.deleteFilter({
 |===
 
 === ml.deleteForecast
+
 [source,ts]
 ----
 client.ml.deleteForecast({
@@ -6072,6 +6281,7 @@ link:{ref}/ml-delete-forecast.html[Reference]
 |===
 
 === ml.deleteJob
+
 [source,ts]
 ----
 client.ml.deleteJob({
@@ -6096,6 +6306,7 @@ _Default:_ `true`
 |===
 
 === ml.deleteModelSnapshot
+
 [source,ts]
 ----
 client.ml.deleteModelSnapshot({
@@ -6115,6 +6326,7 @@ link:{ref}/ml-delete-snapshot.html[Reference]
 |===
 
 === ml.estimateMemoryUsage
+*Stability:* experimental
 [source,ts]
 ----
 client.ml.estimateMemoryUsage({
@@ -6130,6 +6342,7 @@ link:{ref}/estimate-memory-usage-dfanalytics.html[Reference]
 |===
 
 === ml.evaluateDataFrame
+*Stability:* experimental
 [source,ts]
 ----
 client.ml.evaluateDataFrame({
@@ -6145,6 +6358,7 @@ link:{ref}/evaluate-dfanalytics.html[Reference]
 |===
 
 === ml.findFileStructure
+*Stability:* experimental
 [source,ts]
 ----
 client.ml.findFileStructure({
@@ -6219,6 +6433,7 @@ _Default:_ `25s`
 |===
 
 === ml.flushJob
+
 [source,ts]
 ----
 client.ml.flushJob({
@@ -6258,6 +6473,7 @@ link:{ref}/ml-flush-job.html[Reference]
 |===
 
 === ml.forecast
+
 [source,ts]
 ----
 client.ml.forecast({
@@ -6280,6 +6496,7 @@ client.ml.forecast({
 |===
 
 === ml.getBuckets
+
 [source,ts]
 ----
 client.ml.getBuckets({
@@ -6339,6 +6556,7 @@ link:{ref}/ml-get-bucket.html[Reference]
 |===
 
 === ml.getCalendarEvents
+
 [source,ts]
 ----
 client.ml.getCalendarEvents({
@@ -6373,6 +6591,7 @@ client.ml.getCalendarEvents({
 |===
 
 === ml.getCalendars
+
 [source,ts]
 ----
 client.ml.getCalendars({
@@ -6399,6 +6618,7 @@ client.ml.getCalendars({
 |===
 
 === ml.getCategories
+
 [source,ts]
 ----
 client.ml.getCategories({
@@ -6430,6 +6650,7 @@ link:{ref}/ml-get-category.html[Reference]
 |===
 
 === ml.getDataFrameAnalytics
+*Stability:* experimental
 [source,ts]
 ----
 client.ml.getDataFrameAnalytics({
@@ -6459,6 +6680,7 @@ _Default:_ `100`
 |===
 
 === ml.getDataFrameAnalyticsStats
+*Stability:* experimental
 [source,ts]
 ----
 client.ml.getDataFrameAnalyticsStats({
@@ -6488,6 +6710,7 @@ _Default:_ `100`
 |===
 
 === ml.getDatafeedStats
+
 [source,ts]
 ----
 client.ml.getDatafeedStats({
@@ -6507,6 +6730,7 @@ link:{ref}/ml-get-datafeed-stats.html[Reference]
 |===
 
 === ml.getDatafeeds
+
 [source,ts]
 ----
 client.ml.getDatafeeds({
@@ -6526,6 +6750,7 @@ link:{ref}/ml-get-datafeed.html[Reference]
 |===
 
 === ml.getFilters
+
 [source,ts]
 ----
 client.ml.getFilters({
@@ -6548,6 +6773,7 @@ client.ml.getFilters({
 |===
 
 === ml.getInfluencers
+
 [source,ts]
 ----
 client.ml.getInfluencers({
@@ -6599,6 +6825,7 @@ link:{ref}/ml-get-influencer.html[Reference]
 |===
 
 === ml.getJobStats
+
 [source,ts]
 ----
 client.ml.getJobStats({
@@ -6618,6 +6845,7 @@ link:{ref}/ml-get-job-stats.html[Reference]
 |===
 
 === ml.getJobs
+
 [source,ts]
 ----
 client.ml.getJobs({
@@ -6637,6 +6865,7 @@ link:{ref}/ml-get-job.html[Reference]
 |===
 
 === ml.getModelSnapshots
+
 [source,ts]
 ----
 client.ml.getModelSnapshots({
@@ -6684,6 +6913,7 @@ link:{ref}/ml-get-snapshot.html[Reference]
 |===
 
 === ml.getOverallBuckets
+
 [source,ts]
 ----
 client.ml.getOverallBuckets({
@@ -6731,6 +6961,7 @@ link:{ref}/ml-get-overall-buckets.html[Reference]
 |===
 
 === ml.getRecords
+
 [source,ts]
 ----
 client.ml.getRecords({
@@ -6782,6 +7013,7 @@ link:{ref}/ml-get-record.html[Reference]
 |===
 
 === ml.info
+
 [source,ts]
 ----
 client.ml.info()
@@ -6789,12 +7021,11 @@ client.ml.info()
 
 
 === ml.openJob
+
 [source,ts]
 ----
 client.ml.openJob({
-  job_id: string,
-  ignore_downtime: boolean,
-  timeout: string
+  job_id: string
 })
 ----
 link:{ref}/ml-open-job.html[Reference]
@@ -6803,15 +7034,10 @@ link:{ref}/ml-open-job.html[Reference]
 |`job_id` or `jobId`
 |`string` - The ID of the job to open
 
-|`ignore_downtime` or `ignoreDowntime`
-|`boolean` - Controls if gaps in data are treated as anomalous or as a maintenance window after a job re-start
-
-|`timeout`
-|`string` - Controls the time to wait until a job has opened. Default to 30 minutes
-
 |===
 
 === ml.postCalendarEvents
+
 [source,ts]
 ----
 client.ml.postCalendarEvents({
@@ -6830,6 +7056,7 @@ client.ml.postCalendarEvents({
 |===
 
 === ml.postData
+
 [source,ts]
 ----
 client.ml.postData({
@@ -6857,6 +7084,7 @@ link:{ref}/ml-post-data.html[Reference]
 |===
 
 === ml.previewDatafeed
+
 [source,ts]
 ----
 client.ml.previewDatafeed({
@@ -6872,6 +7100,7 @@ link:{ref}/ml-preview-datafeed.html[Reference]
 |===
 
 === ml.putCalendar
+
 [source,ts]
 ----
 client.ml.putCalendar({
@@ -6890,6 +7119,7 @@ client.ml.putCalendar({
 |===
 
 === ml.putCalendarJob
+
 [source,ts]
 ----
 client.ml.putCalendarJob({
@@ -6908,6 +7138,7 @@ client.ml.putCalendarJob({
 |===
 
 === ml.putDataFrameAnalytics
+*Stability:* experimental
 [source,ts]
 ----
 client.ml.putDataFrameAnalytics({
@@ -6927,6 +7158,7 @@ link:{ref}/put-dfanalytics.html[Reference]
 |===
 
 === ml.putDatafeed
+
 [source,ts]
 ----
 client.ml.putDatafeed({
@@ -6946,6 +7178,7 @@ link:{ref}/ml-put-datafeed.html[Reference]
 |===
 
 === ml.putFilter
+
 [source,ts]
 ----
 client.ml.putFilter({
@@ -6964,6 +7197,7 @@ client.ml.putFilter({
 |===
 
 === ml.putJob
+
 [source,ts]
 ----
 client.ml.putJob({
@@ -6983,6 +7217,7 @@ link:{ref}/ml-put-job.html[Reference]
 |===
 
 === ml.revertModelSnapshot
+
 [source,ts]
 ----
 client.ml.revertModelSnapshot({
@@ -7010,6 +7245,7 @@ link:{ref}/ml-revert-snapshot.html[Reference]
 |===
 
 === ml.setUpgradeMode
+
 [source,ts]
 ----
 client.ml.setUpgradeMode({
@@ -7029,6 +7265,7 @@ link:{ref}/ml-set-upgrade-mode.html[Reference]
 |===
 
 === ml.startDataFrameAnalytics
+*Stability:* experimental
 [source,ts]
 ----
 client.ml.startDataFrameAnalytics({
@@ -7052,6 +7289,7 @@ link:{ref}/start-dfanalytics.html[Reference]
 |===
 
 === ml.startDatafeed
+
 [source,ts]
 ----
 client.ml.startDatafeed({
@@ -7083,6 +7321,7 @@ link:{ref}/ml-start-datafeed.html[Reference]
 |===
 
 === ml.stopDataFrameAnalytics
+*Stability:* experimental
 [source,ts]
 ----
 client.ml.stopDataFrameAnalytics({
@@ -7114,6 +7353,7 @@ link:{ref}/stop-dfanalytics.html[Reference]
 |===
 
 === ml.stopDatafeed
+
 [source,ts]
 ----
 client.ml.stopDatafeed({
@@ -7141,6 +7381,7 @@ link:{ref}/ml-stop-datafeed.html[Reference]
 |===
 
 === ml.updateDatafeed
+
 [source,ts]
 ----
 client.ml.updateDatafeed({
@@ -7160,6 +7401,7 @@ link:{ref}/ml-update-datafeed.html[Reference]
 |===
 
 === ml.updateFilter
+
 [source,ts]
 ----
 client.ml.updateFilter({
@@ -7178,6 +7420,7 @@ client.ml.updateFilter({
 |===
 
 === ml.updateJob
+
 [source,ts]
 ----
 client.ml.updateJob({
@@ -7197,6 +7440,7 @@ link:{ref}/ml-update-job.html[Reference]
 |===
 
 === ml.updateModelSnapshot
+
 [source,ts]
 ----
 client.ml.updateModelSnapshot({
@@ -7220,6 +7464,7 @@ link:{ref}/ml-update-snapshot.html[Reference]
 |===
 
 === ml.validate
+
 [source,ts]
 ----
 client.ml.validate({
@@ -7234,6 +7479,7 @@ client.ml.validate({
 |===
 
 === ml.validateDetector
+
 [source,ts]
 ----
 client.ml.validateDetector({
@@ -7248,6 +7494,7 @@ client.ml.validateDetector({
 |===
 
 === monitoring.bulk
+*Stability:* experimental
 [source,ts]
 ----
 client.monitoring.bulk({
@@ -7262,7 +7509,9 @@ link:{ref}/es-monitoring.html[Reference]
 [cols=2*]
 |===
 |`type`
-|`string` - Default document type for items which don't provide one
+|`string` - Default document type for items which don't provide one +
+
+WARNING: This parameter has been deprecated.
 
 |`system_id` or `systemId`
 |`string` - Identifier of the monitored system
@@ -7279,6 +7528,7 @@ link:{ref}/es-monitoring.html[Reference]
 |===
 
 === rollup.deleteJob
+*Stability:* experimental
 [source,ts]
 ----
 client.rollup.deleteJob({
@@ -7293,6 +7543,7 @@ client.rollup.deleteJob({
 |===
 
 === rollup.getJobs
+*Stability:* experimental
 [source,ts]
 ----
 client.rollup.getJobs({
@@ -7307,6 +7558,7 @@ client.rollup.getJobs({
 |===
 
 === rollup.getRollupCaps
+*Stability:* experimental
 [source,ts]
 ----
 client.rollup.getRollupCaps({
@@ -7321,6 +7573,7 @@ client.rollup.getRollupCaps({
 |===
 
 === rollup.getRollupIndexCaps
+*Stability:* experimental
 [source,ts]
 ----
 client.rollup.getRollupIndexCaps({
@@ -7335,6 +7588,7 @@ client.rollup.getRollupIndexCaps({
 |===
 
 === rollup.putJob
+*Stability:* experimental
 [source,ts]
 ----
 client.rollup.putJob({
@@ -7353,6 +7607,7 @@ client.rollup.putJob({
 |===
 
 === rollup.rollupSearch
+*Stability:* experimental
 [source,ts]
 ----
 client.rollup.rollupSearch({
@@ -7369,7 +7624,9 @@ client.rollup.rollupSearch({
 |`string \| string[]` - The indices or index-pattern(s) (containing rollup or regular data) that should be searched
 
 |`type`
-|`string` - The doc type inside the index
+|`string` - The doc type inside the index +
+
+WARNING: This parameter has been deprecated.
 
 |`typed_keys` or `typedKeys`
 |`boolean` - Specify whether aggregation and suggester names should be prefixed by their respective types in the response
@@ -7383,6 +7640,7 @@ client.rollup.rollupSearch({
 |===
 
 === rollup.startJob
+*Stability:* experimental
 [source,ts]
 ----
 client.rollup.startJob({
@@ -7397,6 +7655,7 @@ client.rollup.startJob({
 |===
 
 === rollup.stopJob
+*Stability:* experimental
 [source,ts]
 ----
 client.rollup.stopJob({
@@ -7419,6 +7678,7 @@ client.rollup.stopJob({
 |===
 
 === security.authenticate
+
 [source,ts]
 ----
 client.security.authenticate()
@@ -7427,6 +7687,7 @@ link:{ref}/security-api-authenticate.html[Reference]
 
 
 === security.changePassword
+
 [source,ts]
 ----
 client.security.changePassword({
@@ -7450,6 +7711,7 @@ link:{ref}/security-api-change-password.html[Reference]
 |===
 
 === security.clearCachedRealms
+
 [source,ts]
 ----
 client.security.clearCachedRealms({
@@ -7469,6 +7731,7 @@ link:{ref}/security-api-clear-cache.html[Reference]
 |===
 
 === security.clearCachedRoles
+
 [source,ts]
 ----
 client.security.clearCachedRoles({
@@ -7484,6 +7747,7 @@ link:{ref}/security-api-clear-role-cache.html[Reference]
 |===
 
 === security.createApiKey
+
 [source,ts]
 ----
 client.security.createApiKey({
@@ -7503,6 +7767,7 @@ link:{ref}/security-api-create-api-key.html[Reference]
 |===
 
 === security.deletePrivileges
+
 [source,ts]
 ----
 client.security.deletePrivileges({
@@ -7526,6 +7791,7 @@ link:TODO[Reference]
 |===
 
 === security.deleteRole
+
 [source,ts]
 ----
 client.security.deleteRole({
@@ -7545,6 +7811,7 @@ link:{ref}/security-api-delete-role.html[Reference]
 |===
 
 === security.deleteRoleMapping
+
 [source,ts]
 ----
 client.security.deleteRoleMapping({
@@ -7564,6 +7831,7 @@ link:{ref}/security-api-delete-role-mapping.html[Reference]
 |===
 
 === security.deleteUser
+
 [source,ts]
 ----
 client.security.deleteUser({
@@ -7583,6 +7851,7 @@ link:{ref}/security-api-delete-user.html[Reference]
 |===
 
 === security.disableUser
+
 [source,ts]
 ----
 client.security.disableUser({
@@ -7602,6 +7871,7 @@ link:{ref}/security-api-disable-user.html[Reference]
 |===
 
 === security.enableUser
+
 [source,ts]
 ----
 client.security.enableUser({
@@ -7621,6 +7891,7 @@ link:{ref}/security-api-enable-user.html[Reference]
 |===
 
 === security.getApiKey
+
 [source,ts]
 ----
 client.security.getApiKey({
@@ -7648,6 +7919,7 @@ link:{ref}/security-api-get-api-key.html[Reference]
 |===
 
 === security.getBuiltinPrivileges
+
 [source,ts]
 ----
 client.security.getBuiltinPrivileges()
@@ -7656,6 +7928,7 @@ link:{ref}/security-api-get-builtin-privileges.html[Reference]
 
 
 === security.getPrivileges
+
 [source,ts]
 ----
 client.security.getPrivileges({
@@ -7675,6 +7948,7 @@ link:{ref}/security-api-get-privileges.html[Reference]
 |===
 
 === security.getRole
+
 [source,ts]
 ----
 client.security.getRole({
@@ -7690,6 +7964,7 @@ link:{ref}/security-api-get-role.html[Reference]
 |===
 
 === security.getRoleMapping
+
 [source,ts]
 ----
 client.security.getRoleMapping({
@@ -7705,6 +7980,7 @@ link:{ref}/security-api-get-role-mapping.html[Reference]
 |===
 
 === security.getToken
+
 [source,ts]
 ----
 client.security.getToken({
@@ -7720,6 +7996,7 @@ link:{ref}/security-api-get-token.html[Reference]
 |===
 
 === security.getUser
+
 [source,ts]
 ----
 client.security.getUser({
@@ -7735,6 +8012,7 @@ link:{ref}/security-api-get-user.html[Reference]
 |===
 
 === security.getUserPrivileges
+
 [source,ts]
 ----
 client.security.getUserPrivileges()
@@ -7743,6 +8021,7 @@ link:{ref}/security-api-get-privileges.html[Reference]
 
 
 === security.hasPrivileges
+
 [source,ts]
 ----
 client.security.hasPrivileges({
@@ -7762,6 +8041,7 @@ link:{ref}/security-api-has-privileges.html[Reference]
 |===
 
 === security.invalidateApiKey
+
 [source,ts]
 ----
 client.security.invalidateApiKey({
@@ -7777,6 +8057,7 @@ link:{ref}/security-api-invalidate-api-key.html[Reference]
 |===
 
 === security.invalidateToken
+
 [source,ts]
 ----
 client.security.invalidateToken({
@@ -7792,6 +8073,7 @@ link:{ref}/security-api-invalidate-token.html[Reference]
 |===
 
 === security.putPrivileges
+
 [source,ts]
 ----
 client.security.putPrivileges({
@@ -7811,6 +8093,7 @@ link:TODO[Reference]
 |===
 
 === security.putRole
+
 [source,ts]
 ----
 client.security.putRole({
@@ -7834,6 +8117,7 @@ link:{ref}/security-api-put-role.html[Reference]
 |===
 
 === security.putRoleMapping
+
 [source,ts]
 ----
 client.security.putRoleMapping({
@@ -7857,6 +8141,7 @@ link:{ref}/security-api-put-role-mapping.html[Reference]
 |===
 
 === security.putUser
+
 [source,ts]
 ----
 client.security.putUser({
@@ -7880,6 +8165,7 @@ link:{ref}/security-api-put-user.html[Reference]
 |===
 
 === slm.deleteLifecycle
+
 [source,ts]
 ----
 client.slm.deleteLifecycle({
@@ -7895,6 +8181,7 @@ link:{ref}/slm-api-delete.html[Reference]
 |===
 
 === slm.executeLifecycle
+
 [source,ts]
 ----
 client.slm.executeLifecycle({
@@ -7910,6 +8197,7 @@ link:{ref}/slm-api-execute.html[Reference]
 |===
 
 === slm.getLifecycle
+
 [source,ts]
 ----
 client.slm.getLifecycle({
@@ -7924,7 +8212,17 @@ link:{ref}/slm-api-get.html[Reference]
 
 |===
 
+=== slm.getStats
+
+[source,ts]
+----
+client.slm.getStats()
+----
+link:{ref}/slm-api.html[Reference]
+
+
 === slm.putLifecycle
+
 [source,ts]
 ----
 client.slm.putLifecycle({
@@ -7944,6 +8242,7 @@ link:{ref}/slm-api-put.html[Reference]
 |===
 
 === sql.clearCursor
+
 [source,ts]
 ----
 client.sql.clearCursor({
@@ -7959,6 +8258,7 @@ link:Clear SQL cursor[Reference]
 |===
 
 === sql.query
+
 [source,ts]
 ----
 client.sql.query({
@@ -7978,6 +8278,7 @@ link:Execute SQL[Reference]
 |===
 
 === sql.translate
+
 [source,ts]
 ----
 client.sql.translate({
@@ -7993,6 +8294,7 @@ link:Translate SQL into Elasticsearch queries[Reference]
 |===
 
 === ssl.certificates
+
 [source,ts]
 ----
 client.ssl.certificates()
@@ -8001,6 +8303,7 @@ link:{ref}/security-api-ssl.html[Reference]
 
 
 === watcher.ackWatch
+
 [source,ts]
 ----
 client.watcher.ackWatch({
@@ -8020,6 +8323,7 @@ link:{ref}/watcher-api-ack-watch.html[Reference]
 |===
 
 === watcher.activateWatch
+
 [source,ts]
 ----
 client.watcher.activateWatch({
@@ -8035,6 +8339,7 @@ link:{ref}/watcher-api-activate-watch.html[Reference]
 |===
 
 === watcher.deactivateWatch
+
 [source,ts]
 ----
 client.watcher.deactivateWatch({
@@ -8050,6 +8355,7 @@ link:{ref}/watcher-api-deactivate-watch.html[Reference]
 |===
 
 === watcher.deleteWatch
+
 [source,ts]
 ----
 client.watcher.deleteWatch({
@@ -8065,6 +8371,7 @@ link:{ref}/watcher-api-delete-watch.html[Reference]
 |===
 
 === watcher.executeWatch
+
 [source,ts]
 ----
 client.watcher.executeWatch({
@@ -8088,6 +8395,7 @@ link:{ref}/watcher-api-execute-watch.html[Reference]
 |===
 
 === watcher.getWatch
+
 [source,ts]
 ----
 client.watcher.getWatch({
@@ -8103,6 +8411,7 @@ link:{ref}/watcher-api-get-watch.html[Reference]
 |===
 
 === watcher.putWatch
+
 [source,ts]
 ----
 client.watcher.putWatch({
@@ -8138,6 +8447,7 @@ link:{ref}/watcher-api-put-watch.html[Reference]
 |===
 
 === watcher.start
+
 [source,ts]
 ----
 client.watcher.start()
@@ -8146,10 +8456,10 @@ link:{ref}/watcher-api-start.html[Reference]
 
 
 === watcher.stats
+
 [source,ts]
 ----
 client.watcher.stats({
-  metric: string | string[],
   metric: string | string[],
   emit_stacktraces: boolean
 })
@@ -8160,15 +8470,13 @@ link:{ref}/watcher-api-stats.html[Reference]
 |`metric`
 |`string \| string[]` - Controls what additional stat metrics should be include in the response
 
-|`metric`
-|`string \| string[]` - Controls what additional stat metrics should be include in the response
-
 |`emit_stacktraces` or `emitStacktraces`
 |`boolean` - Emits stack traces of currently running watches
 
 |===
 
 === watcher.stop
+
 [source,ts]
 ----
 client.watcher.stop()
@@ -8177,6 +8485,7 @@ link:{ref}/watcher-api-stop.html[Reference]
 
 
 === xpack.info
+
 [source,ts]
 ----
 client.xpack.info({
@@ -8192,6 +8501,7 @@ link:{ref}/info-api.html[Reference]
 |===
 
 === xpack.usage
+
 [source,ts]
 ----
 client.xpack.usage({

--- a/index.d.ts
+++ b/index.d.ts
@@ -569,10 +569,14 @@ declare class Client extends EventEmitter {
     executeLifecycle: ApiMethod<RequestParams.SlmExecuteLifecycle>
     get_lifecycle: ApiMethod<RequestParams.SlmGetLifecycle>
     getLifecycle: ApiMethod<RequestParams.SlmGetLifecycle>
+    get_stats: ApiMethod<RequestParams.SlmGetStats>
+    getStats: ApiMethod<RequestParams.SlmGetStats>
     put_lifecycle: ApiMethod<RequestParams.SlmPutLifecycle>
     putLifecycle: ApiMethod<RequestParams.SlmPutLifecycle>
   }
   snapshot: {
+    cleanup_repository: ApiMethod<RequestParams.SnapshotCleanupRepository>
+    cleanupRepository: ApiMethod<RequestParams.SnapshotCleanupRepository>
     create: ApiMethod<RequestParams.SnapshotCreate>
     create_repository: ApiMethod<RequestParams.SnapshotCreateRepository>
     createRepository: ApiMethod<RequestParams.SnapshotCreateRepository>

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -101,6 +101,8 @@ function start (opts) {
       log.text = `Processing ${file}`
 
       const spec = require(join(apiFolder, file))
+      // const { stability } = spec[Object.keys(spec)[0]]
+      // if (stability !== 'stable') return
       allSpec.push(spec)
       const code = generate(opts.branch || opts.tag, spec, common)
       const filePath = join(apiOutputFolder, `${file.slice(0, file.lastIndexOf('.'))}.js`)

--- a/scripts/utils/generateRequestTypes.js
+++ b/scripts/utils/generateRequestTypes.js
@@ -33,11 +33,34 @@ export interface Generic {
       .replace(/\.([a-z])/g, k => k[1].toUpperCase())
       .replace(/_([a-z])/g, k => k[1].toUpperCase())
 
-    const { parts = {}, params = {} } = spec[api].url
-    const { body } = spec[api]
+    const { paths = {} } = spec[api].url
+    const { body, params = {} } = spec[api]
 
-    const partsArr = Object.keys(parts)
-      .map(k => ({ key: k, value: parts[k] }))
+    // get the required parts from the url
+    // if the url has at least one static path,
+    // then there are not required parts of the url
+    var allParts = []
+    var requiredParts = []
+    for (const path of paths) {
+      if (path.parts) {
+        allParts.push(Object.keys(path.parts))
+      } else {
+        allParts = []
+        break
+      }
+    }
+    if (allParts.length > 0) {
+      requiredParts = intersect(...allParts)
+    }
+
+    const parts = paths.reduce((acc, path) => {
+      if (!path.parts) return acc
+      for (const part in path.parts) {
+        if (acc[part] != null) continue
+        acc[part] = { key: part, value: path.parts[part], required: requiredParts.includes(part) }
+      }
+      return acc
+    }, {})
     const deprecatedParametersToAdd = []
     const paramsArr = Object.keys(params)
       .filter(k => !Object.keys(parts).includes(k))
@@ -45,16 +68,18 @@ export interface Generic {
         if (deprecatedParameters[release] && deprecatedParameters[release][k]) {
           deprecatedParametersToAdd.push({
             key: deprecatedParameters[release][k],
-            value: params[k]
+            value: params[k],
+            required: params[k].required
           })
         }
-        return { key: k, value: params[k] }
+        return { key: k, value: params[k], required: params[k].required }
       })
 
+    const partsArr = Object.keys(parts).map(k => parts[k])
     deprecatedParametersToAdd.forEach(k => partsArr.push(k))
 
     const genLine = e => {
-      const optional = e.value.required ? '' : '?'
+      const optional = e.required ? '' : '?'
       return `${e.key}${optional}: ${getType(e.value.type, e.value.options)};`
     }
 
@@ -89,6 +114,12 @@ export interface ${name[0].toUpperCase() + name.slice(1)}${body ? '<T = any>' : 
         return type
     }
   }
+}
+
+function intersect (first, ...rest) {
+  return rest.reduce((accum, current) => {
+    return accum.filter(x => current.indexOf(x) !== -1)
+  }, first)
 }
 
 module.exports = generate


### PR DESCRIPTION
This pr updates the code generation scripts to use the new spec format introduced in https://github.com/elastic/elasticsearch/pull/42346.

Closes: https://github.com/elastic/elasticsearch-js/issues/944
Fixes: https://github.com/elastic/elasticsearch-js/issues/931

Notable changes:
- The generated code does not contain the full parameter list, but only a brief description of the API and the URL of the documentation.
- The reference.asciidoc now signals deprecated parameter and unstable APIs.
- The generated code has more flexible handling of the HTTP method.

This needs to be backported to `7.x`.