### PR TITLE
Integration test: Parse dates as string

### DIFF
--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -288,8 +288,9 @@ function now () {
 }
 
 function parse (data) {
+  const schema = yaml.Schema.create(yaml.CORE_SCHEMA, [])
   try {
-    var doc = yaml.safeLoad(data)
+    var doc = yaml.safeLoad(data, { schema })
   } catch (err) {
     console.error(err)
     return


### PR DESCRIPTION
By default, the yaml parser will parse look-like dates to date objects, which will break the comparison with the Elasticsearch responses, where dates are represented as string.