### PR TITLE
Added async generator support in bulk helper

### DIFF
--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -43,7 +43,7 @@ To create a new instance of the Bulk helper, you should access it as shown in th
 [cols=2*]
 |===
 |`datasource`
-a|An array or a readable stream with the data you need to index/create/update/delete.
+a|An array, async generator or a readable stream with the data you need to index/create/update/delete.
 It can be an array of strings or objects, but also a stream of json strings or JavaScript objects. +
 If it is a stream, we recommend to use the https://www.npmjs.com/package/split2[`split2`] package, that will split the stream on new lines delimiters. +
 This parameter is mandatory.
@@ -180,6 +180,36 @@ const result = await client.helpers.bulk({
   },
   pipeline: 'my-pipeline'
 })
+----
+
+==== Usage with an async generator
+
+[source,js]
+----
+const { Client } = require('@elastic/elasticsearch')
+
+async function * generator () {
+  const dataset = [
+    { user: 'jon', age: 23 },
+    { user: 'arya', age: 18 },
+    { user: 'tyrion', age: 39 }
+  ]
+  for (const doc of dataset) {
+    yield doc
+  }
+}
+
+const client = new Client({ node: 'http://localhost:9200' })
+const result = await client.helpers.bulk({
+  datasource: generator(),
+  onDocument (doc) {
+    return {
+      index: { _index: 'my-index' }
+    }
+  }
+})
+
+console.log(result)
 ----
 
 === Search Helper

--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -10,7 +10,7 @@ export default class Helpers {
   search<TRequestBody extends RequestBody, TDocument = unknown>(params: Search<TRequestBody>, options?: TransportRequestOptions): Promise<TDocument[]>
   scrollSearch<TRequestBody extends RequestBody, TDocument = unknown, TResponse = ResponseBody, TContext = unknown>(params: Search<TRequestBody>, options?: TransportRequestOptions): AsyncIterable<ScrollSearchResponse<TDocument, TResponse, TContext>>
   scrollDocuments<TRequestBody extends RequestBody, TDocument = unknown>(params: Search<TRequestBody>, options?: TransportRequestOptions): AsyncIterable<TDocument>
-  bulk(options: BulkHelperOptions): BulkHelper<BulkStats>
+  bulk<TDocument = unknown>(options: BulkHelperOptions<TDocument>): BulkHelper<BulkStats>
 }
 
 export interface ScrollSearchResponse<TDocument = unknown, TResponse = ResponseBody, TContext = unknown> extends ApiResponse<TResponse, TContext> {
@@ -64,13 +64,13 @@ type UpdateAction = [UpdateActionOperation, Record<string, any>]
 type Action = IndexAction | CreateAction | UpdateAction | DeleteAction
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
-export interface BulkHelperOptions extends Omit<Bulk, 'body'> {
-  datasource: any[] | Buffer | ReadableStream | AsyncIterator<any>
-  onDocument: (doc: Record<string, any>) => Action
+export interface BulkHelperOptions<TDocument = unknown> extends Omit<Bulk, 'body'> {
+  datasource: TDocument[] | Buffer | ReadableStream | AsyncIterator<TDocument>
+  onDocument: (doc: TDocument) => Action
   flushBytes?: number
   concurrency?: number
   retries?: number
   wait?: number,
-  onDrop?: (doc: Record<string, any>) => void,
+  onDrop?: (doc: TDocument) => void,
   refreshOnCompletion?: boolean | string
 }

--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -71,6 +71,20 @@ export interface BulkHelperOptions<TDocument = unknown> extends Omit<Bulk, 'body
   concurrency?: number
   retries?: number
   wait?: number,
-  onDrop?: (doc: TDocument) => void,
+  onDrop?: (doc: OnDropDocument<TDocument>) => void,
   refreshOnCompletion?: boolean | string
+}
+
+export interface OnDropDocument<TDocument = unknown> {
+  status: number
+  error: {
+    type: string,
+    reason: string,
+    caused_by: {
+      type: string,
+      reason: string
+    }
+  }
+  document: TDocument
+  retried: boolean
 }

--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -65,7 +65,7 @@ type Action = IndexAction | CreateAction | UpdateAction | DeleteAction
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 export interface BulkHelperOptions extends Omit<Bulk, 'body'> {
-  datasource: any[] | Buffer | ReadableStream
+  datasource: any[] | Buffer | ReadableStream | AsyncIterator<any>
   onDocument: (doc: Record<string, any>) => Action
   flushBytes?: number
   concurrency?: number

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -158,8 +158,8 @@ class Helpers {
     if (datasource === undefined) {
       return Promise.reject(new ConfigurationError('bulk helper: the datasource is required'))
     }
-    if (!(Array.isArray(datasource) || Buffer.isBuffer(datasource) || typeof datasource.pipe === 'function')) {
-      return Promise.reject(new ConfigurationError('bulk helper: the datasource must be an array or a buffer or a readable stream'))
+    if (!(Array.isArray(datasource) || Buffer.isBuffer(datasource) || typeof datasource.pipe === 'function' || datasource[Symbol.asyncIterator])) {
+      return Promise.reject(new ConfigurationError('bulk helper: the datasource must be an array or a buffer or a readable stream or an async generator'))
     }
     if (onDocument === undefined) {
       return Promise.reject(new ConfigurationError('bulk helper: the onDocument callback is required'))

--- a/test/types/helpers.test-d.ts
+++ b/test/types/helpers.test-d.ts
@@ -9,7 +9,8 @@ import {
   BulkHelper,
   BulkStats,
   BulkHelperOptions,
-  ScrollSearchResponse
+  ScrollSearchResponse,
+  OnDropDocument
 } from '../../lib/Helpers'
 
 const client = new Client({
@@ -29,7 +30,7 @@ const b = client.helpers.bulk<Record<string, any>>({
   retries: 3,
   wait: 5000,
   onDrop (doc) {
-    expectType<Record<string, any>>(doc)
+    expectType<OnDropDocument<Record<string, any>>>(doc)
   },
   refreshOnCompletion: true,
   pipeline: 'my-pipeline'

--- a/test/types/helpers.test-d.ts
+++ b/test/types/helpers.test-d.ts
@@ -18,7 +18,7 @@ const client = new Client({
 
 /// .helpers.bulk
 
-const b = client.helpers.bulk({
+const b = client.helpers.bulk<Record<string, any>>({
   datasource: [],
   onDocument (doc) {
     expectType<Record<string, any>>(doc)
@@ -59,7 +59,7 @@ expectError(
       return { index: { _index: 'test' } } 
     }
   }
-  expectAssignable<BulkHelperOptions>(options)
+  expectAssignable<BulkHelperOptions<Record<string, any>>>(options)
 }
 // create
 {
@@ -69,20 +69,20 @@ expectError(
       return { create: { _index: 'test' } }
     }
   }
-  expectAssignable<BulkHelperOptions>(options)
+  expectAssignable<BulkHelperOptions<Record<string, any>>>(options)
 }
 // update
 {
   // without `:BulkHelperOptions` this test cannot pass
   // but if we write these options inline inside
   // a `.helper.bulk`, it works as expected
-  const options: BulkHelperOptions = {
+  const options: BulkHelperOptions<Record<string, any>> = {
     datasource: [],
     onDocument (doc: Record<string, any>) {
       return [{ update: { _index: 'test' } }, doc]
     }
   }
-  expectAssignable<BulkHelperOptions>(options)
+  expectAssignable<BulkHelperOptions<Record<string, any>>>(options)
 }
 // delete
 {
@@ -92,7 +92,7 @@ expectError(
       return { delete: { _index: 'test' } }
     }
   }
-  expectAssignable<BulkHelperOptions>(options)
+  expectAssignable<BulkHelperOptions<Record<string, any>>>(options)
 }
 
 /// .helpers.scrollSearch


### PR DESCRIPTION
Now you can use an async generator as datasource in the bulk helper!

```js
const { Client } = require('@elastic/elasticsearch')

async function * generator () {
  const dataset = [
    { user: 'jon', age: 23 },
    { user: 'arya', age: 18 },
    { user: 'tyrion', age: 39 }
  ]
  for (const doc of dataset) {
    yield doc
  }
}

const client = new Client({ node: 'http://localhost:9200' })
const result = await client.helpers.bulk({
  datasource: generator(),
  onDocument (doc) {
    return {
      index: { _index: 'my-index' }
    }
  }
})

console.log(result)
```