### PR TITLE
Updated Connection.request signature 

### DIFF
--- a/lib/Connection.d.ts
+++ b/lib/Connection.d.ts
@@ -68,7 +68,7 @@ export default class Connection {
   _status: string
   _agent: http.Agent
   constructor(opts?: ConnectionOptions)
-  request(params: RequestOptions, callback: (err: Error | null, response: http.IncomingMessage | null) => void): http.ClientRequest
+  request(params: RequestOptions, callback: (err: Error | null, response: http.IncomingMessage | null, headers: Record<string, any> | null, statusCode: number | null) => void): http.ClientRequest
   close(): Connection
   setRole(role: string, enabled: boolean): Connection
   buildRequestObject(params: any): http.ClientRequestArgs

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -6,10 +6,10 @@
 
 const assert = require('assert')
 const { inspect } = require('util')
+const { createUnzip } = require('zlib')
 const http = require('http')
 const https = require('https')
 const debug = require('debug')('elasticsearch')
-const decompressResponse = require('decompress-response')
 const pump = require('pump')
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/
 const {
@@ -57,13 +57,13 @@ class Connection {
   }
 
   request (params, callback) {
-    this._openRequests++
+    this._openRequests += 1
     var ended = false
 
     const requestParams = this.buildRequestObject(params)
     // https://github.com/nodejs/node/commit/b961d9fd83
     if (INVALID_PATH_REGEX.test(requestParams.path) === true) {
-      callback(new TypeError(`ERR_UNESCAPED_CHARACTERS: ${requestParams.path}`), null)
+      callback(new TypeError(`ERR_UNESCAPED_CHARACTERS: ${requestParams.path}`), null, null, null)
       return { abort: () => {} }
     }
 
@@ -75,12 +75,17 @@ class Connection {
     request.on('response', response => {
       if (ended === false) {
         ended = true
-        this._openRequests--
+        this._openRequests -= 1
 
         if (params.asStream === true) {
-          callback(null, response)
+          callback(null, response, response.headers, response.statusCode)
         } else {
-          callback(null, decompressResponse(response))
+          const contentEncoding = (response.headers['content-encoding'] || '').toLowerCase()
+          if (contentEncoding.indexOf('gzip') > -1 || contentEncoding.indexOf('deflate') > -1) {
+            callback(null, response.pipe(createUnzip()), response.headers, response.statusCode)
+          } else {
+            callback(null, response, response.headers, response.statusCode)
+          }
         }
       }
     })
@@ -89,9 +94,9 @@ class Connection {
     request.on('timeout', () => {
       if (ended === false) {
         ended = true
-        this._openRequests--
+        this._openRequests -= 1
         request.abort()
-        callback(new TimeoutError('Request timed out', params), null)
+        callback(new TimeoutError('Request timed out', params), null, null, null)
       }
     })
 
@@ -99,8 +104,8 @@ class Connection {
     request.on('error', err => {
       if (ended === false) {
         ended = true
-        this._openRequests--
-        callback(new ConnectionError(err.message), null)
+        this._openRequests -= 1
+        callback(new ConnectionError(err.message), null, null, null)
       }
     })
 
@@ -109,8 +114,8 @@ class Connection {
       debug('Request aborted', params)
       if (ended === false) {
         ended = true
-        this._openRequests--
-        callback(new RequestAbortedError(), null)
+        this._openRequests -= 1
+        callback(new RequestAbortedError(), null, null, null)
       }
     })
 
@@ -123,8 +128,8 @@ class Connection {
         /* istanbul ignore if  */
         if (err != null && ended === false) {
           ended = true
-          this._openRequests--
-          callback(err, null)
+          this._openRequests -= 1
+          callback(err, null, null, null)
         }
       })
     } else {

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -129,7 +129,7 @@ class Transport {
       request = meta.connection.request(params, onResponse)
     }
 
-    const onResponse = (err, response) => {
+    const onResponse = (err, response, headers, statusCode) => {
       if (err !== null) {
         if (err.name !== 'RequestAbortedError') {
           // if there is an error in the connection
@@ -157,7 +157,8 @@ class Transport {
         return callback(err, result)
       }
 
-      const { statusCode, headers } = response
+      statusCode = statusCode || response.statusCode
+      headers = headers || response.headers
       result.statusCode = statusCode
       result.headers = headers
       if (headers['warning'] !== undefined) {
@@ -177,7 +178,6 @@ class Transport {
       // collect the payload
       response.setEncoding('utf8')
       response.on('data', chunk => { payload += chunk })
-      /* istanbul ignore next */
       response.on('error', err => {
         const error = new ConnectionError(err.message, result)
         this.emit('response', error, result)

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "decompress-response": "^4.2.0",
     "ms": "^2.1.1",
     "pump": "^3.0.0",
     "secure-json-parse": "^2.1.0"

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -400,10 +400,10 @@ test('Should handle compression', t => {
       connection.request({
         path: '/hello',
         method: 'GET'
-      }, (err, res) => {
+      }, (err, res, headers, statusCode) => {
         t.error(err)
 
-        t.match(res.headers, {
+        t.match(headers, {
           'content-type': 'application/json;utf=8',
           'content-encoding': 'gzip'
         })
@@ -440,10 +440,10 @@ test('Should handle compression', t => {
       connection.request({
         path: '/hello',
         method: 'GET'
-      }, (err, res) => {
+      }, (err, res, headers, statusCode) => {
         t.error(err)
 
-        t.match(res.headers, {
+        t.match(headers, {
           'content-type': 'application/json;utf=8',
           'content-encoding': 'deflate'
         })

--- a/test/utils/MockConnection.js
+++ b/test/utils/MockConnection.js
@@ -26,7 +26,7 @@ class MockConnection extends Connection {
     }
     process.nextTick(() => {
       if (!aborted) {
-        callback(null, stream)
+        callback(null, stream, stream.headers, stream.statusCode)
       } else {
         callback(new RequestAbortedError(), null)
       }
@@ -133,7 +133,7 @@ function buildMockConnection (opts) {
       }
       process.nextTick(() => {
         if (!aborted) {
-          callback(null, stream)
+          callback(null, stream, stream.headers, stream.statusCode)
         } else {
           callback(new RequestAbortedError(), null)
         }


### PR DESCRIPTION
Until now, the signature of `Connection.request` has been the following
```js
Connection.request(params, callback)

function callback (err, response) {}
```

WHere response is the HTTP [`IncomingMessage`](https://nodejs.org/api/http.html#http_class_http_incomingmessage) from Node.js or a stream built with [mimic-response](https://github.com/sindresorhus/mimic-response).
This pr removes the `mimic-response` package and handles the response decompression by hand. Furthermore, now the headers and statusCode are passed in the callback as separate arguments.
```js
Connection.request(params, callback)

function callback (err, response, headers, statusCode) {}
```

### Why this change?

With this change, it will be easier to add different HTTP libraries, where the response stream and the headers/statusCode might be decoupled.


### Is this a breaking change?

It should not, the Transport still fallbacks to the `response.headers` and `response.statusCode` values.
It **might** be a problem if a userland library overrides the `Connection.request` without using `super.request` and the response needs to be decompressed, but I wasn't able to find one on npm.