### PR TITLE
Kibana client support

### DIFF
--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -12,13 +12,15 @@ const { ResponseError, ConfigurationError } = require('./errors')
 
 const pImmediate = promisify(setImmediate)
 const sleep = promisify(setTimeout)
-const kClient = Symbol('elasticsearch-client')
+const kClient = Symbol('elasticsearchjs-client')
+const kSerializer = Symbol('elasticsearchjs-client-serializer')
 /* istanbul ignore next */
 const noop = () => {}
 
 class Helpers {
   constructor (opts) {
     this[kClient] = opts.client
+    this[kSerializer] = opts.serializer
     this.maxRetries = opts.maxRetries
   }
 
@@ -391,7 +393,7 @@ class Helpers {
    */
   bulk (options) {
     const client = this[kClient]
-    const { serialize, deserialize } = client.serializer
+    const { serialize, deserialize } = this[kSerializer]
     const {
       datasource,
       onDocument,

--- a/test/unit/kibana-client.test.js
+++ b/test/unit/kibana-client.test.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const { test } = require('tap')
+const semver = require('semver')
 const { Client, errors } = require('../../index')
 const { connection } = require('../utils')
 
@@ -95,7 +96,7 @@ test('Multiple connections', async t => {
   t.strictEqual(response.meta.connection.id, 'http://localhost:9202/')
 })
 
-test('Can use helpers', async t => {
+test('Can use helpers', { skip: semver.lt(process.versions.node, '10.0.0') }, async t => {
   const dataset = [
     { user: 'jon', age: 23 },
     { user: 'arya', age: 18 },

--- a/test/unit/kibana-client.test.js
+++ b/test/unit/kibana-client.test.js
@@ -9,6 +9,14 @@ const semver = require('semver')
 const { Client, errors } = require('../../index')
 const { connection } = require('../utils')
 
+/**
+ * Subclass method
+ * pros:
+ *   - idiomatic way of solving the problem
+ *   - safe from binding issues
+ * cons:
+ *   - needs to use symbols for accessing "private" properties in kibana core
+ */
 const kTransportRequest = Symbol('kibana-client-transport-request')
 class KibanaClient extends Client {
   constructor (opts) {
@@ -53,185 +61,247 @@ class KibanaClient extends Client {
   }
 }
 
-test('Basic', async t => {
-  const MockConnection = connection.buildMockConnection({
-    onRequest (params) {
-      return { body: { hello: 'world' } }
-    }
-  })
+/**
+ * builder method
+ * pros:
+ *   - no need to use symbols in kibana core for accesssing properties
+ * cons:
+ *   - hackier solution, it requires a lot of small adjustments for binding the client instance
+ */
+function buildKibanaClient (opts) {
+  const client = new Client(opts)
 
-  const client = new KibanaClient({
-    node: 'http://localhost:9200',
-    Connection: MockConnection
-  })
-  const response = await client.info()
-  t.deepEqual(response.body, { hello: 'world' })
-})
-
-test('Multiple connections', async t => {
-  const MockConnection = connection.buildMockConnection({
-    onRequest (params) {
-      return { body: { hello: 'world' } }
-    }
-  })
-
-  const client = new KibanaClient({
-    nodes: [
-      'http://localhost:9200',
-      'http://localhost:9201',
-      'http://localhost:9202'
-    ],
-    Connection: MockConnection
-  })
-  let response = await client.info()
-  t.deepEqual(response.body, { hello: 'world' })
-  t.strictEqual(response.meta.connection.id, 'http://localhost:9200/')
-
-  response = await client.info()
-  t.deepEqual(response.body, { hello: 'world' })
-  t.strictEqual(response.meta.connection.id, 'http://localhost:9201/')
-
-  response = await client.info()
-  t.deepEqual(response.body, { hello: 'world' })
-  t.strictEqual(response.meta.connection.id, 'http://localhost:9202/')
-})
-
-test('Can use helpers', { skip: semver.lt(process.versions.node, '10.0.0') }, async t => {
-  const dataset = [
-    { user: 'jon', age: 23 },
-    { user: 'arya', age: 18 },
-    { user: 'tyrion', age: 39 }
-  ]
-  let count = 0
-  const MockConnection = connection.buildMockConnection({
-    onRequest (params) {
-      t.strictEqual(params.path, '/_bulk')
-      t.match(params.headers, { 'content-type': 'application/x-ndjson' })
-      const [action, payload] = params.body.split('\n')
-      t.deepEqual(JSON.parse(action), { index: { _index: 'test' } })
-      t.deepEqual(JSON.parse(payload), dataset[count++])
-      return { body: { errors: false, items: [{}] } }
-    }
-  })
-
-  const client = new KibanaClient({
-    node: 'http://localhost:9200',
-    Connection: MockConnection
-  })
-  const result = await client.helpers.bulk({
-    datasource: dataset.slice(),
-    flushBytes: 1,
-    concurrency: 1,
-    onDocument (doc) {
-      return {
-        index: { _index: 'test' }
-      }
+  return {
+    ...client,
+    transport: {
+      request: client.transport.request.bind(client.transport)
     },
-    onDrop (doc) {
-      t.fail('This should never be called')
+    connectionPool: undefined,
+    serializer: undefined,
+    helpers: {
+      search: client.helpers.search.bind(client.helpers),
+      scrollSearch: client.helpers.scrollSearch.bind(client.helpers),
+      scrollDocuments: client.helpers.scrollDocuments.bind(client.helpers),
+      msearch: client.helpers.msearch.bind(client.helpers),
+      bulk: client.helpers.bulk.bind(client.helpers)
+    },
+    emit () {
+      throw new errors.ElasticsearchClientError('Cannot access emit method')
+    },
+    on () {
+      throw new errors.ElasticsearchClientError('Cannot access on method')
+    },
+    once () {
+      throw new errors.ElasticsearchClientError('Cannot access once method')
+    },
+    child () {
+      throw new errors.ElasticsearchClientError('Cannot access child method')
+    },
+    close () {
+      throw new errors.ElasticsearchClientError('Cannot access close method')
+    },
+    extend () {
+      throw new errors.ElasticsearchClientError('Cannot access extend method')
     }
+  }
+}
+
+function getClient (type, opts) {
+  if (type === 'subclass') {
+    return new KibanaClient(opts)
+  } else {
+    return buildKibanaClient(opts)
+  }
+}
+
+function runTest (type) {
+  test(type, t => {
+    t.test('Basic', async t => {
+      const MockConnection = connection.buildMockConnection({
+        onRequest (params) {
+          return { body: { hello: 'world' } }
+        }
+      })
+
+      const client = getClient(type, {
+        node: 'http://localhost:9200',
+        Connection: MockConnection
+      })
+      const response = await client.info()
+      t.deepEqual(response.body, { hello: 'world' })
+    })
+
+    t.test('Multiple connections', async t => {
+      const MockConnection = connection.buildMockConnection({
+        onRequest (params) {
+          return { body: { hello: 'world' } }
+        }
+      })
+
+      const client = getClient(type, {
+        nodes: [
+          'http://localhost:9200',
+          'http://localhost:9201',
+          'http://localhost:9202'
+        ],
+        Connection: MockConnection
+      })
+      let response = await client.info()
+      t.deepEqual(response.body, { hello: 'world' })
+      t.strictEqual(response.meta.connection.id, 'http://localhost:9200/')
+
+      response = await client.info()
+      t.deepEqual(response.body, { hello: 'world' })
+      t.strictEqual(response.meta.connection.id, 'http://localhost:9201/')
+
+      response = await client.info()
+      t.deepEqual(response.body, { hello: 'world' })
+      t.strictEqual(response.meta.connection.id, 'http://localhost:9202/')
+    })
+
+    t.test('Can use helpers', { skip: semver.lt(process.versions.node, '10.0.0') }, async t => {
+      const dataset = [
+        { user: 'jon', age: 23 },
+        { user: 'arya', age: 18 },
+        { user: 'tyrion', age: 39 }
+      ]
+      let count = 0
+      const MockConnection = connection.buildMockConnection({
+        onRequest (params) {
+          t.strictEqual(params.path, '/_bulk')
+          t.match(params.headers, { 'content-type': 'application/x-ndjson' })
+          const [action, payload] = params.body.split('\n')
+          t.deepEqual(JSON.parse(action), { index: { _index: 'test' } })
+          t.deepEqual(JSON.parse(payload), dataset[count++])
+          return { body: { errors: false, items: [{}] } }
+        }
+      })
+
+      const client = getClient(type, {
+        node: 'http://localhost:9200',
+        Connection: MockConnection
+      })
+      const result = await client.helpers.bulk({
+        datasource: dataset.slice(),
+        flushBytes: 1,
+        concurrency: 1,
+        onDocument (doc) {
+          return {
+            index: { _index: 'test' }
+          }
+        },
+        onDrop (doc) {
+          t.fail('This should never be called')
+        }
+      })
+
+      t.type(result.time, 'number')
+      t.type(result.bytes, 'number')
+      t.match(result, {
+        total: 3,
+        successful: 3,
+        retry: 0,
+        failed: 0,
+        aborted: false
+      })
+    })
+
+    t.test('Use transport.request', async t => {
+      const MockConnection = connection.buildMockConnection({
+        onRequest (params) {
+          return { body: { hello: 'world' } }
+        }
+      })
+
+      const client = getClient(type, {
+        node: 'http://localhost:9200',
+        Connection: MockConnection
+      })
+
+      const response = await client.transport.request({
+        method: 'GET',
+        path: '/',
+        querystring: null,
+        body: null
+      })
+      t.deepEqual(response.body, { hello: 'world' })
+    })
+
+    t.test('Can\'t access other transport methods', async t => {
+      const client = getClient(type, {
+        node: 'http://localhost:9200'
+      })
+
+      t.strictEqual(client.transport.connectionPool, undefined)
+    })
+
+    t.test('Can\'t access connection pool', async t => {
+      const client = getClient(type, {
+        node: 'http://localhost:9200'
+      })
+
+      t.strictEqual(client.connectionPool, undefined)
+    })
+
+    t.test('Can\'t access serializer', async t => {
+      const client = getClient(type, {
+        node: 'http://localhost:9200'
+      })
+
+      t.strictEqual(client.serializer, undefined)
+    })
+
+    t.test('Can\'t use child method', async t => {
+      const client = getClient(type, {
+        node: 'http://localhost:9200'
+      })
+
+      t.throws(() => {
+        client.child()
+      })
+    })
+
+    t.test('Can\'t use close method', async t => {
+      const client = getClient(type, {
+        node: 'http://localhost:9200'
+      })
+
+      t.throws(() => {
+        client.close()
+      })
+    })
+
+    t.test('Can\'t use extend method', async t => {
+      const client = getClient(type, {
+        node: 'http://localhost:9200'
+      })
+
+      t.throws(() => {
+        client.extend()
+      })
+    })
+
+    t.test('Can\'t use events methods', async t => {
+      const client = getClient(type, {
+        node: 'http://localhost:9200'
+      })
+
+      t.throws(() => {
+        client.emit()
+      })
+
+      t.throws(() => {
+        client.on()
+      })
+
+      t.throws(() => {
+        client.once()
+      })
+    })
+
+    t.end()
   })
+}
 
-  t.type(result.time, 'number')
-  t.type(result.bytes, 'number')
-  t.match(result, {
-    total: 3,
-    successful: 3,
-    retry: 0,
-    failed: 0,
-    aborted: false
-  })
-})
-
-test('Use transport.request', async t => {
-  const MockConnection = connection.buildMockConnection({
-    onRequest (params) {
-      return { body: { hello: 'world' } }
-    }
-  })
-
-  const client = new KibanaClient({
-    node: 'http://localhost:9200',
-    Connection: MockConnection
-  })
-
-  const response = await client.transport.request({
-    method: 'GET',
-    path: '/',
-    querystring: null,
-    body: null
-  })
-  t.deepEqual(response.body, { hello: 'world' })
-})
-
-test('Can\'t access other transport methods', async t => {
-  const client = new KibanaClient({
-    node: 'http://localhost:9200'
-  })
-
-  t.strictEqual(client.transport.connectionPool, undefined)
-})
-
-test('Can\'t access connection pool', async t => {
-  const client = new KibanaClient({
-    node: 'http://localhost:9200'
-  })
-
-  t.strictEqual(client.connectionPool, undefined)
-})
-
-test('Can\'t access serializer', async t => {
-  const client = new KibanaClient({
-    node: 'http://localhost:9200'
-  })
-
-  t.strictEqual(client.serializer, undefined)
-})
-
-test('Can\'t use child method', async t => {
-  const client = new KibanaClient({
-    node: 'http://localhost:9200'
-  })
-
-  t.throws(() => {
-    client.child()
-  })
-})
-
-test('Can\'t use close method', async t => {
-  const client = new KibanaClient({
-    node: 'http://localhost:9200'
-  })
-
-  t.throws(() => {
-    client.close()
-  })
-})
-
-test('Can\'t use extend method', async t => {
-  const client = new KibanaClient({
-    node: 'http://localhost:9200'
-  })
-
-  t.throws(() => {
-    client.extend()
-  })
-})
-
-test('Can\'t use events methods', async t => {
-  const client = new KibanaClient({
-    node: 'http://localhost:9200'
-  })
-
-  t.throws(() => {
-    client.emit()
-  })
-
-  t.throws(() => {
-    client.on()
-  })
-
-  t.throws(() => {
-    client.once()
-  })
-})
+runTest('subclass')
+runTest('builder')

--- a/test/unit/kibana-client.test.js
+++ b/test/unit/kibana-client.test.js
@@ -1,0 +1,236 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+'use strict'
+
+const { test } = require('tap')
+const { Client, errors } = require('../../index')
+const { connection } = require('../utils')
+
+const kTransportRequest = Symbol('kibana-client-transport-request')
+class KibanaClient extends Client {
+  constructor (opts) {
+    super(opts)
+    this[kTransportRequest] = super.transport.request.bind(super.transport)
+  }
+
+  get transport () {
+    return { request: this[kTransportRequest] }
+  }
+
+  get connectionPool () {
+    return undefined
+  }
+
+  get serializer () {
+    return undefined
+  }
+
+  child () {
+    throw new errors.ElasticsearchClientError('Cannot access child method')
+  }
+
+  close () {
+    throw new errors.ElasticsearchClientError('Cannot access close method')
+  }
+
+  extend () {
+    throw new errors.ElasticsearchClientError('Cannot access extend method')
+  }
+
+  emit () {
+    throw new errors.ElasticsearchClientError('Cannot access emit method')
+  }
+
+  on () {
+    throw new errors.ElasticsearchClientError('Cannot access on method')
+  }
+
+  once () {
+    throw new errors.ElasticsearchClientError('Cannot access once method')
+  }
+}
+
+test('Basic', async t => {
+  const MockConnection = connection.buildMockConnection({
+    onRequest (params) {
+      return { body: { hello: 'world' } }
+    }
+  })
+
+  const client = new KibanaClient({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+  const response = await client.info()
+  t.deepEqual(response.body, { hello: 'world' })
+})
+
+test('Multiple connections', async t => {
+  const MockConnection = connection.buildMockConnection({
+    onRequest (params) {
+      return { body: { hello: 'world' } }
+    }
+  })
+
+  const client = new KibanaClient({
+    nodes: [
+      'http://localhost:9200',
+      'http://localhost:9201',
+      'http://localhost:9202'
+    ],
+    Connection: MockConnection
+  })
+  let response = await client.info()
+  t.deepEqual(response.body, { hello: 'world' })
+  t.strictEqual(response.meta.connection.id, 'http://localhost:9200/')
+
+  response = await client.info()
+  t.deepEqual(response.body, { hello: 'world' })
+  t.strictEqual(response.meta.connection.id, 'http://localhost:9201/')
+
+  response = await client.info()
+  t.deepEqual(response.body, { hello: 'world' })
+  t.strictEqual(response.meta.connection.id, 'http://localhost:9202/')
+})
+
+test('Can use helpers', async t => {
+  const dataset = [
+    { user: 'jon', age: 23 },
+    { user: 'arya', age: 18 },
+    { user: 'tyrion', age: 39 }
+  ]
+  let count = 0
+  const MockConnection = connection.buildMockConnection({
+    onRequest (params) {
+      t.strictEqual(params.path, '/_bulk')
+      t.match(params.headers, { 'content-type': 'application/x-ndjson' })
+      const [action, payload] = params.body.split('\n')
+      t.deepEqual(JSON.parse(action), { index: { _index: 'test' } })
+      t.deepEqual(JSON.parse(payload), dataset[count++])
+      return { body: { errors: false, items: [{}] } }
+    }
+  })
+
+  const client = new KibanaClient({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+  const result = await client.helpers.bulk({
+    datasource: dataset.slice(),
+    flushBytes: 1,
+    concurrency: 1,
+    onDocument (doc) {
+      return {
+        index: { _index: 'test' }
+      }
+    },
+    onDrop (doc) {
+      t.fail('This should never be called')
+    }
+  })
+
+  t.type(result.time, 'number')
+  t.type(result.bytes, 'number')
+  t.match(result, {
+    total: 3,
+    successful: 3,
+    retry: 0,
+    failed: 0,
+    aborted: false
+  })
+})
+
+test('Use transport.request', async t => {
+  const MockConnection = connection.buildMockConnection({
+    onRequest (params) {
+      return { body: { hello: 'world' } }
+    }
+  })
+
+  const client = new KibanaClient({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  const response = await client.transport.request({
+    method: 'GET',
+    path: '/',
+    querystring: null,
+    body: null
+  })
+  t.deepEqual(response.body, { hello: 'world' })
+})
+
+test('Can\'t access other transport methods', async t => {
+  const client = new KibanaClient({
+    node: 'http://localhost:9200'
+  })
+
+  t.strictEqual(client.transport.connectionPool, undefined)
+})
+
+test('Can\'t access connection pool', async t => {
+  const client = new KibanaClient({
+    node: 'http://localhost:9200'
+  })
+
+  t.strictEqual(client.connectionPool, undefined)
+})
+
+test('Can\'t access serializer', async t => {
+  const client = new KibanaClient({
+    node: 'http://localhost:9200'
+  })
+
+  t.strictEqual(client.serializer, undefined)
+})
+
+test('Can\'t use child method', async t => {
+  const client = new KibanaClient({
+    node: 'http://localhost:9200'
+  })
+
+  t.throws(() => {
+    client.child()
+  })
+})
+
+test('Can\'t use close method', async t => {
+  const client = new KibanaClient({
+    node: 'http://localhost:9200'
+  })
+
+  t.throws(() => {
+    client.close()
+  })
+})
+
+test('Can\'t use extend method', async t => {
+  const client = new KibanaClient({
+    node: 'http://localhost:9200'
+  })
+
+  t.throws(() => {
+    client.extend()
+  })
+})
+
+test('Can\'t use events methods', async t => {
+  const client = new KibanaClient({
+    node: 'http://localhost:9200'
+  })
+
+  t.throws(() => {
+    client.emit()
+  })
+
+  t.throws(() => {
+    client.on()
+  })
+
+  t.throws(() => {
+    client.once()
+  })
+})

--- a/test/unit/kibana-client.test.js
+++ b/test/unit/kibana-client.test.js
@@ -71,20 +71,25 @@ class KibanaClient extends Client {
 function buildKibanaClient (opts) {
   const client = new Client(opts)
 
-  return {
-    ...client,
-    transport: {
-      request: client.transport.request.bind(client.transport)
-    },
-    connectionPool: undefined,
-    serializer: undefined,
-    helpers: {
+  let helpers = null
+  if (semver.gte(process.versions.node, '10.0.0')) {
+    helpers = {
       search: client.helpers.search.bind(client.helpers),
       scrollSearch: client.helpers.scrollSearch.bind(client.helpers),
       scrollDocuments: client.helpers.scrollDocuments.bind(client.helpers),
       msearch: client.helpers.msearch.bind(client.helpers),
       bulk: client.helpers.bulk.bind(client.helpers)
+    }
+  }
+
+  return {
+    ...client,
+    transport: {
+      request: client.transport.request.bind(client.transport)
     },
+    helpers,
+    connectionPool: undefined,
+    serializer: undefined,
     emit () {
       throw new errors.ElasticsearchClientError('Cannot access emit method')
     },


### PR DESCRIPTION
Proposal for offering first-class support to Kibana.

## Requirements
- [x] Avoid the creation of a wrapper
- [x] Some properties and methods of the client should not be accessed by mistake
  - [x] `transport`
  - [x] `connectionPool`
  - [x] `serializer`
  - [x] `close`
  - [x] `child`
  - [x] `extend`
  - [x] `on`
  - [x] `once`
  - [x] `emit`
- [ ] Simplified type definition *(the work done in https://github.com/elastic/elasticsearch-js/pull/1239 will merged here)*
- [ ] Ship the kibana type definition with the client
- [ ] The chosen solution will be part of the testing suite of the client
- [ ] Support of jest mocks

## Implementation
Currently, the idea is that the Kibana client will extend the base Client and hide the properties that should not be accessed by plugin users.
The main counterargument of this approach is that if Kibana core needs to access these methods, we'll need to re-expose them via symbols, for example:
```js
const kClose = Symbol('kibana-client-close')
class KibanaClient extends Client {
  get [kClose] () {
    return super.close
  }
}

const client = new KibanaClient()
client[kClose]()
```

A different solution is to exclude the properties we don't want to be accessed with a builder function.
```js
const client = new Client(opts)
function buildKibanaClient () {
  return {
    ...client,
    transport: {
      request: client.transport.request.bind(client.transport)
    },
    connectionPool: undefined,
    serializer: undefined,
    close () {
      throw new errors.ElasticsearchClientError('Cannot access close method')
    }
  }
}

const kclient = buildKibanaClient()
```

In my opinion, the first method is more elegant, as it uses idiomatic JavaScript to solve the issue, but will require you to use symbols for accessing "private" APIs. The second method feels hackier, as we'll need to bind the client in some places, but it removes the need to use Symbols at all.

@elastic/kibana-platform what do you think?