### PR TITLE
[DOCS] Fixes out-dated monitoring links

### DIFF
--- a/api/api/monitoring.bulk.js
+++ b/api/api/monitoring.bulk.js
@@ -25,7 +25,7 @@ function buildMonitoringBulk (opts) {
 
   /**
    * Perform a monitoring.bulk request
-   * https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html
    */
   return function monitoringBulk (params, options, callback) {
     options = options || {}

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -7946,7 +7946,7 @@ client.monitoring.bulk({
   body: object
 })
 ----
-link:{ref}/es-monitoring.html[Documentation] +
+link:{ref}/monitor-elasticsearch-cluster.html[Documentation] +
 [cols=2*]
 |===
 |`type`

--- a/scripts/utils/generateDocs.js
+++ b/scripts/utils/generateDocs.js
@@ -244,7 +244,7 @@ const LINK_OVERRIDES = {
   'license.post_start_basic': '{ref}/start-basic.html',
   'license.post_start_trial': '{ref}/start-trial.html',
   'migration.deprecations': '{ref}/migration-api-deprecation.html',
-  'monitoring.bulk': '{ref}/es-monitoring.html',
+  'monitoring.bulk': '{ref}/monitor-elasticsearch-cluster.html',
   'ingest.delete_pipeline': '{ref}/delete-pipeline-api.html',
   'ingest.get_pipeline': '{ref}/get-pipeline-api.html',
   'ingest.put_pipeline': '{ref}/put-pipeline-api.html',


### PR DESCRIPTION
This PR updates links that were pointing to a deleted page (https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html)

I have updated the links to point to the "Monitor a cluster" top-level section: https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html

Related to https://github.com/elastic/elasticsearch/pull/52790