### PR TITLE
ClientOptions["cloud"] should have optional auth fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,8 +101,8 @@ interface ClientOptions {
   cloud?: {
     id: string;
     // TODO: remove username and password here in 8
-    username: string;
-    password: string;
+    username?: string;
+    password?: string;
   }
 }
 


### PR DESCRIPTION
This changes the optional username and password under `cloud` to actually be optional.

```diff
  cloud?: {
    id: string;
    // TODO: remove username and password here in 8
-    username: string;
-    password: string;
+    username?: string;
+    password?: string;
  }
```

This lets the documented workflow where the `cloud.id` is specified along with traditional `auth` work in TypeScript without cheating.

Prior to this PR, the workaround is:

```ts
  return new Client({
    cloud: {
      id: env.CLOUD_ID,
    } as ClientOptions['cloud'], // note: in 7.5.0 it has the optional user/pass as not optional
    auth: {
      username: env.USERNAME,
      password: env.PASSWORD,
    },
  });
```