### PR TITLE
Removed repeated `type` field in `bulk` api docs 6.x

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -43,7 +43,6 @@ client.bulk({
   refresh: 'true' | 'false' | 'wait_for',
   routing: string,
   timeout: string,
-  type: string,
   fields: string | string[],
   _source: string | string[],
   _source_excludes: string | string[],

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -72,9 +72,6 @@ link:{ref}/docs-bulk.html[Reference]
 |`timeout`
 |`string` - Explicit operation timeout
 
-|`type`
-|`string` - Default document type for items which don't provide one
-
 |`fields`
 |`string \| string[]` - Default comma-separated list of fields to return in the response for updates, can be overridden on each sub-request
 


### PR DESCRIPTION
The `type` field is repeated twice in the `bulk` API reference documentation:

<img width="712" alt="Screenshot 2019-12-18 at 15 48 42" src="https://user-images.githubusercontent.com/205629/71096070-fa436100-21ad-11ea-9653-d9700ef1e389.png">

