### PR TITLE
Fix errors in type definitions

### DIFF
--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -138,7 +138,7 @@ export default class Transport {
   _nextSniff: number;
   _isSniffing: boolean;
   constructor(opts: TransportOptions);
-  request(params: TransportRequestParams, options?: TransportRequestOptions): Promise<ApiResponse>;
+  request(params: TransportRequestParams, options?: TransportRequestOptions): TransportRequestPromise<ApiResponse>;
   request(params: TransportRequestParams, options?: TransportRequestOptions, callback?: (err: ApiError, result: ApiResponse) => void): TransportRequestCallback;
   getConnection(opts: TransportGetConnectionOptions): Connection | null;
   sniff(opts?: TransportSniffOptions, callback?: (...args: any[]) => void): void;

--- a/scripts/utils/generateRequestTypes.js
+++ b/scripts/utils/generateRequestTypes.js
@@ -26,7 +26,6 @@ import { RequestBody, RequestNDBody } from '../lib/Transport'
 
 export interface Generic {
   method?: string;
-  ignore?: number | number[];
   filter_path?: string | string[];
   pretty?: boolean;
   human?: boolean;
@@ -118,7 +117,31 @@ export interface ${toPascalCase(name)}${body ? `<T = ${bodyGeneric}>` : ''} exte
       case 'timeout':
         return 'string'
       case 'enum':
-        return options.map(k => `'${k}'`).join(' | ')
+        // the following code changes 'true' | 'false' to boolean
+        let foundTrue = false
+        let foundFalse = false
+        options = options
+          .map(k => {
+            if (k === 'true') {
+              foundTrue = true
+              return true
+            } else if (k === 'false') {
+              foundFalse = true
+              return false
+            } else {
+              return `'${k}'`
+            }
+          })
+          .filter(k => {
+            if (foundTrue && foundFalse && (k === true || k === false)) {
+              return false
+            }
+            return true
+          })
+        if (foundTrue && foundFalse) {
+          options.push('boolean')
+        }
+        return options.join(' | ')
       case 'int':
       case 'double':
       case 'long':

--- a/test/types/transport.test-d.ts
+++ b/test/types/transport.test-d.ts
@@ -14,6 +14,7 @@ import {
   TransportRequestParams,
   TransportRequestOptions,
   TransportRequestCallback,
+  TransportRequestPromise,
   RequestEvent,
   ApiError,
   RequestBody,
@@ -152,7 +153,7 @@ transport.request({
 })
 
 const promise = transport.request(params, options)
-expectType<Promise<ApiResponse>>(promise)
+expectType<TransportRequestPromise<ApiResponse>>(promise)
 promise.then(result => expectType<ApiResponse>(result))
 expectType<ApiResponse>(await promise)
 


### PR DESCRIPTION
- The `ignore` paramater is part of the request options and not the request params.
- In the rest-api-spec boolean are written as string (`'true'` and `false'`), this pr generates them as `boolean`.

The type definition fix will be generated once in `master`, `7.x`, and `7.9`.
Related: https://github.com/elastic/kibana/pull/72388 https://github.com/elastic/kibana/pull/72289 