### PR TITLE
Improve child API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,7 @@ declare class Client {
   helpers: Helpers;
   child(opts?: ClientOptions): Client;
   close(callback?: Function): Promise<void> | void;
+  emit(event: string | symbol, ...args: any[]): boolean;
   on(event: 'request', listener: (err: ApiError, meta: RequestEvent) => void): this;
   on(event: 'response', listener: (err: ApiError, meta: RequestEvent) => void): this;
   on(event: 'sniff', listener: (err: ApiError, meta: RequestEvent) => void): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,7 +102,7 @@ interface ClientOptions {
   }
 }
 
-declare class Client extends EventEmitter {
+declare class Client {
   constructor(opts?: ClientOptions);
   connectionPool: ConnectionPool;
   transport: Transport;
@@ -111,6 +111,16 @@ declare class Client extends EventEmitter {
   helpers: Helpers;
   child(opts?: ClientOptions): Client;
   close(callback?: Function): Promise<void> | void;
+  on(event: 'request', listener: (err: ApiError, meta: RequestEvent) => void): this;
+  on(event: 'response', listener: (err: ApiError, meta: RequestEvent) => void): this;
+  on(event: 'sniff', listener: (err: ApiError, meta: RequestEvent) => void): this;
+  on(event: 'resurrect', listener: (err: null, meta: ResurrectEvent) => void): this;
+  once(event: 'request', listener: (err: ApiError, meta: RequestEvent) => void): this;
+  once(event: 'response', listener: (err: ApiError, meta: RequestEvent) => void): this;
+  once(event: 'sniff', listener: (err: ApiError, meta: RequestEvent) => void): this;
+  once(event: 'resurrect', listener: (err: null, meta: ResurrectEvent) => void): this;
+  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+  off(event: string | symbol, listener: (...args: any[]) => void): this;
   /* GENERATED */
   async_search: {
     delete<TResponse = Record<string, any>, TContext = unknown>(params?: RequestParams.AsyncSearchDelete, options?: TransportRequestOptions): TransportRequestPromise<ApiResponse<TResponse, TContext>>
@@ -2607,34 +2617,6 @@ declare class Client extends EventEmitter {
     usage<TResponse = Record<string, any>, TContext = unknown>(params: RequestParams.XpackUsage, options: TransportRequestOptions, callback: callbackFn<TResponse, TContext>): TransportRequestCallback
   }
   /* /GENERATED */
-}
-
-// We must redeclare the EventEmitter class so we can provide
-// better type definitions for our events, otherwise the default
-// signature is `(event: string | symbol, listener: (...args: any[]) => void): this;`
-declare class EventEmitter {
-  addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-  on(event: 'request', listener: (err: ApiError, meta: RequestEvent) => void): this;
-  on(event: 'response', listener: (err: ApiError, meta: RequestEvent) => void): this;
-  on(event: 'sniff', listener: (err: ApiError, meta: RequestEvent) => void): this;
-  on(event: 'resurrect', listener: (err: null, meta: ResurrectEvent) => void): this;
-  once(event: 'request', listener: (err: ApiError, meta: RequestEvent) => void): this;
-  once(event: 'response', listener: (err: ApiError, meta: RequestEvent) => void): this;
-  once(event: 'sniff', listener: (err: ApiError, meta: RequestEvent) => void): this;
-  once(event: 'resurrect', listener: (err: null, meta: ResurrectEvent) => void): this;
-  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-  off(event: string | symbol, listener: (...args: any[]) => void): this;
-  removeAllListeners(event?: string | symbol): this;
-  setMaxListeners(n: number): this;
-  getMaxListeners(): number;
-  listeners(event: string | symbol): Function[];
-  rawListeners(event: string | symbol): Function[];
-  emit(event: string | symbol, ...args: any[]): boolean;
-  listenerCount(type: string | symbol): number;
-  // Added in Node 6...
-  prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
-  prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
-  eventNames(): Array<string | symbol>;
 }
 
 declare const events: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,6 @@ declare class Client {
   once(event: 'response', listener: (err: ApiError, meta: RequestEvent) => void): this;
   once(event: 'sniff', listener: (err: ApiError, meta: RequestEvent) => void): this;
   once(event: 'resurrect', listener: (err: null, meta: ResurrectEvent) => void): this;
-  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
   off(event: string | symbol, listener: (...args: any[]) => void): this;
   /* GENERATED */
   async_search: {

--- a/index.js
+++ b/index.js
@@ -151,6 +151,10 @@ class Client {
     }
   }
 
+  get emit () {
+    return this[kEventEmitter].emit.bind(this[kEventEmitter])
+  }
+
   get on () {
     return this[kEventEmitter].on.bind(this[kEventEmitter])
   }

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -54,6 +54,113 @@ test('Should emit a request event when a request is performed', t => {
   })
 })
 
+test('Should emit a request event once when a request is performed', t => {
+  t.plan(4)
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  client.once(events.REQUEST, (err, request) => {
+    t.error(err)
+    t.match(request, {
+      body: null,
+      statusCode: null,
+      headers: null,
+      warnings: null,
+      meta: {
+        context: null,
+        name: 'elasticsearch-js',
+        request: {
+          params: {
+            method: 'GET',
+            path: '/test/_search',
+            body: '',
+            querystring: 'q=foo%3Abar'
+          },
+          options: {},
+          id: 1
+        },
+        connection: {
+          id: 'http://localhost:9200'
+        },
+        attempts: 0,
+        aborted: false
+      }
+    })
+  })
+
+  client.search({
+    index: 'test',
+    q: 'foo:bar'
+  }, (err, result) => {
+    t.error(err)
+  })
+
+  client.search({
+    index: 'test',
+    q: 'foo:bar'
+  }, (err, result) => {
+    t.error(err)
+  })
+})
+
+test('Remove an event', t => {
+  t.plan(4)
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  client.on(events.REQUEST, onRequest)
+  function onRequest (err, request) {
+    t.error(err)
+    t.match(request, {
+      body: null,
+      statusCode: null,
+      headers: null,
+      warnings: null,
+      meta: {
+        context: null,
+        name: 'elasticsearch-js',
+        request: {
+          params: {
+            method: 'GET',
+            path: '/test/_search',
+            body: '',
+            querystring: 'q=foo%3Abar'
+          },
+          options: {},
+          id: 1
+        },
+        connection: {
+          id: 'http://localhost:9200'
+        },
+        attempts: 0,
+        aborted: false
+      }
+    })
+
+    client.off('request', onRequest)
+  }
+
+  client.search({
+    index: 'test',
+    q: 'foo:bar'
+  }, (err, result) => {
+    t.error(err)
+  })
+
+  client.search({
+    index: 'test',
+    q: 'foo:bar'
+  }, (err, result) => {
+    t.error(err)
+  })
+})
+
 test('Should emit a response event in case of a successful response', t => {
   t.plan(3)
 

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -259,3 +259,19 @@ test('Should emit a response event with the error set', t => {
     t.ok(err instanceof TimeoutError)
   })
 })
+
+test('Emit event', t => {
+  t.plan(2)
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  client.on(events.REQUEST, (err, request) => {
+    t.error(err)
+    t.deepEqual(request, { hello: 'world' })
+  })
+
+  client.emit(events.REQUEST, null, { hello: 'world' })
+})

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const { test } = require('tap')
+const semver = require('semver')
 const { Client, events } = require('../../index')
 const { TimeoutError } = require('../../lib/errors')
 const { connection: { MockConnection, MockConnectionTimeout } } = require('../utils')
@@ -106,7 +107,7 @@ test('Should emit a request event once when a request is performed', t => {
   })
 })
 
-test('Remove an event', t => {
+test('Remove an event', { skip: semver.lt(process.versions.node, '10.0.0') }, t => {
   t.plan(4)
 
   const client = new Client({


### PR DESCRIPTION
This pr introduce two changes which should not impact the surface API:
- Refactored the `client.child` API to allocate fewer objects, this change improves memory consumption over time and improves the child creation performances by ~12%.
- The client no longer inherits from the `EventEmitter` class, but instead has an internal event emitter and exposes only the API useful for the users, namely `emit`, `on`, `once`, and `off`. The type definitions have been updated accordingly.