### PR TITLE
Add Node.js v14 to test matrix

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -2,7 +2,8 @@
 
 source /usr/local/bin/bash_standard_lib.sh
 
-DOCKER_IMAGES="node:12-alpine
+DOCKER_IMAGES="node:14-alpine
+node:12-alpine
 node:10-alpine
 node:8-alpine
 "

--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -3,6 +3,7 @@ STACK_VERSION:
   - 8.0.0-SNAPSHOT
 
 NODE_JS_VERSION:
+  - 14
   - 12
   - 10
   - 8

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -71,7 +71,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
As titled.
I've also removed Node.js v13, a sit will go EOL soon and it's not an LTS release.