### PR TITLE
[7.x][DOCS] Fixes link in API reference

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -6741,7 +6741,7 @@ client.closePointInTime({
   body: object
 })
 ----
-link:{ref}/point-in-time.html[Documentation] +
+link:{ref}/point-in-time-api.html[Documentation] +
 [cols=2*]
 |===
 |`body`
@@ -9107,7 +9107,7 @@ client.openPointInTime({
   keep_alive: string
 })
 ----
-link:{ref}/point-in-time.html[Documentation] +
+link:{ref}/point-in-time-api.html[Documentation] +
 [cols=2*]
 |===
 |`index`


### PR DESCRIPTION
## Overview

This PR fixes a link in the API reference documentation on the 7.x branch.
`{ref}/point-in-time.html`--> `{ref}/point-in-time-api.html`