### PR TITLE
Change TransportRequestOptions.ignore to number[]

### DIFF
--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -81,7 +81,7 @@ export interface TransportRequestParams {
 }
 
 export interface TransportRequestOptions {
-  ignore?: [number];
+  ignore?: number[];
   requestTimeout?: number | string;
   maxRetries?: number;
   asStream?: boolean;


### PR DESCRIPTION
The underlying JavaScript handles arrays of any length. The current type of TransportRequestOptions.ignore, which is [number], only allows arrays with length==1, which looks like a mistake, and prevents the ignore API from being usable when we want to ignore multiple error statuses (which I do).