### PR TITLE
Fix in bulk api reference body content

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -121,7 +121,7 @@ link:{ref}/docs-bulk.html[Reference]
 |`string` - The pipeline id to preprocess incoming documents with
 
 |`body`
-|`object` - The operation definition and data (action-data pairs), separated by newlines
+|`array` - The operation definition and data (action-data pairs) are used as array members. Data is optional according to action type. E.g. [action,data,action,action,data]
 
 |===
 

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -84,7 +84,7 @@ client.bulk({
   _source_excludes: string | string[],
   _source_includes: string | string[],
   pipeline: string,
-  body: object
+  body: array
 })
 ----
 link:{ref}/docs-bulk.html[Reference]

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -84,7 +84,7 @@ client.bulk({
   _source_excludes: string | string[],
   _source_includes: string | string[],
   pipeline: string,
-  body: array
+  body: object[]
 })
 ----
 link:{ref}/docs-bulk.html[Reference]
@@ -121,7 +121,7 @@ link:{ref}/docs-bulk.html[Reference]
 |`string` - The pipeline id to preprocess incoming documents with
 
 |`body`
-|`array` - The operation definition and data (action-data pairs) are used as array members. Data is optional according to action type. E.g. [action,data,action,action,data]
+|`object[]` - The operation definition and data (action-data pair) objects are used as array members. Data is optional according to action type. E.g. [action,data,action,action,data]
 
 |===
 


### PR DESCRIPTION
Bulk api's body argument type is an 'array'. It was 'object' in documentation and changed to 'array', also added cleaner description.
About #686
