### PR TITLE
Improved cleanup yaml tests

### DIFF
--- a/test/integration/test-runner.js
+++ b/test/integration/test-runner.js
@@ -75,11 +75,7 @@ function build (opts = {}) {
     }
 
     try {
-      const { body: templates } = await client.indices.getTemplate()
-      await helper.runInParallel(
-        client, 'indices.deleteTemplate',
-        Object.keys(templates).map(t => ({ name: t }))
-      )
+      await client.indices.deleteTemplate({ name: '*'})
     } catch (err) {
       assert.ifError(err, 'should not error: indices.deleteTemplate')
     }
@@ -87,12 +83,7 @@ function build (opts = {}) {
     try {
       const { body: repositories } = await client.snapshot.getRepository()
       for (const repository of Object.keys(repositories)) {
-        const { body: snapshots } = await client.snapshot.get({ repository, snapshot: '_all' })
-        await helper.runInParallel(
-          client, 'snapshot.delete',
-          Object.keys(snapshots).map(snapshot => ({ snapshot, repository })),
-          { ignore: [404] }
-        )
+        await client.snapshot.delete({ repository, snapshot: '*'}, { ignore: [404] })
         await client.snapshot.deleteRepository({ repository }, { ignore: [404] })
       }
     } catch (err) {

--- a/test/integration/test-runner.js
+++ b/test/integration/test-runner.js
@@ -75,7 +75,7 @@ function build (opts = {}) {
     }
 
     try {
-      await client.indices.deleteTemplate({ name: '*'})
+      await client.indices.deleteTemplate({ name: '*' })
     } catch (err) {
       assert.ifError(err, 'should not error: indices.deleteTemplate')
     }
@@ -83,7 +83,7 @@ function build (opts = {}) {
     try {
       const { body: repositories } = await client.snapshot.getRepository()
       for (const repository of Object.keys(repositories)) {
-        await client.snapshot.delete({ repository, snapshot: '*'}, { ignore: [404] })
+        await client.snapshot.delete({ repository, snapshot: '*' }, { ignore: [404] })
         await client.snapshot.deleteRepository({ repository }, { ignore: [404] })
       }
     } catch (err) {


### PR DESCRIPTION
This PR improves the cleanup step of the YAML integration tests using wildcard `*` operator for deleting all the templates and all the snapshosts. Here some references:
- [delete template API using wildcards for <index-template>](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-template.html#delete-template-api-path-params)
- [delete spanshost API using * in name](https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-snapshots.html)

I didn't test it but I expect a saving of the overall YAML tests execution time.