### PR TITLE
[#1321] Fix scroll cursor leak inside searchScroll helper.

### DIFF
--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -127,6 +127,10 @@ class Helpers {
         throw new ResponseError(response)
       }
     }
+
+    if (!stop && scroll_id) {
+      await clear()
+    }
   }
 
   /**


### PR DESCRIPTION
I didn't find a way to test this change.
The leak is not visible in the client side but only in the server side during the scroll window.
