### PR TITLE
Added option to run the benchmarks sequentially or concurrently

### DIFF
--- a/test/benchmarks/actions/001_ping.js
+++ b/test/benchmarks/actions/001_ping.js
@@ -9,6 +9,7 @@ const { Action } = require('../lib')
 module.exports = new Action({
   action: 'ping',
   category: 'core',
+  run: 'sequential',
   measure (n, benchmark, done) {
     benchmark.runnerClient.ping(done)
   }

--- a/test/benchmarks/actions/002_info.js
+++ b/test/benchmarks/actions/002_info.js
@@ -9,6 +9,7 @@ const { Action } = require('../lib')
 module.exports = new Action({
   action: 'info',
   category: 'core',
+  run: 'sequential',
   measure (n, benchmark, done) {
     benchmark.runnerClient.info(done)
   }

--- a/test/benchmarks/actions/003_get.js
+++ b/test/benchmarks/actions/003_get.js
@@ -9,6 +9,7 @@ const { Action } = require('../lib')
 module.exports = new Action({
   action: 'get',
   category: 'core',
+  run: 'sequential',
   warmups: 100,
   async setup (benchmark) {
     await benchmark.runnerClient.indices.delete({ index: 'test-bench-get' }, { ignore: [404] })

--- a/test/benchmarks/actions/004_index.js
+++ b/test/benchmarks/actions/004_index.js
@@ -13,6 +13,7 @@ let id = 0
 module.exports = new Action({
   action: 'index',
   category: 'core',
+  run: 'sequential',
   warmups: 100,
   async setup (benchmark) {
     payload = JSON.parse(readFileSync(join(benchmark.config.dataSource, 'small', 'document.json'), 'utf8'))

--- a/test/benchmarks/actions/005_bulk.js
+++ b/test/benchmarks/actions/005_bulk.js
@@ -13,6 +13,7 @@ const OPERATIONS = 10000
 module.exports = new Action({
   action: 'bulk',
   category: 'core',
+  run: 'sequential',
   warmups: 10,
   repetitions: 1000,
   operations: OPERATIONS,

--- a/test/benchmarks/actions/006_bulk-helper.js
+++ b/test/benchmarks/actions/006_bulk-helper.js
@@ -20,6 +20,7 @@ async function * generate () {
 module.exports = new Action({
   action: 'bulk-helper',
   category: 'helpers',
+  run: 'sequential',
   warmups: 10,
   repetitions: 10,
   operations: OPERATIONS,
@@ -50,7 +51,7 @@ module.exports = new Action({
         done(null, { statusCode: 200 }, stats.successful)
       })
       .catch(err => {
-        done(err, { statusCode: 418 }, 0)
+        done(err, { statusCode: err.statusCode || 418 }, 0)
       })
   }
 })

--- a/test/benchmarks/lib.js
+++ b/test/benchmarks/lib.js
@@ -119,8 +119,10 @@ class Action {
     assert(opts.action, 'Missing action name')
     assert(opts.action, 'Missing action category')
     assert(opts.measure, 'Missing action measure function')
+    assert(opts.run, 'Missing actionrun type (sequential or concurrent)')
     this.action = opts.action
     this.category = opts.category
+    this.run = opts.run
     this.warmups = opts.warmups || Action.DEFAULT_WARMUPS
     this.repetitions = opts.repetitions || Action.DEFAULT_REPETITIONS
     this.operations = opts.operations || Action.DEFAULT_OPERATIONS

--- a/test/benchmarks/lib.js
+++ b/test/benchmarks/lib.js
@@ -119,7 +119,7 @@ class Action {
     assert(opts.action, 'Missing action name')
     assert(opts.action, 'Missing action category')
     assert(opts.measure, 'Missing action measure function')
-    assert(opts.run, 'Missing actionrun type (sequential or concurrent)')
+    assert(opts.run, 'Missing action run type (sequential or concurrent)')
     this.action = opts.action
     this.category = opts.category
     this.run = opts.run


### PR DESCRIPTION
We can now pick which style to use with the `run` option, it can either be `sequential` or `concurrent`.