### PR TITLE
Updated default http agent configuration

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -44,7 +44,8 @@ class Connection {
         keepAlive: true,
         keepAliveMsecs: 1000,
         maxSockets: keepAliveFalse ? Infinity : 256,
-        maxFreeSockets: 256
+        maxFreeSockets: 256,
+        scheduling: 'lifo'
       }, opts.agent)
       this.agent = this.url.protocol === 'http:'
         ? new http.Agent(agentOptions)


### PR DESCRIPTION
Added the `scheduling: 'lifo'` option to the default HTTP agent configuration to avoid maximizing the open sockets against Elasticsearch and lowering the risk of encountering socket timeouts.
This feature is only available from Node v14.5+, but it should be backported to v10 and v12.

Related: https://github.com/nodejs/node/pull/33278