### PR TITLE
ApiKey should take precedence over basic auth

### DIFF
--- a/docs/authentication.asciidoc
+++ b/docs/authentication.asciidoc
@@ -41,6 +41,8 @@ const client = new Client({
 You can provide your credentials by passing the `username` and `password` 
 parameters via the `auth` option.
 
+NOTE: If you provide both basic authentication credentials and the Api Key configuration, the Api Key will take precedence.
+
 [source,js]
 ----
 const { Client } = require('@elastic/elasticsearch')
@@ -73,6 +75,8 @@ authentication by passing the `apiKey` parameter via the `auth` option. The
 `apiKey` parameter can be either a base64 encoded string or an object with the 
 values that you can obtain from the 
 https://www.elastic.co/guide/en/elasticsearch/reference/7.x/security-api-create-api-key.html[create api key endpoint].
+
+NOTE: If you provide both basic authentication credentials and the Api Key configuration, the Api Key will take precedence.
 
 [source,js]
 ----

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -294,16 +294,14 @@ function resolve (host, path) {
 
 function prepareHeaders (headers = {}, auth) {
   if (auth != null && headers.authorization == null) {
-    if (auth.username && auth.password) {
-      headers.authorization = 'Basic ' + Buffer.from(`${auth.username}:${auth.password}`).toString('base64')
-    }
-
     if (auth.apiKey) {
       if (typeof auth.apiKey === 'object') {
         headers.authorization = 'ApiKey ' + Buffer.from(`${auth.apiKey.id}:${auth.apiKey.api_key}`).toString('base64')
       } else {
         headers.authorization = `ApiKey ${auth.apiKey}`
       }
+    } else if (auth.username && auth.password) {
+      headers.authorization = 'Basic ' + Buffer.from(`${auth.username}:${auth.password}`).toString('base64')
     }
   }
   return headers

--- a/lib/pool/BaseConnectionPool.js
+++ b/lib/pool/BaseConnectionPool.js
@@ -42,13 +42,13 @@ class BaseConnectionPool {
       opts = this.urlToHost(opts)
     }
 
-    if (opts.url.username !== '' && opts.url.password !== '') {
+    if (this.auth !== null) {
+      opts.auth = this.auth
+    } else if (opts.url.username !== '' && opts.url.password !== '') {
       opts.auth = {
         username: decodeURIComponent(opts.url.username),
         password: decodeURIComponent(opts.url.password)
       }
-    } else if (this.auth !== null) {
-      opts.auth = this.auth
     }
 
     if (opts.ssl == null) opts.ssl = this._ssl


### PR DESCRIPTION
Currently, the basic auth takes precedence, which is not correct. This pr addresses this issue.