### PR TITLE
[DOCS] Fine-tunes the Node.Js client authentication section

### DIFF
--- a/docs/authentication.asciidoc
+++ b/docs/authentication.asciidoc
@@ -1,19 +1,25 @@
 [[auth-reference]]
 == Authentication
 
-This document contains code snippets to show you how to connect to various Elasticsearch providers.
+This document contains code snippets to show you how to connect to various {es} 
+providers.
 
 
 === Elastic Cloud
 
-If you are using https://www.elastic.co/cloud[Elastic Cloud], the client offers a easy way to connect to it via the `cloud` option. +
-You must pass the Cloud ID that you can find in the cloud console, then your username and password inside the `auth` option.
+If you are using https://www.elastic.co/cloud[Elastic Cloud], the client offers 
+an easy way to connect to it via the `cloud` option. You must pass the Cloud ID 
+that you can find in the cloud console, then your username and password inside 
+the `auth` option.
 
-NOTE: When connecting to Elastic Cloud, the client will automatically enable both request and response compression by default, since it yields significant throughput improvements. +
-Moreover, the client will also set the ssl option `secureProtocol` to `TLSv1_2_method` unless specified otherwise.
-You can still override this option by configuring them.
+NOTE: When connecting to Elastic Cloud, the client will automatically enable 
+both request and response compression by default, since it yields significant 
+throughput improvements. Moreover, the client will also set the ssl option 
+`secureProtocol` to `TLSv1_2_method` unless specified otherwise. You can still 
+override this option by configuring them.
 
-IMPORTANT: Do not enable sniffing when using Elastic Cloud, since the nodes are behind a load balancer, Elastic Cloud will take care of everything for you.
+IMPORTANT: Do not enable sniffing when using Elastic Cloud, since the nodes are 
+behind a load balancer, Elastic Cloud will take care of everything for you.
 
 [source,js]
 ----
@@ -29,9 +35,11 @@ const client = new Client({
 })
 ----
 
+
 === Basic authentication
 
-You can provide your credentials by passing the `username` and `password` parameters via the `auth` option.
+You can provide your credentials by passing the `username` and `password` 
+parameters via the `auth` option.
 
 [source,js]
 ----
@@ -45,6 +53,7 @@ const client = new Client({
 })
 ----
 
+
 Otherwise, you can provide your credentials in the node(s) URL.
 
 [source,js]
@@ -55,10 +64,15 @@ const client = new Client({
 })
 ----
 
+
 === ApiKey authentication
 
-You can use the https://www.elastic.co/guide/en/elasticsearch/reference/7.x/security-api-create-api-key.html[ApiKey] authentication by passing the `apiKey` parameter via the `auth` option. +
-The `apiKey` parameter can be either a base64 encoded string or an object with the values that you can obtain from the https://www.elastic.co/guide/en/elasticsearch/reference/7.x/security-api-create-api-key.html[create api key endpoint].
+You can use the 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.x/security-api-create-api-key.html[ApiKey] 
+authentication by passing the `apiKey` parameter via the `auth` option. The 
+`apiKey` parameter can be either a base64 encoded string or an object with the 
+values that you can obtain from the 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.x/security-api-create-api-key.html[create api key endpoint].
 
 [source,js]
 ----
@@ -88,7 +102,14 @@ const client = new Client({
 
 === SSL configuration
 
-Without any additional configuration you can specify `https://` node urls, but the certificates used to sign these requests will not verified (`rejectUnauthorized: false`). To turn on certificate verification you must specify an `ssl` object either in the top level config or in each host config object and set `rejectUnauthorized: true`. The ssl config object can contain many of the same configuration options that https://nodejs.org/api/tls.html#tls_tls_connect_options_callback[tls.connect()] accepts.
+Without any additional configuration you can specify `https://` node urls, but 
+the certificates used to sign these requests will not verified 
+(`rejectUnauthorized: false`). To turn on certificate verification, you must 
+specify an `ssl` object either in the top level config or in each host config 
+object and set `rejectUnauthorized: true`. The ssl config object can contain 
+many of the same configuration options that 
+https://nodejs.org/api/tls.html#tls_tls_connect_options_callback[tls.connect()] 
+accepts.
 
 [source,js]
 ----


### PR DESCRIPTION
This PR fine-tunes the wording of the authentication section in the Node.js book and improves readability.

Related issue: elastic/stack-docs#594