### PR TITLE
[DOCS] Fixes link to cat transforms API

### DIFF
--- a/api/api/transform.cat_transform.js
+++ b/api/api/transform.cat_transform.js
@@ -30,7 +30,7 @@ function buildTransformCatTransform (opts) {
 
   /**
    * Perform a transform.cat_transform request
-   * https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transform.html
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html
    */
   return function transformCatTransform (params, options, callback) {
     options = options || {}

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -9175,7 +9175,7 @@ client.transform.catTransform({
   v: boolean
 })
 ----
-link:{ref}/cat-transform.html[Documentation] +
+link:{ref}/cat-transforms.html[Documentation] +
 [cols=2*]
 |===
 |`transform_id` or `transformId`


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/53743

There is a link from https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/master/api-reference.html to the Elasticsearch Reference (in particular a cat transforms API reference page) that is breaking because the file name is changing:

> 11:29:54 INFO:build_docs:Bad cross-document links:
11:29:54 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/master/api-reference.html:
11:29:54 INFO:build_docs:   - en/elasticsearch/reference/master/cat-transform.html

This PR attempts to fix that broken link.
