### PR TITLE
Skip compression in case of empty string body

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -130,15 +130,17 @@ class Transport {
             return callback(err, result)
           }
         }
-        headers['Content-Type'] = headers['Content-Type'] || 'application/json'
 
-        if (compression === 'gzip') {
-          if (isStream(params.body) === false) {
-            params.body = intoStream(params.body).pipe(createGzip())
-          } else {
-            params.body = params.body.pipe(createGzip())
+        if (params.body !== '') {
+          headers['Content-Type'] = headers['Content-Type'] || 'application/json'
+          if (compression === 'gzip') {
+            if (isStream(params.body) === false) {
+              params.body = intoStream(params.body).pipe(createGzip())
+            } else {
+              params.body = params.body.pipe(createGzip())
+            }
+            headers['Content-Encoding'] = compression
           }
-          headers['Content-Encoding'] = compression
         }
 
         if (isStream(params.body) === false) {

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -34,7 +34,6 @@ test('Should emit a request event when a request is performed', t => {
             body: '',
             querystring: 'q=foo%3Abar',
             headers: {
-              'Content-Type': 'application/json',
               'Content-Length': '0'
             }
           },
@@ -86,7 +85,6 @@ test('Should emit a response event in case of a successful response', t => {
             body: '',
             querystring: 'q=foo%3Abar',
             headers: {
-              'Content-Type': 'application/json',
               'Content-Length': '0'
             }
           },
@@ -136,7 +134,6 @@ test('Should emit a response event with the error set', t => {
             body: '',
             querystring: 'q=foo%3Abar',
             headers: {
-              'Content-Type': 'application/json',
               'Content-Length': '0'
             }
           },

--- a/test/unit/transport.test.js
+++ b/test/unit/transport.test.js
@@ -1813,6 +1813,55 @@ test('Compress request', t => {
     }
   })
 
+  t.test('Should skip the compression for empty strings/null/undefined', t => {
+    t.plan(9)
+
+    function handler (req, res) {
+      t.strictEqual(req.headers['content-encoding'], undefined)
+      t.strictEqual(req.headers['content-type'], undefined)
+      res.end()
+    }
+
+    buildServer(handler, ({ port }, server) => {
+      const pool = new ConnectionPool({ Connection })
+      pool.addConnection(`http://localhost:${port}`)
+
+      const transport = new Transport({
+        emit: () => {},
+        connectionPool: pool,
+        serializer: new Serializer(),
+        maxRetries: 3,
+        compression: 'gzip',
+        requestTimeout: 30000,
+        sniffInterval: false,
+        sniffOnStart: false
+      })
+
+      transport.request({
+        method: 'DELETE',
+        path: '/hello',
+        body: ''
+      }, (err, { body }) => {
+        t.error(err)
+        transport.request({
+          method: 'GET',
+          path: '/hello',
+          body: null
+        }, (err, { body }) => {
+          t.error(err)
+          transport.request({
+            method: 'GET',
+            path: '/hello',
+            body: undefined
+          }, (err, { body }) => {
+            t.error(err)
+            server.stop()
+          })
+        })
+      })
+    })
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
We should skip compression if the body is empty, as some proxy/load balancer could return an error because the body has a wrong format.

Fixes: #1069 