### PR TITLE
Correct param name for `scroll` calls

### DIFF
--- a/docs/examples/scroll.asciidoc
+++ b/docs/examples/scroll.asciidoc
@@ -102,7 +102,7 @@ async function run () {
     // get the next response if there are more quotes to fetch
     responseQueue.push(
       await client.scroll({
-        scrollId: body._scroll_id,
+        scroll_id: body._scroll_id,
         scroll: '30s'
       })
     )
@@ -142,7 +142,7 @@ async function * scrollSearch (params) {
     }
 
     response = await client.scroll({
-      scrollId: response.body._scroll_id,
+      scroll_id: response.body._scroll_id,
       scroll: params.scroll
     })
   }


### PR DESCRIPTION
Not sure if this is an issue with previous version of the client but on 7.x there is definitely a mistake in the docs.