### PR TITLE
Added timeout support in bulk and msearch helpers

### DIFF
--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -96,6 +96,16 @@ const b = client.helpers.bulk({
 })
 ----
 
+|`flushInterval`
+a|How much time (in milliseconds) the helper will wait before flushing the body from the last document read. +
+_Default:_ `30000`
+[source,js]
+----
+const b = client.helpers.bulk({
+  flushInterval: 30000
+})
+----
+
 |`concurrency`
 a|How many request will be executed at the same time. +
 _Default:_ `5`
@@ -254,11 +264,21 @@ To create a new instance of the Msearch helper, you should access it as shown in
 |===
 |`operations`
 a|How many search operations should be sent in a single msearch request. +
-_Default:_ `20`
+_Default:_ `5`
 [source,js]
 ----
 const b = client.helpers.msearch({
   operations: 10
+})
+----
+
+|`flushInterval`
+a|How much time (in milliseconds) the helper will wait before flushing the operations from the last operation read. +
+_Default:_ `500`
+[source,js]
+----
+const b = client.helpers.msearch({
+  flushInterval: 500
 })
 ----
 

--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -69,6 +69,7 @@ export interface BulkHelperOptions<TDocument = unknown> extends Omit<Bulk, 'body
   datasource: TDocument[] | Buffer | ReadableStream | AsyncIterator<TDocument>
   onDocument: (doc: TDocument) => Action
   flushBytes?: number
+  flushInterval?: number
   concurrency?: number
   retries?: number
   wait?: number
@@ -92,6 +93,7 @@ export interface OnDropDocument<TDocument = unknown> {
 
 export interface MsearchHelperOptions extends Omit<Msearch, 'body'> {
   operations?: number
+  flushInterval?: number
   concurrency?: number
   retries?: number
   wait?: number

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -259,8 +259,13 @@ class Helpers {
         msearchBody.length = 0
         callbacks.length = 0
         loadedOperations = 0
-        const send = await semaphore()
-        send(msearchBodyCopy, callbacksCopy)
+        try {
+          const send = await semaphore()
+          send(msearchBodyCopy, callbacksCopy)
+        } catch (err) {
+          /* istanbul ignore next */
+          console.error(err)
+        }
       }
     }
 
@@ -519,8 +524,13 @@ class Helpers {
         const bulkBodyCopy = bulkBody.slice()
         bulkBody.length = 0
         chunkBytes = 0
-        const send = await semaphore()
-        send(bulkBodyCopy)
+        try {
+          const send = await semaphore()
+          send(bulkBodyCopy)
+        } catch (err) {
+          /* istanbul ignore next */
+          console.error(err)
+        }
       }
     }
 

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -163,8 +163,7 @@ class Helpers {
     })
 
     const p = iterate()
-
-    return {
+    const helper = {
       then (onFulfilled, onRejected) {
         return p.then(onFulfilled, onRejected)
       },
@@ -172,12 +171,14 @@ class Helpers {
         return p.catch(onRejected)
       },
       stop (error = null) {
-        clearTimeout(timeoutId)
+        if (stopReading === true) return
         stopReading = true
         stopError = error
         operationsStream.push(null)
       },
       // TODO: support abort a single search?
+      // NOTE: the validation checks are synchronous and the callback/promise will
+      //       be resolved in the same tick. We might want to fix this in the future.
       search (header, body, callback) {
         if (stopReading === true) {
           const error = stopError === null
@@ -216,6 +217,8 @@ class Helpers {
         }
       }
     }
+
+    return helper
 
     async function iterate () {
       const { semaphore, finish } = buildSemaphore()
@@ -264,7 +267,7 @@ class Helpers {
           send(msearchBodyCopy, callbacksCopy)
         } catch (err) {
           /* istanbul ignore next */
-          console.error(err)
+          helper.stop(err)
         }
       }
     }
@@ -424,8 +427,7 @@ class Helpers {
     }
 
     const p = iterate()
-
-    return {
+    const helper = {
       then (onFulfilled, onRejected) {
         return p.then(onFulfilled, onRejected)
       },
@@ -439,6 +441,8 @@ class Helpers {
         return this
       }
     }
+
+    return helper
 
     /**
      * Function that iterates over the given datasource and start a bulk operation as soon
@@ -529,7 +533,7 @@ class Helpers {
           send(bulkBodyCopy)
         } catch (err) {
           /* istanbul ignore next */
-          console.error(err)
+          helper.abort()
         }
       }
     }

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -145,10 +145,9 @@ class Helpers {
   msearch (options = {}) {
     const client = this[kClient]
     const {
-      operations = 20,
+      operations = 5,
       concurrency = 5,
-      // TODO: is this the best name (=> maxDelay?)
-      flushInterval = 1000,
+      flushInterval = 500,
       retries = this.maxRetries,
       wait = 5000,
       ...msearchOptions

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -143,12 +143,12 @@ class Helpers {
    * @return {object} The possible operations to run.
    */
   msearch (options = {}) {
-    // TODO: add an interval to force flush the body
-    //       to handle the slow producer problem
     const client = this[kClient]
     const {
       operations = 20,
       concurrency = 5,
+      // TODO: is this the best name (=> maxDelay?)
+      flushInterval = 1000,
       retries = this.maxRetries,
       wait = 5000,
       ...msearchOptions
@@ -156,6 +156,7 @@ class Helpers {
 
     let stopReading = false
     let stopError = null
+    let timeoutId = null
     const operationsStream = new Readable({
       objectMode: true,
       read (size) {}
@@ -171,6 +172,7 @@ class Helpers {
         return p.catch(onRejected)
       },
       stop (error = null) {
+        clearTimeout(timeoutId)
         stopReading = true
         stopError = error
         operationsStream.push(null)
@@ -222,6 +224,7 @@ class Helpers {
       let loadedOperations = 0
 
       for await (const operation of operationsStream) {
+        clearTimeout(timeoutId)
         loadedOperations += 1
         msearchBody.push(operation[0], operation[1])
         callbacks.push(operation[2])
@@ -231,9 +234,12 @@ class Helpers {
           msearchBody.length = 0
           callbacks.length = 0
           loadedOperations = 0
+        } else {
+          timeoutId = setTimeout(onFlushTimeout, flushInterval)
         }
       }
 
+      clearTimeout(timeoutId)
       // In some cases the previos http call does not have finished,
       // or we didn't reach the flush bytes threshold, so we force one last operation.
       if (loadedOperations > 0) {
@@ -245,6 +251,16 @@ class Helpers {
 
       if (stopError !== null) {
         throw stopError
+      }
+
+      async function onFlushTimeout () {
+        const msearchBodyCopy = msearchBody.slice()
+        const callbacksCopy = callbacks.slice()
+        msearchBody.length = 0
+        callbacks.length = 0
+        loadedOperations = 0
+        const send = await semaphore()
+        send(msearchBodyCopy, callbacksCopy)
       }
     }
 
@@ -365,14 +381,13 @@ class Helpers {
    * @return {object} The possible operations to run with the datasource.
    */
   bulk (options) {
-    // TODO: add an interval to force flush the body
-    //       to handle the slow producer problem
     const client = this[kClient]
     const { serialize, deserialize } = client.serializer
     const {
       datasource,
       onDocument,
       flushBytes = 5000000,
+      flushInterval = 30000,
       concurrency = 5,
       retries = this.maxRetries,
       wait = 5000,
@@ -392,6 +407,7 @@ class Helpers {
     }
 
     let shouldAbort = false
+    let timeoutId = null
     const stats = {
       total: 0,
       failed: 0,
@@ -412,6 +428,7 @@ class Helpers {
         return p.catch(onRejected)
       },
       abort () {
+        clearTimeout(timeoutId)
         shouldAbort = true
         stats.aborted = true
         return this
@@ -437,6 +454,7 @@ class Helpers {
 
       for await (const chunk of datasource) {
         if (shouldAbort === true) break
+        clearTimeout(timeoutId)
         const action = onDocument(chunk)
         const operation = Array.isArray(action)
           ? Object.keys(action[0])[0]
@@ -445,16 +463,14 @@ class Helpers {
           actionBody = serialize(action)
           payloadBody = typeof chunk === 'string' ? chunk : serialize(chunk)
           chunkBytes += Buffer.byteLength(actionBody) + Buffer.byteLength(payloadBody)
-          bulkBody.push(actionBody)
-          bulkBody.push(payloadBody)
+          bulkBody.push(actionBody, payloadBody)
         } else if (operation === 'update') {
           actionBody = serialize(action[0])
           payloadBody = typeof chunk === 'string'
             ? `{doc:${chunk}}`
             : serialize({ doc: chunk, ...action[1] })
           chunkBytes += Buffer.byteLength(actionBody) + Buffer.byteLength(payloadBody)
-          bulkBody.push(actionBody)
-          bulkBody.push(payloadBody)
+          bulkBody.push(actionBody, payloadBody)
         } else if (operation === 'delete') {
           actionBody = serialize(action)
           chunkBytes += Buffer.byteLength(actionBody)
@@ -469,9 +485,12 @@ class Helpers {
           send(bulkBody.slice())
           bulkBody.length = 0
           chunkBytes = 0
+        } else {
+          timeoutId = setTimeout(onFlushTimeout, flushInterval)
         }
       }
 
+      clearTimeout(timeoutId)
       // In some cases the previos http call does not have finished,
       // or we didn't reach the flush bytes threshold, so we force one last operation.
       if (shouldAbort === false && chunkBytes > 0) {
@@ -494,6 +513,15 @@ class Helpers {
       stats.total = stats.successful + stats.failed
 
       return stats
+
+      async function onFlushTimeout () {
+        stats.bytes += chunkBytes
+        const bulkBodyCopy = bulkBody.slice()
+        bulkBody.length = 0
+        chunkBytes = 0
+        const send = await semaphore()
+        send(bulkBodyCopy)
+      }
     }
 
     // This function builds a semaphore using the concurrency

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "company": "Elasticsearch BV"
   },
   "devDependencies": {
+    "@sinonjs/fake-timers": "^6.0.1",
     "@types/node": "^12.6.2",
     "convert-hrtime": "^3.0.0",
     "dedent": "^0.7.0",

--- a/test/types/helpers.test-d.ts
+++ b/test/types/helpers.test-d.ts
@@ -27,6 +27,7 @@ const b = client.helpers.bulk<Record<string, any>>({
     return { index: { _index: 'test' } }
   },
   flushBytes: 5000000,
+  flushInterval: 30000,
   concurrency: 5,
   retries: 3,
   wait: 5000,
@@ -58,7 +59,7 @@ expectError(
   const options = {
     datasource: [],
     onDocument (doc: Record<string, any>) {
-      return { index: { _index: 'test' } } 
+      return { index: { _index: 'test' } }
     }
   }
   expectAssignable<BulkHelperOptions<Record<string, any>>>(options)
@@ -139,20 +140,20 @@ expectError(
 }
 
 // with type defs
-{  
+{
   interface ShardsResponse {
     total: number;
     successful: number;
     failed: number;
     skipped: number;
   }
-  
+
   interface Explanation {
     value: number;
     description: string;
     details: Explanation[];
   }
-  
+
   interface SearchResponse<T> {
     took: number;
     timed_out: boolean;
@@ -178,7 +179,7 @@ expectError(
     };
     aggregations?: any;
   }
-  
+
   interface Source {
     foo: string
   }
@@ -208,20 +209,20 @@ expectError(
       match: { foo: string }
     }
   }
-  
+
   interface ShardsResponse {
     total: number;
     successful: number;
     failed: number;
     skipped: number;
   }
-  
+
   interface Explanation {
     value: number;
     description: string;
     details: Explanation[];
   }
-  
+
   interface SearchResponse<T> {
     took: number;
     timed_out: boolean;
@@ -247,7 +248,7 @@ expectError(
     };
     aggregations?: any;
   }
-  
+
   interface Source {
     foo: string
   }
@@ -310,7 +311,7 @@ expectError(
 }
 
 // with type defs
-{ 
+{
   interface Source {
     foo: string
   }
@@ -337,7 +338,7 @@ expectError(
       match: { foo: string }
     }
   }
-  
+
   interface Source {
     foo: string
   }
@@ -415,7 +416,7 @@ expectError(
       match: { foo: string }
     }
   }
-  
+
   interface Source {
     foo: string
   }
@@ -436,7 +437,8 @@ expectError(
 /// .helpers.msearch
 
 const s = client.helpers.msearch({
-  operations: 20,
+  operations: 5,
+  flushInterval: 500,
   concurrency: 5,
   retries: 5,
   wait: 5000

--- a/test/unit/helpers/bulk.test.js
+++ b/test/unit/helpers/bulk.test.js
@@ -1019,7 +1019,6 @@ test('Flush interval', t => {
         }
       })(),
       flushBytes: 5000000,
-      flushInterval: 100,
       concurrency: 1,
       onDocument (doc) {
         return {
@@ -1068,14 +1067,16 @@ test('Flush interval', t => {
       datasource: (async function * generator () {
         for (const chunk of dataset) {
           await clock.nextAsync()
-          if (count > 1) {
+          if (chunk.user === 'tyrion') {
+            // Needed otherwise in Node.js 10
+            // the second request will never be sent
+            await Promise.resolve()
             b.abort()
           }
           yield chunk
         }
       })(),
       flushBytes: 5000000,
-      flushInterval: 100,
       concurrency: 1,
       onDocument (doc) {
         return {

--- a/test/unit/helpers/msearch.test.js
+++ b/test/unit/helpers/msearch.test.js
@@ -672,3 +672,57 @@ test('Flush interval - early stop', t => {
 
   s.stop()
 })
+
+test('Stop should resolve the helper', t => {
+  t.plan(1)
+
+  const MockConnection = connection.buildMockConnection({
+    onRequest (params) {
+      return {
+        body: {
+          responses: []
+        }
+      }
+    }
+  })
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  const s = client.helpers.msearch()
+  setImmediate(s.stop)
+
+  s.then(() => t.pass('Called'))
+    .catch(() => t.fail('Should not fail'))
+})
+
+test('Stop should resolve the helper (error)', t => {
+  t.plan(3)
+
+  const MockConnection = connection.buildMockConnection({
+    onRequest (params) {
+      return {
+        body: {
+          responses: []
+        }
+      }
+    }
+  })
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  const s = client.helpers.msearch()
+  setImmediate(s.stop, new Error('kaboom'))
+
+  s.then(() => t.fail('Should not fail'))
+    .catch(err => t.is(err.message, 'kaboom'))
+
+  s.catch(err => t.is(err.message, 'kaboom'))
+
+  s.then(() => t.fail('Should not fail'), err => t.is(err.message, 'kaboom'))
+})


### PR DESCRIPTION
If there is a slow producer, the bulk helper might send data with very large period of time, and if the process crashes for any reason, the data would be lost.
This pr introduces a `flushInterval` option in the bulk helper to avoid this issue. By default, the bulk helper will flush the data automatically every 30 seconds, unless the threshold has been reached before.

The same problem might happen with the multi search helper, where the user is not sending search requests fast enough. A `flushInterval` options has been added as well, with a default value of 1 second.