### PR TITLE
Added node.js support doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,33 @@ The official Node.js client for Elasticsearch.
 npm install @elastic/elasticsearch
 ```
 
-### Compatibility
+### Node.js support
 
-The minimum supported version of Node.js is `v8`.
+NOTE: The minimum supported version of Node.js is `v8`.
+
+The client versioning follows the Elastc Stack versioning, this means that
+major, minor, and patch releases are done following a precise schedule that
+often does not coincide with the [Node.js release](https://nodejs.org/en/about/releases/) times.
+
+To avoid support insecure and unsupported versions of Node.js, the
+client **will drop the support of EOL versions of Node.js between minor releases**.
+Typically, as soon as a Node.js version goes into EOL, the client will continue
+to support that version for at least another minor release. If you are using the client
+with a version of Node.js that will be unsupported soon, you will see a warning
+in your logs (the client will start logging the warning with two minors in advance).
+
+Unless you are **always** using a supported version of Node.js, 
+we recommend defining the client dependency in your
+`package.json` with the `~` instead of `^`. In this way, you will lock the
+dependency on the minor release and not the major. (for example, `~7.10.0` instead
+of `^7.10.0`).
+
+| Node.js Version | Node.js EOL date | End of support         |
+| --------------- |------------------| ---------------------- |
+| `8.x`           | `December 2019`  | `7.11` (early 2021)    |       
+| `10.x`          | `Apri 2021`      | `7.12` (mid 2021)      |        
+
+### Compatibility
 
 The library is compatible with all Elasticsearch versions since 5.x, and you should use the same major version of the Elasticsearch instance that you are using.
 

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -37,8 +37,8 @@ to support that version for at least another minor release. If you are using the
 with a version of Node.js that will be unsupported soon, you will see a warning
 in your logs (the client will start logging the warning with two minors in advance).
 
-Because of the reasons defined above, unless you are *always* using a supported
-version of Node.js, we recommend defining the client dependency in your
+Unless you are *always* using a supported version of Node.js, 
+we recommend defining the client dependency in your
 `package.json` with the `~` instead of `^`. In this way, you will lock the
 dependency on the minor release and not the major. (for example, `~7.10.0` instead
 of `^7.10.0`).

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -40,7 +40,7 @@ in your logs (the client will start logging the warning with two minors in advan
 Because of the reasons defined above, unless you are *always* using a supported
 version of Node.js, we recommend defining the client dependency in your
 `package.json` with the `~` instead of `^`. In this way, you will lock the
-dependency on the minor release and not the major. (eg: `~7.10.0` instead
+dependency on the minor release and not the major. (for example, `~7.10.0` instead
 of `^7.10.0`).
 
 [%header,cols=3*]

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -26,7 +26,7 @@ To learn more about the supported major versions, please refer to the
 
 NOTE: The minimum supported version of Node.js is `v8`.
 
-The client versioning follows the Elastic Stack versioning, this means that
+The client versioning follows the {stack} versioning, this means that
 major, minor, and patch releases are done following a precise schedule that
 often does not coincide with the https://nodejs.org/en/about/releases/[Node.js release] times.
 

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -20,12 +20,47 @@ npm install @elastic/elasticsearch@<major>
 To learn more about the supported major versions, please refer to the 
 <<js-compatibility-matrix>>.
 
+[discrete]
+[[nodejs-support]]
+=== Node.js support
+
+NOTE: The minimum supported version of Node.js is `v8`.
+
+The client versioning follows the Elastic Stack versioning, this means that
+major, minor, and patch releases are done following a precise schedule that
+often does not coincide with the https://nodejs.org/en/about/releases/[Node.js release] times.
+
+For avoiding supporting insecure and unsupported versions of Node.js, the
+client *will drop the support of EOL versions of Node.js between minor releases*.
+Typically, as soon as a Node.js version goes into EOL, the client will continue
+to support that version for at least another minor release. If you are using the client
+with a version of Node.js that will be unsupported soon, you will see a warning
+in your logs (the client will start logging the warning with two minors in advance).
+
+Because of the reasons defined above, unless you are *always* using a supported
+version of Node.js, we recommend defining the client dependency in your
+`package.json` with the `~` instead of `^`. In this way, you will lock the
+dependency on the minor release and not the major. (eg: `~7.10.0` instead
+of `^7.10.0`).
+
+[%header,cols=3*]
+|===
+|Node.js Version
+|Node.js EOL date
+|End of support
+
+|`8.x`
+|December 2019
+|`7.11` (early 2021)
+
+|`10.x`
+|April 2021
+|`7.12` (mid 2021)
+|===
 
 [discrete]
 [[js-compatibility-matrix]]
 === Compatibility matrix
-
-The minimum supported version of Node.js is `v8`.
 
 The library is compatible with all {es} versions since 5.x. We recommend you to
 use the same major version of the client as the {es} instance that you are

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -30,7 +30,7 @@ The client versioning follows the {stack} versioning, this means that
 major, minor, and patch releases are done following a precise schedule that
 often does not coincide with the https://nodejs.org/en/about/releases/[Node.js release] times.
 
-For avoiding supporting insecure and unsupported versions of Node.js, the
+To avoid support insecure and unsupported versions of Node.js, the
 client *will drop the support of EOL versions of Node.js between minor releases*.
 Typically, as soon as a Node.js version goes into EOL, the client will continue
 to support that version for at least another minor release. If you are using the client


### PR DESCRIPTION
Since the client **must** follow the stack versioning, it's really hard to follow the [node.js release cadence](https://nodejs.org/en/about/releases/), so we have decided to allow dropping EOL node.js version in minor releases. This pr contains the formalization of the process we will follow in the future.

- [x] asciidoc updated
- [x] README updated