### PR TITLE
[DOC] Example link added for bulk request

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -88,6 +88,7 @@ client.bulk({
 })
 ----
 link:{ref}/docs-bulk.html[Reference]
+<<bulk_examples,Example>>
 [cols=2*]
 |===
 |`index`


### PR DESCRIPTION
See link: https://github.com/elastic/elasticsearch/pull/50699#discussion_r365110384

There is a misunderstanding about bulk request in NodeJS api client doc so i added an example link after advise from @delvedor .