### PR TITLE
[DOCS] Update docs for 'synced flush' and 'SLM' APIs

### DIFF
--- a/api/api/indices.flush_synced.js
+++ b/api/api/indices.flush_synced.js
@@ -33,7 +33,7 @@ function buildIndicesFlushSynced (opts) {
   /**
    * Perform a indices.flush_synced request
    * Performs a synced flush operation on one or more indices.
-   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html#synced-flush-api
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush-api.html
    */
   return function indicesFlushSynced (params, options, callback) {
     options = options || {}

--- a/api/api/slm.get_stats.js
+++ b/api/api/slm.get_stats.js
@@ -21,7 +21,7 @@ function buildSlmGetStats (opts) {
 
   /**
    * Perform a slm.get_stats request
-   * https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api.html
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-get-stats.html
    */
   return function slmGetStats (params, options, callback) {
     options = options || {}

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -2617,7 +2617,7 @@ client.indices.flushSynced({
   expand_wildcards: 'open' | 'closed' | 'none' | 'all'
 })
 ----
-link:{ref}/indices-flush.html#synced-flush-api[Reference]
+link:{ref}/indices-synced-flush-api.html[Reference]
 [cols=2*]
 |===
 |`index`

--- a/index.d.ts
+++ b/index.d.ts
@@ -195,8 +195,6 @@ declare class Client extends EventEmitter {
     startDataFrameTransform: ApiMethod<RequestParams.DataFrameStartDataFrameTransform>
     stop_data_frame_transform: ApiMethod<RequestParams.DataFrameStopDataFrameTransform>
     stopDataFrameTransform: ApiMethod<RequestParams.DataFrameStopDataFrameTransform>
-    update_data_frame_transform: ApiMethod<RequestParams.DataFrameUpdateDataFrameTransform>
-    updateDataFrameTransform: ApiMethod<RequestParams.DataFrameUpdateDataFrameTransform>
   }
   dataFrame: {
     delete_data_frame_transform: ApiMethod<RequestParams.DataFrameDeleteDataFrameTransform>
@@ -213,8 +211,6 @@ declare class Client extends EventEmitter {
     startDataFrameTransform: ApiMethod<RequestParams.DataFrameStartDataFrameTransform>
     stop_data_frame_transform: ApiMethod<RequestParams.DataFrameStopDataFrameTransform>
     stopDataFrameTransform: ApiMethod<RequestParams.DataFrameStopDataFrameTransform>
-    update_data_frame_transform: ApiMethod<RequestParams.DataFrameUpdateDataFrameTransform>
-    updateDataFrameTransform: ApiMethod<RequestParams.DataFrameUpdateDataFrameTransform>
   }
   delete: ApiMethod<RequestParams.Delete>
   delete_by_query: ApiMethod<RequestParams.DeleteByQuery>
@@ -261,7 +257,6 @@ declare class Client extends EventEmitter {
     analyze: ApiMethod<RequestParams.IndicesAnalyze>
     clear_cache: ApiMethod<RequestParams.IndicesClearCache>
     clearCache: ApiMethod<RequestParams.IndicesClearCache>
-    clone: ApiMethod<RequestParams.IndicesClone>
     close: ApiMethod<RequestParams.IndicesClose>
     create: ApiMethod<RequestParams.IndicesCreate>
     delete: ApiMethod<RequestParams.IndicesDelete>
@@ -373,8 +368,6 @@ declare class Client extends EventEmitter {
     deleteJob: ApiMethod<RequestParams.MlDeleteJob>
     delete_model_snapshot: ApiMethod<RequestParams.MlDeleteModelSnapshot>
     deleteModelSnapshot: ApiMethod<RequestParams.MlDeleteModelSnapshot>
-    estimate_memory_usage: ApiMethod<RequestParams.MlEstimateMemoryUsage>
-    estimateMemoryUsage: ApiMethod<RequestParams.MlEstimateMemoryUsage>
     evaluate_data_frame: ApiMethod<RequestParams.MlEvaluateDataFrame>
     evaluateDataFrame: ApiMethod<RequestParams.MlEvaluateDataFrame>
     find_file_structure: ApiMethod<RequestParams.MlFindFileStructure>
@@ -569,14 +562,10 @@ declare class Client extends EventEmitter {
     executeLifecycle: ApiMethod<RequestParams.SlmExecuteLifecycle>
     get_lifecycle: ApiMethod<RequestParams.SlmGetLifecycle>
     getLifecycle: ApiMethod<RequestParams.SlmGetLifecycle>
-    get_stats: ApiMethod<RequestParams.SlmGetStats>
-    getStats: ApiMethod<RequestParams.SlmGetStats>
     put_lifecycle: ApiMethod<RequestParams.SlmPutLifecycle>
     putLifecycle: ApiMethod<RequestParams.SlmPutLifecycle>
   }
   snapshot: {
-    cleanup_repository: ApiMethod<RequestParams.SnapshotCleanupRepository>
-    cleanupRepository: ApiMethod<RequestParams.SnapshotCleanupRepository>
     create: ApiMethod<RequestParams.SnapshotCreate>
     create_repository: ApiMethod<RequestParams.SnapshotCreateRepository>
     createRepository: ApiMethod<RequestParams.SnapshotCreateRepository>


### PR DESCRIPTION
Regenerates docs to include the following changes from Elasticsearch documentation:

- Synced flush API link change: https://github.com/elastic/elasticsearch/pull/46634
- SLM API link change: https://github.com/elastic/elasticsearch/pull/46838

Plan to backport to 7.x.