### PR TITLE
Fix flaky test

### DIFF
--- a/lib/pool/ConnectionPool.js
+++ b/lib/pool/ConnectionPool.js
@@ -32,6 +32,24 @@ class ConnectionPool extends BaseConnectionPool {
   }
 
   /**
+   * Checks if the connection is present in this.connections
+   *
+   * @param {number} connectionId
+   *
+   * @returns {boolean} True if the connection is found, otherwise False
+   */
+  hasConnection (connectionId) {
+    return this.connections.find(conn => conn.id === connectionId)
+  }
+
+  removeDead (connectionId) {
+    const index = this.dead.indexOf(connectionId)
+    if (index > -1) {
+      this.dead.splice(index, 1)
+    }
+  }
+
+  /**
    * Marks a connection as 'alive'.
    * If needed removes the connection from the dead list
    * and then resets the `deadCount`.
@@ -40,9 +58,14 @@ class ConnectionPool extends BaseConnectionPool {
    */
   markAlive (connection) {
     const { id } = connection
-    debug(`Marking as 'alive' connection '${id}'`)
-    const index = this.dead.indexOf(id)
-    if (index > -1) this.dead.splice(index, 1)
+    if (!this.hasConnection(id)) {
+      debug(`markAlive: Cannot mark connection '${id}' as alive (connection not found)`)
+      this.removeDead(id)
+      return
+    }
+
+    debug(`markAlive: Marking as 'alive' connection '${id}'`)
+    this.removeDead(id)
     connection.status = Connection.statuses.ALIVE
     connection.deadCount = 0
     connection.resurrectTimeout = 0
@@ -58,7 +81,12 @@ class ConnectionPool extends BaseConnectionPool {
    */
   markDead (connection) {
     const { id } = connection
-    debug(`Marking as 'dead' connection '${id}'`)
+    if (!this.hasConnection(id)) {
+      debug(`markDead: Cannot mark connection '${id}' as dead (connection not found)`)
+      return
+    }
+
+    debug(`markDead: Marking as 'dead' connection '${id}'`)
     if (this.dead.indexOf(id) === -1) {
       this.dead.push(id)
     }

--- a/test/behavior/resurrect.test.js
+++ b/test/behavior/resurrect.test.js
@@ -49,8 +49,7 @@ test('Should execute the recurrect API with the ping strategy', t => {
     })
 
     q.add((q, done) => {
-      cluster.kill('node0')
-      setTimeout(done, 100)
+      cluster.kill('node0', done)
     })
 
     q.add((q, done) => {
@@ -173,8 +172,7 @@ test('Should execute the recurrect API with the optimistic strategy', t => {
     })
 
     q.add((q, done) => {
-      cluster.kill('node0')
-      setTimeout(done, 100)
+      cluster.kill('node0', done)
     })
 
     q.add((q, done) => {


### PR DESCRIPTION
Fixes flaky **'Sniff interval'** in `sniff.test.js`.

The problem was caused by not waiting for the asynchronous `kill()` to finish the task,
before making a request about the current `connectionPool.size`.

The error was:

```js
t.strictEqual(client.connectionPool.size, 3)

// expected: 3  => because one node should be killed
//   actual: 4  => because the request was made before the node was killed
```

The solution was to update `kill()` by adding a `callback` and calling it after the `stop()` in `stoppable.js` has finished. This was then used in `sniff.test.js` and `resurrect.test.js`.

Logging in `shutdown()` is also improved.

Unused `spawn()` is removed.

Closes https://github.com/elastic/elasticsearch-js/issues/1108.