### PR TITLE
Fix 1153

### DIFF
--- a/lib/pool/ConnectionPool.js
+++ b/lib/pool/ConnectionPool.js
@@ -60,7 +60,17 @@ class ConnectionPool extends BaseConnectionPool {
     const { id } = connection
     debug(`Marking as 'dead' connection '${id}'`)
     if (this.dead.indexOf(id) === -1) {
-      this.dead.push(id)
+      // It might happen that `markDead` is called jsut after
+      // a pool update, and in such case we will add to the dead
+      // list a node that no longer exist. The following check verify
+      // that the connection is still part of the pool before
+      // marking it as dead.
+      for (var i = 0; i < this.size; i++) {
+        if (this.connections[i].id === id) {
+          this.dead.push(id)
+          break
+        }
+      }
     }
     connection.status = Connection.statuses.DEAD
     connection.deadCount++

--- a/test/unit/connection-pool.test.js
+++ b/test/unit/connection-pool.test.js
@@ -74,6 +74,14 @@ test('API', t => {
     }, 10)
   })
 
+  t.test('markDead should ignore connections that no longer exists', t => {
+    const pool = new ConnectionPool({ Connection, sniffEnabled: true })
+    pool.addConnection('http://localhost:9200/')
+    pool.markDead({ id: 'foo-bar' })
+    t.deepEqual(pool.dead, [])
+    t.end()
+  })
+
   t.test('markAlive', t => {
     const pool = new ConnectionPool({ Connection, sniffEnabled: true })
     const href = 'http://localhost:9200/'


### PR DESCRIPTION
It might happen that `markDead` is called just after a pool update, and in such case, we will add to the dead list a node that no longer exists.
This pr fixes this issue :)
A big thanks to @penge for his initial research.

Closes: #1153 
Related: https://github.com/elastic/elasticsearch-js/issues/1122 https://github.com/elastic/elasticsearch-js/issues/1153