### PR TITLE
Fixes 'Documentation' link from indices.getAlias

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -3052,7 +3052,7 @@ client.indices.getAlias({
   local: boolean
 })
 ----
-link:{ref}/indices-aliases.html[Documentation] +
+link:{ref}/indices-get-alias.html[Documentation] +
 [cols=2*]
 |===
 |`name`


### PR DESCRIPTION
The 'Documentation' link for `indices.getAlias` was pointing to the update aliases documentation not get aliases documentation.
