### PR TITLE
ESM support

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,10 @@
+import mod from "./index.js";
+
+export default mod;
+export const Client = mod.Client;
+export const Transport = mod.Transport;
+export const ConnectionPool = mod.ConnectionPool;
+export const Connection = mod.Connection;
+export const Serializer = mod.Serializer;
+export const events = mod.events;
+export const errors = mod.errors;

--- a/index.mjs
+++ b/index.mjs
@@ -1,10 +1,10 @@
-import mod from "./index.js";
+import mod from './index.js'
 
-export default mod;
-export const Client = mod.Client;
-export const Transport = mod.Transport;
-export const ConnectionPool = mod.ConnectionPool;
-export const Connection = mod.Connection;
-export const Serializer = mod.Serializer;
-export const events = mod.events;
-export const errors = mod.errors;
+export default mod
+export const Client = mod.Client
+export const Transport = mod.Transport
+export const ConnectionPool = mod.ConnectionPool
+export const Connection = mod.Connection
+export const Serializer = mod.Serializer
+export const events = mod.events
+export const errors = mod.errors

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "description": "The official Elasticsearch client for Node.js",
   "main": "index.js",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "require": "index.js",
+      "import": "index.mjs"
+    },
+    "./": "./"
+  },
   "homepage": "http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html",
   "version": "8.0.0-SNAPSHOT.9f33e3c7",
   "keywords": [
@@ -28,7 +35,8 @@
     "test:coverage-ui": "tap test/{unit,acceptance}/{*,**/*}.test.js --coverage --coverage-report=html --nyc-arg=\"--exclude=api\"",
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "license-checker": "license-checker --production --onlyAllow='MIT;Apache-2.0;Apache1.1;ISC;BSD-3-Clause;BSD-2-Clause'"
+    "license-checker": "license-checker --production --onlyAllow='MIT;Apache-2.0;Apache1.1;ISC;BSD-3-Clause;BSD-2-Clause'",
+    "build-esm": "npx gen-esm-wrapper . index.mjs"
   },
   "author": {
     "name": "Tomas Della Vedova",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
-      "require": "index.js",
-      "import": "index.mjs"
+      "require": "./index.js",
+      "import": "./index.mjs"
     },
     "./": "./"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "license-checker": "license-checker --production --onlyAllow='MIT;Apache-2.0;Apache1.1;ISC;BSD-3-Clause;BSD-2-Clause'",
-    "build-esm": "npx gen-esm-wrapper . index.mjs"
+    "build-esm": "npx gen-esm-wrapper . index.mjs && standard --fix index.mjs"
   },
   "author": {
     "name": "Tomas Della Vedova",

--- a/test/unit/esm/index.mjs
+++ b/test/unit/esm/index.mjs
@@ -1,0 +1,8 @@
+import t from 'tap'
+import { Client } from '../../../index.mjs'
+
+t.test('esm support', t => {
+  t.plan(1)
+  const client = new Client({ node: 'http://localhost:9200' })
+  t.strictEqual(client.name, 'elasticsearch-js')
+})

--- a/test/unit/esm/index.test.js
+++ b/test/unit/esm/index.test.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const t = require('tap')
+const semver = require('semver')
+
+if (semver.lt(process.versions.node, '12.17.0')) {
+  t.skip('Skip because Node version < 12.17.0')
+  t.end()
+} else {
+  // Node v8 throw a `SyntaxError: Unexpected token import`
+  // even if this branch is never touch in the code,
+  // by using `eval` we can avoid this issue.
+  // eslint-disable-next-line
+  new Function('module', 'return import(module)')('./index.mjs').catch((err) => {
+    process.nextTick(() => {
+      throw err
+    })
+  })
+}


### PR DESCRIPTION
With Node.js v12.17.0 ES modules are out without the flag (even if they are still experimental)., this pr adds the support for es modules via [gen-esm-wrapper](https://github.com/addaleax/gen-esm-wrapper).

Closes: https://github.com/elastic/elasticsearch-js/issues/1205