### PR TITLE
migrated to FakeTimers

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "into-stream": "^5.1.1",
     "js-yaml": "^3.13.1",
     "license-checker": "^25.0.1",
-    "lolex": "^4.0.1",
     "minimist": "^1.2.0",
     "ora": "^3.4.0",
     "pretty-hrtime": "^1.0.3",

--- a/test/behavior/observability.test.js
+++ b/test/behavior/observability.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
-const lolex = require('lolex')
+const FakeTimers = require('@sinonjs/fake-timers')
 const { Client, Transport } = require('../../index')
 const {
   connection: { MockConnection, MockConnectionSniff }
@@ -125,7 +125,7 @@ test('Request id', t => {
   t.test('Resurrect should use the same request id of the request that starts it', t => {
     t.plan(2)
 
-    const clock = lolex.install({ toFake: ['Date'] })
+    const clock = FakeTimers.install({ toFake: ['Date'] })
     const client = new Client({
       node: 'http://localhost:9200',
       Connection: MockConnection,
@@ -281,7 +281,7 @@ test('Client name', t => {
   t.test('Resurrect should have the client name configured', t => {
     t.plan(2)
 
-    const clock = lolex.install({ toFake: ['Date'] })
+    const clock = FakeTimers.install({ toFake: ['Date'] })
     const client = new Client({
       node: 'http://localhost:9200',
       Connection: MockConnection,
@@ -305,7 +305,7 @@ test('Client name', t => {
   t.test('Resurrect should have the client name configured (child client)', t => {
     t.plan(2)
 
-    const clock = lolex.install({ toFake: ['Date'] })
+    const clock = FakeTimers.install({ toFake: ['Date'] })
     const client = new Client({
       node: 'http://localhost:9200',
       Connection: MockConnection,

--- a/test/behavior/resurrect.test.js
+++ b/test/behavior/resurrect.test.js
@@ -6,7 +6,7 @@
 
 const { test } = require('tap')
 const { URL } = require('url')
-const lolex = require('lolex')
+const FakeTimers = require('@sinonjs/fake-timers')
 const workq = require('workq')
 const { buildCluster } = require('../utils')
 const { Client, events } = require('../../index')
@@ -24,7 +24,7 @@ const { Client, events } = require('../../index')
 test('Should execute the recurrect API with the ping strategy', t => {
   t.plan(8)
 
-  const clock = lolex.install({ toFake: ['Date'] })
+  const clock = FakeTimers.install({ toFake: ['Date'] })
   const q = workq()
 
   buildCluster({ numberOfNodes: 2 }, cluster => {
@@ -77,7 +77,7 @@ test('Should execute the recurrect API with the ping strategy', t => {
 test('Resurrect a node and handle 502/3/4 status code', t => {
   t.plan(15)
 
-  const clock = lolex.install({ toFake: ['Date'] })
+  const clock = FakeTimers.install({ toFake: ['Date'] })
   const q = workq()
 
   var count = 0
@@ -146,7 +146,7 @@ test('Resurrect a node and handle 502/3/4 status code', t => {
 test('Should execute the recurrect API with the optimistic strategy', t => {
   t.plan(8)
 
-  const clock = lolex.install({ toFake: ['Date'] })
+  const clock = FakeTimers.install({ toFake: ['Date'] })
   const q = workq()
 
   buildCluster({ numberOfNodes: 2 }, cluster => {

--- a/test/behavior/sniff.test.js
+++ b/test/behavior/sniff.test.js
@@ -6,7 +6,7 @@
 
 const { test } = require('tap')
 const { URL } = require('url')
-const lolex = require('lolex')
+const FakeTimers = require('@sinonjs/fake-timers')
 const workq = require('workq')
 const { buildCluster } = require('../utils')
 const { Client, Connection, Transport, events, errors } = require('../../index')
@@ -115,7 +115,7 @@ test('Should handle hostnames in publish_address', t => {
 
 test('Sniff interval', t => {
   t.plan(11)
-  const clock = lolex.install({ toFake: ['Date'] })
+  const clock = FakeTimers.install({ toFake: ['Date'] })
   const q = workq()
 
   buildCluster(({ nodes, shutdown, kill }) => {

--- a/test/unit/transport.test.js
+++ b/test/unit/transport.test.js
@@ -6,7 +6,7 @@
 
 const { test } = require('tap')
 const { URL } = require('url')
-const lolex = require('lolex')
+const FakeTimers = require('@sinonjs/fake-timers')
 const { createGunzip } = require('zlib')
 const os = require('os')
 const intoStream = require('into-stream')
@@ -1072,7 +1072,7 @@ test('sniff', t => {
   t.test('sniffInterval', t => {
     t.plan(6)
 
-    const clock = lolex.install({ toFake: ['Date'] })
+    const clock = FakeTimers.install({ toFake: ['Date'] })
     t.teardown(() => clock.uninstall())
 
     class MyTransport extends Transport {


### PR DESCRIPTION
Migrated tests to use [@sinonjs/fake-timers](https://www.npmjs.com/package/@sinonjs/fake-timers) instead of [lolex](https://www.npmjs.com/package/lolex)

Fixes #1210