### PR TITLE
Fix rendering of name field in configuration.md

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -203,7 +203,7 @@ function generateRequestId (params, options) {
 ----
 
 |`name`
-|`string | symbol` - The name to identify the client instance in the events. +
+|`string, symbol` - The name to identify the client instance in the events. +
 _Default:_ `elasticsearch-js`
 
 |`opaqueIdPrefix`


### PR DESCRIPTION
Name field had `string | symbol` but the | was treated as a table column separator.
