### PR TITLE
Fix maxRetries request option handling

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -135,7 +135,8 @@ class Transport {
     // a copy of the stream to be able to send it again, but since we don't know in advance
     // the size of the stream, we risk to take too much memory.
     // Furthermore, copying everytime the stream is very a expensive operation.
-    const maxRetries = isStream(params.body) ? 0 : options.maxRetries || this.maxRetries
+    const maxRetries = isStream(params.body) || isStream(params.bulkBody)
+      ? 0 : (typeof options.maxRetries === 'number' ? options.maxRetries : this.maxRetries)
     const compression = options.compression !== undefined ? options.compression : this.compression
     var request = { abort: noop }
 

--- a/test/unit/transport.test.js
+++ b/test/unit/transport.test.js
@@ -677,6 +677,98 @@ test('Should not retry if the body is a stream', t => {
   })
 })
 
+test('Should not retry if the bulkBody is a stream', t => {
+  t.plan(2)
+
+  var count = 0
+  function handler (req, res) {
+    count++
+    res.setHeader('Content-Type', 'application/json;utf=8')
+    res.statusCode = 504
+    res.end(JSON.stringify({ error: true }))
+  }
+
+  buildServer(handler, ({ port }, server) => {
+    const pool = new ConnectionPool({ Connection })
+    pool.addConnection([{
+      url: new URL(`http://localhost:${port}`),
+      id: 'node1'
+    }, {
+      url: new URL(`http://localhost:${port}`),
+      id: 'node2'
+    }, {
+      url: new URL(`http://localhost:${port}`),
+      id: 'node3'
+    }])
+
+    const transport = new Transport({
+      emit: () => {},
+      connectionPool: pool,
+      serializer: new Serializer(),
+      maxRetries: 1,
+      sniffInterval: false,
+      sniffOnStart: false
+    })
+
+    transport.request({
+      method: 'POST',
+      path: '/hello',
+      bulkBody: intoStream(JSON.stringify([{ hello: 'world' }]))
+    }, (err, { body }) => {
+      t.ok(err instanceof ResponseError)
+      t.strictEqual(count, 1)
+      server.stop()
+    })
+  })
+})
+
+test('No retry', t => {
+  t.plan(2)
+
+  var count = 0
+  function handler (req, res) {
+    count++
+    res.setHeader('Content-Type', 'application/json;utf=8')
+    res.statusCode = 504
+    res.end(JSON.stringify({ error: true }))
+  }
+
+  buildServer(handler, ({ port }, server) => {
+    const pool = new ConnectionPool({ Connection })
+    pool.addConnection([{
+      url: new URL(`http://localhost:${port}`),
+      id: 'node1'
+    }, {
+      url: new URL(`http://localhost:${port}`),
+      id: 'node2'
+    }, {
+      url: new URL(`http://localhost:${port}`),
+      id: 'node3'
+    }])
+
+    const transport = new Transport({
+      emit: () => {},
+      connectionPool: pool,
+      serializer: new Serializer(),
+      maxRetries: 3,
+      sniffInterval: false,
+      sniffOnStart: false
+    })
+
+    transport.request({
+      method: 'POST',
+      path: '/hello',
+      body: intoStream(JSON.stringify({ hello: 'world' }))
+    }, {
+      maxRetries: 0
+    }, (err, { body }) => {
+      t.ok(err instanceof ResponseError)
+      t.strictEqual(count, 1)
+      server.stop()
+    })
+  })
+})
+
 test('Custom retry mechanism', t => {
   t.plan(2)
 


### PR DESCRIPTION
- If `maxRetries` request option is zero, the client should not use the default
- Check if the `bulkBody` is a stream as well.