### PR TITLE
Prevent upstream error of getting property 'username' or 'password' o…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ interface ClientExtends {
 // /Extend API
 
 interface NodeOptions {
-  url: URL;
+  url: string | URL;
   id?: string;
   agent?: AgentOptions;
   ssl?: TlsConnectionOptions;

--- a/index.js
+++ b/index.js
@@ -243,6 +243,8 @@ function getAuth (node) {
         username: decodeURIComponent(node.url.username),
         password: decodeURIComponent(node.url.password)
       }
+    } else {
+      return {}
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -238,16 +238,20 @@ function getAuth (node) {
         username: decodeURIComponent(username),
         password: decodeURIComponent(password)
       }
-    } else if (node.url instanceof URL) {
+    }
+
+    if (typeof node === 'object' && node.url instanceof URL) {
       return {
         username: decodeURIComponent(node.url.username),
         password: decodeURIComponent(node.url.password)
       }
-    } else {
-      return {}
     }
-  }
-}
+
+    return {
+      username: undefined,
+      password: undefined
+    }
+  }}
 
 const events = {
   RESPONSE: 'response',

--- a/lib/ConfigurationHelpers.js
+++ b/lib/ConfigurationHelpers.js
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+'use strict'
+
+const { ConfigurationError } = require('./errors')
+
+function getAuth (nodes) {
+  nodes = nodes || []
+  nodes = Array.isArray(nodes) ? nodes : [nodes]
+
+  for (const node of nodes) {
+    const auth = getUsernameAndPassword(node)
+    if (auth.username) return auth
+  }
+
+  return null
+
+  function getUsernameAndPassword (node) {
+    let it = node && (node.url || node)
+    try {
+      it = it instanceof URL ? it : new URL((it && it.toString()))
+    } catch (e) {
+      throw new ConfigurationError(`invalid url in option "node${node.url ? '.url' : ''}": ${e.message}`)
+    }
+
+    return {
+      username: decodeURIComponent(it.username),
+      password: decodeURIComponent(it.password)
+    }
+  }
+}
+
+module.exports = {
+  getAuth
+}

--- a/test/unit/configuration-helpers.test.js
+++ b/test/unit/configuration-helpers.test.js
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+'use strict'
+
+const { test } = require('tap')
+const { getAuth } = require('../../lib/ConfigurationHelpers')
+const { ConfigurationError } = require('../../lib/errors')
+
+test('Should be a valid config with a string node', t => {
+  getAuth('http://foobar:9200')
+  t.end()
+})
+
+test('Should be a valid config with a string node & username + password', t => {
+  const auth = getAuth('http://u:p@foobar:9200')
+  t.equal(auth.username, 'u')
+  t.equal(auth.password, 'p')
+  t.end()
+})
+
+test('Should be a valid config with a string node & username + no password', t => {
+  const auth = getAuth('http://u@foobar:9200')
+  t.equal(auth.username, 'u')
+  t.equal(auth.password, '')
+  t.end()
+})
+
+test('Should be a valid config with a URL node', t => {
+  getAuth(new URL('http://foobar:9200'))
+  t.end()
+})
+
+test('Should be a valid config with a node object with string', t => {
+  getAuth({ url: 'http://foobar:9200' })
+  t.end()
+})
+
+test('Should be a valid config with a node object with URL', t => {
+  getAuth({ url: new URL('http://foobar:9200') })
+  t.end()
+})
+
+test('Should be an invalid config with a falsey node', t => {
+  t.throws(() => getAuth([{}]), ConfigurationError)
+  t.end()
+})
+
+test('Should be an invalid config with a falsey node.url', t => {
+  t.throws(() => getAuth({ url: undefined }), ConfigurationError, /^invalid url in option "node\.url"/)
+  t.end()
+})
+
+test('Should be an invalid config with a malformed URL in node', t => {
+  t.throws(() => getAuth('farts'), ConfigurationError, /^invalid url in option "node"/)
+  t.end()
+})
+
+test('Should be an invalid config with a malformed URL in node.url', t => {
+  t.throws(() => getAuth({ url: 'farts' }), ConfigurationError, /^invalid url in option "node\.url"/)
+  t.end()
+})


### PR DESCRIPTION
…f undefined

The prior implementation returns `undefined`, causing line 219 to fail, because it's getting property `username` of `undefined`.  This improves the situation by at least returning an empty object.

<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->
