### PR TITLE
[DOCS] Fixes Indices component template link in reference docs

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -1095,7 +1095,7 @@ client.cluster.deleteComponentTemplate({
   master_timeout: string
 })
 ----
-link:{ref}/indices-component-templates.html[Documentation] +
+link:{ref}/indices-component-template.html[Documentation] +
 [cols=2*]
 |===
 |`name`

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -1136,7 +1136,7 @@ client.cluster.existsComponentTemplate({
   local: boolean
 })
 ----
-link:{ref}/indices-component-templates.html[Documentation] +
+link:{ref}/indices-component-template.html[Documentation] +
 [cols=2*]
 |===
 |`name`
@@ -1160,7 +1160,7 @@ client.cluster.getComponentTemplate({
   local: boolean
 })
 ----
-link:{ref}/indices-component-templates.html[Documentation] +
+link:{ref}/indices-component-template.html[Documentation] +
 [cols=2*]
 |===
 |`name`
@@ -1321,7 +1321,7 @@ client.cluster.putComponentTemplate({
   body: object
 })
 ----
-link:{ref}/indices-component-templates.html[Documentation] +
+link:{ref}/indices-component-template.html[Documentation] +
 [cols=2*]
 |===
 |`name`


### PR DESCRIPTION
This PR fixes a link in the API reference docs which is incorrect and now breaks the docs build.