### PR TITLE
Added API name to request metadata

### DIFF
--- a/api/api/async_search.js
+++ b/api/api/async_search.js
@@ -55,6 +55,7 @@ AsyncSearchApi.prototype.delete = function asyncSearchDeleteApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.async_search.delete'
   return this.transport.request(request, options, callback)
 }
 
@@ -82,6 +83,7 @@ AsyncSearchApi.prototype.get = function asyncSearchGetApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.async_search.get'
   return this.transport.request(request, options, callback)
 }
 
@@ -109,6 +111,7 @@ AsyncSearchApi.prototype.status = function asyncSearchStatusApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.async_search.status'
   return this.transport.request(request, options, callback)
 }
 
@@ -135,6 +138,7 @@ AsyncSearchApi.prototype.submit = function asyncSearchSubmitApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.async_search.submit'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/autoscaling.js
+++ b/api/api/autoscaling.js
@@ -55,6 +55,7 @@ AutoscalingApi.prototype.deleteAutoscalingPolicy = function autoscalingDeleteAut
     querystring
   }
 
+  options.api = 'elasticsearch.autoscaling.delete_autoscaling_policy'
   return this.transport.request(request, options, callback)
 }
 
@@ -76,6 +77,7 @@ AutoscalingApi.prototype.getAutoscalingCapacity = function autoscalingGetAutosca
     querystring
   }
 
+  options.api = 'elasticsearch.autoscaling.get_autoscaling_capacity'
   return this.transport.request(request, options, callback)
 }
 
@@ -103,6 +105,7 @@ AutoscalingApi.prototype.getAutoscalingPolicy = function autoscalingGetAutoscali
     querystring
   }
 
+  options.api = 'elasticsearch.autoscaling.get_autoscaling_policy'
   return this.transport.request(request, options, callback)
 }
 
@@ -134,6 +137,7 @@ AutoscalingApi.prototype.putAutoscalingPolicy = function autoscalingPutAutoscali
     querystring
   }
 
+  options.api = 'elasticsearch.autoscaling.put_autoscaling_policy'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/bulk.js
+++ b/api/api/bulk.js
@@ -64,6 +64,7 @@ function bulkApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.bulk'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/cat.js
+++ b/api/api/cat.js
@@ -54,6 +54,7 @@ CatApi.prototype.aliases = function catAliasesApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.aliases'
   return this.transport.request(request, options, callback)
 }
 
@@ -80,6 +81,7 @@ CatApi.prototype.allocation = function catAllocationApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.cat.allocation'
   return this.transport.request(request, options, callback)
 }
 
@@ -106,6 +108,7 @@ CatApi.prototype.count = function catCountApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.count'
   return this.transport.request(request, options, callback)
 }
 
@@ -132,6 +135,7 @@ CatApi.prototype.fielddata = function catFielddataApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.cat.fielddata'
   return this.transport.request(request, options, callback)
 }
 
@@ -153,6 +157,7 @@ CatApi.prototype.health = function catHealthApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.health'
   return this.transport.request(request, options, callback)
 }
 
@@ -174,6 +179,7 @@ CatApi.prototype.help = function catHelpApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.help'
   return this.transport.request(request, options, callback)
 }
 
@@ -200,6 +206,7 @@ CatApi.prototype.indices = function catIndicesApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.indices'
   return this.transport.request(request, options, callback)
 }
 
@@ -221,6 +228,7 @@ CatApi.prototype.master = function catMasterApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.master'
   return this.transport.request(request, options, callback)
 }
 
@@ -242,6 +250,7 @@ CatApi.prototype.nodeattrs = function catNodeattrsApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.cat.nodeattrs'
   return this.transport.request(request, options, callback)
 }
 
@@ -263,6 +272,7 @@ CatApi.prototype.nodes = function catNodesApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.nodes'
   return this.transport.request(request, options, callback)
 }
 
@@ -284,6 +294,7 @@ CatApi.prototype.pendingTasks = function catPendingTasksApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.cat.pending_tasks'
   return this.transport.request(request, options, callback)
 }
 
@@ -305,6 +316,7 @@ CatApi.prototype.plugins = function catPluginsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.plugins'
   return this.transport.request(request, options, callback)
 }
 
@@ -331,6 +343,7 @@ CatApi.prototype.recovery = function catRecoveryApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.cat.recovery'
   return this.transport.request(request, options, callback)
 }
 
@@ -352,6 +365,7 @@ CatApi.prototype.repositories = function catRepositoriesApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.cat.repositories'
   return this.transport.request(request, options, callback)
 }
 
@@ -378,6 +392,7 @@ CatApi.prototype.segments = function catSegmentsApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.cat.segments'
   return this.transport.request(request, options, callback)
 }
 
@@ -404,6 +419,7 @@ CatApi.prototype.shards = function catShardsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.shards'
   return this.transport.request(request, options, callback)
 }
 
@@ -430,6 +446,7 @@ CatApi.prototype.snapshots = function catSnapshotsApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.cat.snapshots'
   return this.transport.request(request, options, callback)
 }
 
@@ -451,6 +468,7 @@ CatApi.prototype.tasks = function catTasksApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.tasks'
   return this.transport.request(request, options, callback)
 }
 
@@ -477,6 +495,7 @@ CatApi.prototype.templates = function catTemplatesApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.cat.templates'
   return this.transport.request(request, options, callback)
 }
 
@@ -503,6 +522,7 @@ CatApi.prototype.threadPool = function catThreadPoolApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.cat.thread_pool'
   return this.transport.request(request, options, callback)
 }
 
@@ -529,6 +549,7 @@ CatApi.prototype.mlDataFrameAnalytics = function catMlDataFrameAnalyticsApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.cat.ml_data_frame_analytics'
   return this.transport.request(request, options, callback)
 }
 
@@ -555,6 +576,7 @@ CatApi.prototype.mlDatafeeds = function catMlDatafeedsApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.cat.ml_datafeeds'
   return this.transport.request(request, options, callback)
 }
 
@@ -581,6 +603,7 @@ CatApi.prototype.mlJobs = function catMlJobsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.cat.ml_jobs'
   return this.transport.request(request, options, callback)
 }
 
@@ -607,6 +630,7 @@ CatApi.prototype.mlTrainedModels = function catMlTrainedModelsApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.cat.ml_trained_models'
   return this.transport.request(request, options, callback)
 }
 
@@ -633,6 +657,7 @@ CatApi.prototype.transforms = function catTransformsApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.cat.transforms'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/ccr.js
+++ b/api/api/ccr.js
@@ -55,6 +55,7 @@ CcrApi.prototype.deleteAutoFollowPattern = function ccrDeleteAutoFollowPatternAp
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.delete_auto_follow_pattern'
   return this.transport.request(request, options, callback)
 }
 
@@ -86,6 +87,7 @@ CcrApi.prototype.follow = function ccrFollowApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.follow'
   return this.transport.request(request, options, callback)
 }
 
@@ -113,6 +115,7 @@ CcrApi.prototype.followInfo = function ccrFollowInfoApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.follow_info'
   return this.transport.request(request, options, callback)
 }
 
@@ -140,6 +143,7 @@ CcrApi.prototype.followStats = function ccrFollowStatsApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.follow_stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -171,6 +175,7 @@ CcrApi.prototype.forgetFollower = function ccrForgetFollowerApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.forget_follower'
   return this.transport.request(request, options, callback)
 }
 
@@ -197,6 +202,7 @@ CcrApi.prototype.getAutoFollowPattern = function ccrGetAutoFollowPatternApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.get_auto_follow_pattern'
   return this.transport.request(request, options, callback)
 }
 
@@ -224,6 +230,7 @@ CcrApi.prototype.pauseAutoFollowPattern = function ccrPauseAutoFollowPatternApi 
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.pause_auto_follow_pattern'
   return this.transport.request(request, options, callback)
 }
 
@@ -251,6 +258,7 @@ CcrApi.prototype.pauseFollow = function ccrPauseFollowApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.pause_follow'
   return this.transport.request(request, options, callback)
 }
 
@@ -282,6 +290,7 @@ CcrApi.prototype.putAutoFollowPattern = function ccrPutAutoFollowPatternApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.put_auto_follow_pattern'
   return this.transport.request(request, options, callback)
 }
 
@@ -309,6 +318,7 @@ CcrApi.prototype.resumeAutoFollowPattern = function ccrResumeAutoFollowPatternAp
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.resume_auto_follow_pattern'
   return this.transport.request(request, options, callback)
 }
 
@@ -336,6 +346,7 @@ CcrApi.prototype.resumeFollow = function ccrResumeFollowApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.resume_follow'
   return this.transport.request(request, options, callback)
 }
 
@@ -357,6 +368,7 @@ CcrApi.prototype.stats = function ccrStatsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -384,6 +396,7 @@ CcrApi.prototype.unfollow = function ccrUnfollowApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.ccr.unfollow'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/clear_scroll.js
+++ b/api/api/clear_scroll.js
@@ -49,6 +49,7 @@ function clearScrollApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.clear_scroll'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/close_point_in_time.js
+++ b/api/api/close_point_in_time.js
@@ -44,6 +44,7 @@ function closePointInTimeApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.close_point_in_time'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/cluster.js
+++ b/api/api/cluster.js
@@ -49,6 +49,7 @@ ClusterApi.prototype.allocationExplain = function clusterAllocationExplainApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.allocation_explain'
   return this.transport.request(request, options, callback)
 }
 
@@ -76,6 +77,7 @@ ClusterApi.prototype.deleteComponentTemplate = function clusterDeleteComponentTe
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.delete_component_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -97,6 +99,7 @@ ClusterApi.prototype.deleteVotingConfigExclusions = function clusterDeleteVoting
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.delete_voting_config_exclusions'
   return this.transport.request(request, options, callback)
 }
 
@@ -124,6 +127,7 @@ ClusterApi.prototype.existsComponentTemplate = function clusterExistsComponentTe
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.exists_component_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -150,6 +154,7 @@ ClusterApi.prototype.getComponentTemplate = function clusterGetComponentTemplate
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.get_component_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -171,6 +176,7 @@ ClusterApi.prototype.getSettings = function clusterGetSettingsApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.get_settings'
   return this.transport.request(request, options, callback)
 }
 
@@ -197,6 +203,7 @@ ClusterApi.prototype.health = function clusterHealthApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.health'
   return this.transport.request(request, options, callback)
 }
 
@@ -218,6 +225,7 @@ ClusterApi.prototype.pendingTasks = function clusterPendingTasksApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.pending_tasks'
   return this.transport.request(request, options, callback)
 }
 
@@ -239,6 +247,7 @@ ClusterApi.prototype.postVotingConfigExclusions = function clusterPostVotingConf
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.post_voting_config_exclusions'
   return this.transport.request(request, options, callback)
 }
 
@@ -270,6 +279,7 @@ ClusterApi.prototype.putComponentTemplate = function clusterPutComponentTemplate
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.put_component_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -297,6 +307,7 @@ ClusterApi.prototype.putSettings = function clusterPutSettingsApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.put_settings'
   return this.transport.request(request, options, callback)
 }
 
@@ -318,6 +329,7 @@ ClusterApi.prototype.remoteInfo = function clusterRemoteInfoApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.remote_info'
   return this.transport.request(request, options, callback)
 }
 
@@ -339,6 +351,7 @@ ClusterApi.prototype.reroute = function clusterRerouteApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.reroute'
   return this.transport.request(request, options, callback)
 }
 
@@ -374,6 +387,7 @@ ClusterApi.prototype.state = function clusterStateApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.state'
   return this.transport.request(request, options, callback)
 }
 
@@ -400,6 +414,7 @@ ClusterApi.prototype.stats = function clusterStatsApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.cluster.stats'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/count.js
+++ b/api/api/count.js
@@ -49,6 +49,7 @@ function countApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.count'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/create.js
+++ b/api/api/create.js
@@ -63,6 +63,7 @@ function createApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.create'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/dangling_indices.js
+++ b/api/api/dangling_indices.js
@@ -55,6 +55,7 @@ DanglingIndicesApi.prototype.deleteDanglingIndex = function danglingIndicesDelet
     querystring
   }
 
+  options.api = 'elasticsearch.dangling_indices.delete_dangling_index'
   return this.transport.request(request, options, callback)
 }
 
@@ -82,6 +83,7 @@ DanglingIndicesApi.prototype.importDanglingIndex = function danglingIndicesImpor
     querystring
   }
 
+  options.api = 'elasticsearch.dangling_indices.import_dangling_index'
   return this.transport.request(request, options, callback)
 }
 
@@ -103,6 +105,7 @@ DanglingIndicesApi.prototype.listDanglingIndices = function danglingIndicesListD
     querystring
   }
 
+  options.api = 'elasticsearch.dangling_indices.list_dangling_indices'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/delete.js
+++ b/api/api/delete.js
@@ -59,6 +59,7 @@ function deleteApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.delete'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/delete_by_query.js
+++ b/api/api/delete_by_query.js
@@ -54,6 +54,7 @@ function deleteByQueryApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.delete_by_query'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/delete_by_query_rethrottle.js
+++ b/api/api/delete_by_query_rethrottle.js
@@ -54,6 +54,7 @@ function deleteByQueryRethrottleApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.delete_by_query_rethrottle'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/delete_script.js
+++ b/api/api/delete_script.js
@@ -50,6 +50,7 @@ function deleteScriptApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.delete_script'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/enrich.js
+++ b/api/api/enrich.js
@@ -55,6 +55,7 @@ EnrichApi.prototype.deletePolicy = function enrichDeletePolicyApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.enrich.delete_policy'
   return this.transport.request(request, options, callback)
 }
 
@@ -82,6 +83,7 @@ EnrichApi.prototype.executePolicy = function enrichExecutePolicyApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.enrich.execute_policy'
   return this.transport.request(request, options, callback)
 }
 
@@ -108,6 +110,7 @@ EnrichApi.prototype.getPolicy = function enrichGetPolicyApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.enrich.get_policy'
   return this.transport.request(request, options, callback)
 }
 
@@ -139,6 +142,7 @@ EnrichApi.prototype.putPolicy = function enrichPutPolicyApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.enrich.put_policy'
   return this.transport.request(request, options, callback)
 }
 
@@ -160,6 +164,7 @@ EnrichApi.prototype.stats = function enrichStatsApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.enrich.stats'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/eql.js
+++ b/api/api/eql.js
@@ -55,6 +55,7 @@ EqlApi.prototype.delete = function eqlDeleteApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.eql.delete'
   return this.transport.request(request, options, callback)
 }
 
@@ -82,6 +83,7 @@ EqlApi.prototype.get = function eqlGetApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.eql.get'
   return this.transport.request(request, options, callback)
 }
 
@@ -113,6 +115,7 @@ EqlApi.prototype.search = function eqlSearchApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.eql.search'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/exists.js
+++ b/api/api/exists.js
@@ -54,6 +54,7 @@ function existsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.exists'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/exists_source.js
+++ b/api/api/exists_source.js
@@ -68,6 +68,7 @@ function existsSourceApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.exists_source'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/explain.js
+++ b/api/api/explain.js
@@ -54,6 +54,7 @@ function explainApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.explain'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/field_caps.js
+++ b/api/api/field_caps.js
@@ -49,6 +49,7 @@ function fieldCapsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.field_caps'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/get.js
+++ b/api/api/get.js
@@ -54,6 +54,7 @@ function getApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.get'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/get_script.js
+++ b/api/api/get_script.js
@@ -50,6 +50,7 @@ function getScriptApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.get_script'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/get_script_context.js
+++ b/api/api/get_script_context.js
@@ -44,6 +44,7 @@ function getScriptContextApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.get_script_context'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/get_script_languages.js
+++ b/api/api/get_script_languages.js
@@ -44,6 +44,7 @@ function getScriptLanguagesApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.get_script_languages'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/get_source.js
+++ b/api/api/get_source.js
@@ -54,6 +54,7 @@ function getSourceApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.get_source'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/graph.js
+++ b/api/api/graph.js
@@ -55,6 +55,7 @@ GraphApi.prototype.explore = function graphExploreApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.graph.explore'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/ilm.js
+++ b/api/api/ilm.js
@@ -55,6 +55,7 @@ IlmApi.prototype.deleteLifecycle = function ilmDeleteLifecycleApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.ilm.delete_lifecycle'
   return this.transport.request(request, options, callback)
 }
 
@@ -82,6 +83,7 @@ IlmApi.prototype.explainLifecycle = function ilmExplainLifecycleApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.ilm.explain_lifecycle'
   return this.transport.request(request, options, callback)
 }
 
@@ -108,6 +110,7 @@ IlmApi.prototype.getLifecycle = function ilmGetLifecycleApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.ilm.get_lifecycle'
   return this.transport.request(request, options, callback)
 }
 
@@ -129,6 +132,7 @@ IlmApi.prototype.getStatus = function ilmGetStatusApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.ilm.get_status'
   return this.transport.request(request, options, callback)
 }
 
@@ -156,6 +160,7 @@ IlmApi.prototype.moveToStep = function ilmMoveToStepApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.ilm.move_to_step'
   return this.transport.request(request, options, callback)
 }
 
@@ -183,6 +188,7 @@ IlmApi.prototype.putLifecycle = function ilmPutLifecycleApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.ilm.put_lifecycle'
   return this.transport.request(request, options, callback)
 }
 
@@ -210,6 +216,7 @@ IlmApi.prototype.removePolicy = function ilmRemovePolicyApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.ilm.remove_policy'
   return this.transport.request(request, options, callback)
 }
 
@@ -237,6 +244,7 @@ IlmApi.prototype.retry = function ilmRetryApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ilm.retry'
   return this.transport.request(request, options, callback)
 }
 
@@ -258,6 +266,7 @@ IlmApi.prototype.start = function ilmStartApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ilm.start'
   return this.transport.request(request, options, callback)
 }
 
@@ -279,6 +288,7 @@ IlmApi.prototype.stop = function ilmStopApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ilm.stop'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/index.js
+++ b/api/api/index.js
@@ -59,6 +59,7 @@ function indexApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.index'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/indices.js
+++ b/api/api/indices.js
@@ -65,6 +65,7 @@ IndicesApi.prototype.addBlock = function indicesAddBlockApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.indices.add_block'
   return this.transport.request(request, options, callback)
 }
 
@@ -91,6 +92,7 @@ IndicesApi.prototype.analyze = function indicesAnalyzeApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.indices.analyze'
   return this.transport.request(request, options, callback)
 }
 
@@ -117,6 +119,7 @@ IndicesApi.prototype.clearCache = function indicesClearCacheApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.indices.clear_cache'
   return this.transport.request(request, options, callback)
 }
 
@@ -154,6 +157,7 @@ IndicesApi.prototype.clone = function indicesCloneApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.indices.clone'
   return this.transport.request(request, options, callback)
 }
 
@@ -181,6 +185,7 @@ IndicesApi.prototype.close = function indicesCloseApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.indices.close'
   return this.transport.request(request, options, callback)
 }
 
@@ -208,6 +213,7 @@ IndicesApi.prototype.create = function indicesCreateApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.indices.create'
   return this.transport.request(request, options, callback)
 }
 
@@ -235,6 +241,7 @@ IndicesApi.prototype.delete = function indicesDeleteApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.indices.delete'
   return this.transport.request(request, options, callback)
 }
 
@@ -277,6 +284,7 @@ IndicesApi.prototype.deleteAlias = function indicesDeleteAliasApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.indices.delete_alias'
   return this.transport.request(request, options, callback)
 }
 
@@ -304,6 +312,7 @@ IndicesApi.prototype.deleteIndexTemplate = function indicesDeleteIndexTemplateAp
     querystring
   }
 
+  options.api = 'elasticsearch.indices.delete_index_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -331,6 +340,7 @@ IndicesApi.prototype.deleteTemplate = function indicesDeleteTemplateApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.indices.delete_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -358,6 +368,7 @@ IndicesApi.prototype.exists = function indicesExistsApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.indices.exists'
   return this.transport.request(request, options, callback)
 }
 
@@ -390,6 +401,7 @@ IndicesApi.prototype.existsAlias = function indicesExistsAliasApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.indices.exists_alias'
   return this.transport.request(request, options, callback)
 }
 
@@ -417,6 +429,7 @@ IndicesApi.prototype.existsIndexTemplate = function indicesExistsIndexTemplateAp
     querystring
   }
 
+  options.api = 'elasticsearch.indices.exists_index_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -444,6 +457,7 @@ IndicesApi.prototype.existsTemplate = function indicesExistsTemplateApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.indices.exists_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -481,6 +495,7 @@ IndicesApi.prototype.existsType = function indicesExistsTypeApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.indices.exists_type'
   return this.transport.request(request, options, callback)
 }
 
@@ -507,6 +522,7 @@ IndicesApi.prototype.flush = function indicesFlushApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.indices.flush'
   return this.transport.request(request, options, callback)
 }
 
@@ -533,6 +549,7 @@ IndicesApi.prototype.forcemerge = function indicesForcemergeApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.indices.forcemerge'
   return this.transport.request(request, options, callback)
 }
 
@@ -560,6 +577,7 @@ IndicesApi.prototype.get = function indicesGetApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.indices.get'
   return this.transport.request(request, options, callback)
 }
 
@@ -592,6 +610,7 @@ IndicesApi.prototype.getAlias = function indicesGetAliasApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.indices.get_alias'
   return this.transport.request(request, options, callback)
 }
 
@@ -624,6 +643,7 @@ IndicesApi.prototype.getFieldMapping = function indicesGetFieldMappingApi (param
     querystring
   }
 
+  options.api = 'elasticsearch.indices.get_field_mapping'
   return this.transport.request(request, options, callback)
 }
 
@@ -650,6 +670,7 @@ IndicesApi.prototype.getIndexTemplate = function indicesGetIndexTemplateApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.indices.get_index_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -676,6 +697,7 @@ IndicesApi.prototype.getMapping = function indicesGetMappingApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.indices.get_mapping'
   return this.transport.request(request, options, callback)
 }
 
@@ -708,6 +730,7 @@ IndicesApi.prototype.getSettings = function indicesGetSettingsApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.indices.get_settings'
   return this.transport.request(request, options, callback)
 }
 
@@ -734,6 +757,7 @@ IndicesApi.prototype.getTemplate = function indicesGetTemplateApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.indices.get_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -761,6 +785,7 @@ IndicesApi.prototype.open = function indicesOpenApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.indices.open'
   return this.transport.request(request, options, callback)
 }
 
@@ -803,6 +828,7 @@ IndicesApi.prototype.putAlias = function indicesPutAliasApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.indices.put_alias'
   return this.transport.request(request, options, callback)
 }
 
@@ -834,6 +860,7 @@ IndicesApi.prototype.putIndexTemplate = function indicesPutIndexTemplateApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.indices.put_index_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -865,6 +892,7 @@ IndicesApi.prototype.putMapping = function indicesPutMappingApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.indices.put_mapping'
   return this.transport.request(request, options, callback)
 }
 
@@ -897,6 +925,7 @@ IndicesApi.prototype.putSettings = function indicesPutSettingsApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.indices.put_settings'
   return this.transport.request(request, options, callback)
 }
 
@@ -928,6 +957,7 @@ IndicesApi.prototype.putTemplate = function indicesPutTemplateApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.indices.put_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -954,6 +984,7 @@ IndicesApi.prototype.recovery = function indicesRecoveryApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.indices.recovery'
   return this.transport.request(request, options, callback)
 }
 
@@ -980,6 +1011,7 @@ IndicesApi.prototype.refresh = function indicesRefreshApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.indices.refresh'
   return this.transport.request(request, options, callback)
 }
 
@@ -1007,6 +1039,7 @@ IndicesApi.prototype.resolveIndex = function indicesResolveIndexApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.indices.resolve_index'
   return this.transport.request(request, options, callback)
 }
 
@@ -1045,6 +1078,7 @@ IndicesApi.prototype.rollover = function indicesRolloverApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.indices.rollover'
   return this.transport.request(request, options, callback)
 }
 
@@ -1071,6 +1105,7 @@ IndicesApi.prototype.segments = function indicesSegmentsApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.indices.segments'
   return this.transport.request(request, options, callback)
 }
 
@@ -1097,6 +1132,7 @@ IndicesApi.prototype.shardStores = function indicesShardStoresApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.indices.shard_stores'
   return this.transport.request(request, options, callback)
 }
 
@@ -1134,6 +1170,7 @@ IndicesApi.prototype.shrink = function indicesShrinkApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.indices.shrink'
   return this.transport.request(request, options, callback)
 }
 
@@ -1161,6 +1198,7 @@ IndicesApi.prototype.simulateIndexTemplate = function indicesSimulateIndexTempla
     querystring
   }
 
+  options.api = 'elasticsearch.indices.simulate_index_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -1187,6 +1225,7 @@ IndicesApi.prototype.simulateTemplate = function indicesSimulateTemplateApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.indices.simulate_template'
   return this.transport.request(request, options, callback)
 }
 
@@ -1224,6 +1263,7 @@ IndicesApi.prototype.split = function indicesSplitApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.indices.split'
   return this.transport.request(request, options, callback)
 }
 
@@ -1256,6 +1296,7 @@ IndicesApi.prototype.stats = function indicesStatsApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.indices.stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -1283,6 +1324,7 @@ IndicesApi.prototype.updateAliases = function indicesUpdateAliasesApi (params, o
     querystring
   }
 
+  options.api = 'elasticsearch.indices.update_aliases'
   return this.transport.request(request, options, callback)
 }
 
@@ -1318,6 +1360,7 @@ IndicesApi.prototype.validateQuery = function indicesValidateQueryApi (params, o
     querystring
   }
 
+  options.api = 'elasticsearch.indices.validate_query'
   return this.transport.request(request, options, callback)
 }
 
@@ -1345,6 +1388,7 @@ IndicesApi.prototype.createDataStream = function indicesCreateDataStreamApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.indices.create_data_stream'
   return this.transport.request(request, options, callback)
 }
 
@@ -1371,6 +1415,7 @@ IndicesApi.prototype.dataStreamsStats = function indicesDataStreamsStatsApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.indices.data_streams_stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -1398,6 +1443,7 @@ IndicesApi.prototype.deleteDataStream = function indicesDeleteDataStreamApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.indices.delete_data_stream'
   return this.transport.request(request, options, callback)
 }
 
@@ -1425,6 +1471,7 @@ IndicesApi.prototype.freeze = function indicesFreezeApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.indices.freeze'
   return this.transport.request(request, options, callback)
 }
 
@@ -1451,6 +1498,7 @@ IndicesApi.prototype.getDataStream = function indicesGetDataStreamApi (params, o
     querystring
   }
 
+  options.api = 'elasticsearch.indices.get_data_stream'
   return this.transport.request(request, options, callback)
 }
 
@@ -1478,6 +1526,7 @@ IndicesApi.prototype.migrateToDataStream = function indicesMigrateToDataStreamAp
     querystring
   }
 
+  options.api = 'elasticsearch.indices.migrate_to_data_stream'
   return this.transport.request(request, options, callback)
 }
 
@@ -1505,6 +1554,7 @@ IndicesApi.prototype.reloadSearchAnalyzers = function indicesReloadSearchAnalyze
     querystring
   }
 
+  options.api = 'elasticsearch.indices.reload_search_analyzers'
   return this.transport.request(request, options, callback)
 }
 
@@ -1532,6 +1582,7 @@ IndicesApi.prototype.unfreeze = function indicesUnfreezeApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.indices.unfreeze'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/info.js
+++ b/api/api/info.js
@@ -44,6 +44,7 @@ function infoApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.info'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/ingest.js
+++ b/api/api/ingest.js
@@ -55,6 +55,7 @@ IngestApi.prototype.deletePipeline = function ingestDeletePipelineApi (params, o
     querystring
   }
 
+  options.api = 'elasticsearch.ingest.delete_pipeline'
   return this.transport.request(request, options, callback)
 }
 
@@ -81,6 +82,7 @@ IngestApi.prototype.getPipeline = function ingestGetPipelineApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.ingest.get_pipeline'
   return this.transport.request(request, options, callback)
 }
 
@@ -102,6 +104,7 @@ IngestApi.prototype.processorGrok = function ingestProcessorGrokApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.ingest.processor_grok'
   return this.transport.request(request, options, callback)
 }
 
@@ -133,6 +136,7 @@ IngestApi.prototype.putPipeline = function ingestPutPipelineApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.ingest.put_pipeline'
   return this.transport.request(request, options, callback)
 }
 
@@ -165,6 +169,7 @@ IngestApi.prototype.simulate = function ingestSimulateApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.ingest.simulate'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/license.js
+++ b/api/api/license.js
@@ -49,6 +49,7 @@ LicenseApi.prototype.delete = function licenseDeleteApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.license.delete'
   return this.transport.request(request, options, callback)
 }
 
@@ -70,6 +71,7 @@ LicenseApi.prototype.get = function licenseGetApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.license.get'
   return this.transport.request(request, options, callback)
 }
 
@@ -91,6 +93,7 @@ LicenseApi.prototype.getBasicStatus = function licenseGetBasicStatusApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.license.get_basic_status'
   return this.transport.request(request, options, callback)
 }
 
@@ -112,6 +115,7 @@ LicenseApi.prototype.getTrialStatus = function licenseGetTrialStatusApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.license.get_trial_status'
   return this.transport.request(request, options, callback)
 }
 
@@ -133,6 +137,7 @@ LicenseApi.prototype.post = function licensePostApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.license.post'
   return this.transport.request(request, options, callback)
 }
 
@@ -154,6 +159,7 @@ LicenseApi.prototype.postStartBasic = function licensePostStartBasicApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.license.post_start_basic'
   return this.transport.request(request, options, callback)
 }
 
@@ -175,6 +181,7 @@ LicenseApi.prototype.postStartTrial = function licensePostStartTrialApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.license.post_start_trial'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/mget.js
+++ b/api/api/mget.js
@@ -55,6 +55,7 @@ function mgetApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.mget'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/migration.js
+++ b/api/api/migration.js
@@ -54,6 +54,7 @@ MigrationApi.prototype.deprecations = function migrationDeprecationsApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.migration.deprecations'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/ml.js
+++ b/api/api/ml.js
@@ -55,6 +55,7 @@ MlApi.prototype.closeJob = function mlCloseJobApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ml.close_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -82,6 +83,7 @@ MlApi.prototype.deleteCalendar = function mlDeleteCalendarApi (params, options, 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_calendar'
   return this.transport.request(request, options, callback)
 }
 
@@ -119,6 +121,7 @@ MlApi.prototype.deleteCalendarEvent = function mlDeleteCalendarEventApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_calendar_event'
   return this.transport.request(request, options, callback)
 }
 
@@ -156,6 +159,7 @@ MlApi.prototype.deleteCalendarJob = function mlDeleteCalendarJobApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_calendar_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -183,6 +187,7 @@ MlApi.prototype.deleteDataFrameAnalytics = function mlDeleteDataFrameAnalyticsAp
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_data_frame_analytics'
   return this.transport.request(request, options, callback)
 }
 
@@ -210,6 +215,7 @@ MlApi.prototype.deleteDatafeed = function mlDeleteDatafeedApi (params, options, 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_datafeed'
   return this.transport.request(request, options, callback)
 }
 
@@ -236,6 +242,7 @@ MlApi.prototype.deleteExpiredData = function mlDeleteExpiredDataApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_expired_data'
   return this.transport.request(request, options, callback)
 }
 
@@ -263,6 +270,7 @@ MlApi.prototype.deleteFilter = function mlDeleteFilterApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_filter'
   return this.transport.request(request, options, callback)
 }
 
@@ -301,6 +309,7 @@ MlApi.prototype.deleteForecast = function mlDeleteForecastApi (params, options, 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_forecast'
   return this.transport.request(request, options, callback)
 }
 
@@ -328,6 +337,7 @@ MlApi.prototype.deleteJob = function mlDeleteJobApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -365,6 +375,7 @@ MlApi.prototype.deleteModelSnapshot = function mlDeleteModelSnapshotApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_model_snapshot'
   return this.transport.request(request, options, callback)
 }
 
@@ -392,6 +403,7 @@ MlApi.prototype.deleteTrainedModel = function mlDeleteTrainedModelApi (params, o
     querystring
   }
 
+  options.api = 'elasticsearch.ml.delete_trained_model'
   return this.transport.request(request, options, callback)
 }
 
@@ -419,6 +431,7 @@ MlApi.prototype.estimateModelMemory = function mlEstimateModelMemoryApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.ml.estimate_model_memory'
   return this.transport.request(request, options, callback)
 }
 
@@ -446,6 +459,7 @@ MlApi.prototype.evaluateDataFrame = function mlEvaluateDataFrameApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.ml.evaluate_data_frame'
   return this.transport.request(request, options, callback)
 }
 
@@ -472,6 +486,7 @@ MlApi.prototype.explainDataFrameAnalytics = function mlExplainDataFrameAnalytics
     querystring
   }
 
+  options.api = 'elasticsearch.ml.explain_data_frame_analytics'
   return this.transport.request(request, options, callback)
 }
 
@@ -499,6 +514,7 @@ MlApi.prototype.findFileStructure = function mlFindFileStructureApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.ml.find_file_structure'
   return this.transport.request(request, options, callback)
 }
 
@@ -526,6 +542,7 @@ MlApi.prototype.flushJob = function mlFlushJobApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ml.flush_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -553,6 +570,7 @@ MlApi.prototype.forecast = function mlForecastApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ml.forecast'
   return this.transport.request(request, options, callback)
 }
 
@@ -591,6 +609,7 @@ MlApi.prototype.getBuckets = function mlGetBucketsApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_buckets'
   return this.transport.request(request, options, callback)
 }
 
@@ -618,6 +637,7 @@ MlApi.prototype.getCalendarEvents = function mlGetCalendarEventsApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_calendar_events'
   return this.transport.request(request, options, callback)
 }
 
@@ -644,6 +664,7 @@ MlApi.prototype.getCalendars = function mlGetCalendarsApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_calendars'
   return this.transport.request(request, options, callback)
 }
 
@@ -682,6 +703,7 @@ MlApi.prototype.getCategories = function mlGetCategoriesApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_categories'
   return this.transport.request(request, options, callback)
 }
 
@@ -708,6 +730,7 @@ MlApi.prototype.getDataFrameAnalytics = function mlGetDataFrameAnalyticsApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_data_frame_analytics'
   return this.transport.request(request, options, callback)
 }
 
@@ -734,6 +757,7 @@ MlApi.prototype.getDataFrameAnalyticsStats = function mlGetDataFrameAnalyticsSta
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_data_frame_analytics_stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -760,6 +784,7 @@ MlApi.prototype.getDatafeedStats = function mlGetDatafeedStatsApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_datafeed_stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -786,6 +811,7 @@ MlApi.prototype.getDatafeeds = function mlGetDatafeedsApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_datafeeds'
   return this.transport.request(request, options, callback)
 }
 
@@ -812,6 +838,7 @@ MlApi.prototype.getFilters = function mlGetFiltersApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_filters'
   return this.transport.request(request, options, callback)
 }
 
@@ -839,6 +866,7 @@ MlApi.prototype.getInfluencers = function mlGetInfluencersApi (params, options, 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_influencers'
   return this.transport.request(request, options, callback)
 }
 
@@ -865,6 +893,7 @@ MlApi.prototype.getJobStats = function mlGetJobStatsApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_job_stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -891,6 +920,7 @@ MlApi.prototype.getJobs = function mlGetJobsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_jobs'
   return this.transport.request(request, options, callback)
 }
 
@@ -929,6 +959,7 @@ MlApi.prototype.getModelSnapshots = function mlGetModelSnapshotsApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_model_snapshots'
   return this.transport.request(request, options, callback)
 }
 
@@ -956,6 +987,7 @@ MlApi.prototype.getOverallBuckets = function mlGetOverallBucketsApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_overall_buckets'
   return this.transport.request(request, options, callback)
 }
 
@@ -983,6 +1015,7 @@ MlApi.prototype.getRecords = function mlGetRecordsApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_records'
   return this.transport.request(request, options, callback)
 }
 
@@ -1009,6 +1042,7 @@ MlApi.prototype.getTrainedModels = function mlGetTrainedModelsApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_trained_models'
   return this.transport.request(request, options, callback)
 }
 
@@ -1035,6 +1069,7 @@ MlApi.prototype.getTrainedModelsStats = function mlGetTrainedModelsStatsApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.ml.get_trained_models_stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -1056,6 +1091,7 @@ MlApi.prototype.info = function mlInfoApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ml.info'
   return this.transport.request(request, options, callback)
 }
 
@@ -1083,6 +1119,7 @@ MlApi.prototype.openJob = function mlOpenJobApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ml.open_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -1114,6 +1151,7 @@ MlApi.prototype.postCalendarEvents = function mlPostCalendarEventsApi (params, o
     querystring
   }
 
+  options.api = 'elasticsearch.ml.post_calendar_events'
   return this.transport.request(request, options, callback)
 }
 
@@ -1145,6 +1183,7 @@ MlApi.prototype.postData = function mlPostDataApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ml.post_data'
   return this.transport.request(request, options, callback)
 }
 
@@ -1172,6 +1211,7 @@ MlApi.prototype.previewDatafeed = function mlPreviewDatafeedApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.ml.preview_datafeed'
   return this.transport.request(request, options, callback)
 }
 
@@ -1199,6 +1239,7 @@ MlApi.prototype.putCalendar = function mlPutCalendarApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.ml.put_calendar'
   return this.transport.request(request, options, callback)
 }
 
@@ -1236,6 +1277,7 @@ MlApi.prototype.putCalendarJob = function mlPutCalendarJobApi (params, options, 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.put_calendar_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -1267,6 +1309,7 @@ MlApi.prototype.putDataFrameAnalytics = function mlPutDataFrameAnalyticsApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.ml.put_data_frame_analytics'
   return this.transport.request(request, options, callback)
 }
 
@@ -1298,6 +1341,7 @@ MlApi.prototype.putDatafeed = function mlPutDatafeedApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.ml.put_datafeed'
   return this.transport.request(request, options, callback)
 }
 
@@ -1329,6 +1373,7 @@ MlApi.prototype.putFilter = function mlPutFilterApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.put_filter'
   return this.transport.request(request, options, callback)
 }
 
@@ -1360,6 +1405,7 @@ MlApi.prototype.putJob = function mlPutJobApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ml.put_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -1391,6 +1437,7 @@ MlApi.prototype.putTrainedModel = function mlPutTrainedModelApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.ml.put_trained_model'
   return this.transport.request(request, options, callback)
 }
 
@@ -1428,6 +1475,7 @@ MlApi.prototype.revertModelSnapshot = function mlRevertModelSnapshotApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.ml.revert_model_snapshot'
   return this.transport.request(request, options, callback)
 }
 
@@ -1449,6 +1497,7 @@ MlApi.prototype.setUpgradeMode = function mlSetUpgradeModeApi (params, options, 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.set_upgrade_mode'
   return this.transport.request(request, options, callback)
 }
 
@@ -1476,6 +1525,7 @@ MlApi.prototype.startDataFrameAnalytics = function mlStartDataFrameAnalyticsApi 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.start_data_frame_analytics'
   return this.transport.request(request, options, callback)
 }
 
@@ -1503,6 +1553,7 @@ MlApi.prototype.startDatafeed = function mlStartDatafeedApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.ml.start_datafeed'
   return this.transport.request(request, options, callback)
 }
 
@@ -1530,6 +1581,7 @@ MlApi.prototype.stopDataFrameAnalytics = function mlStopDataFrameAnalyticsApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.ml.stop_data_frame_analytics'
   return this.transport.request(request, options, callback)
 }
 
@@ -1557,6 +1609,7 @@ MlApi.prototype.stopDatafeed = function mlStopDatafeedApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.ml.stop_datafeed'
   return this.transport.request(request, options, callback)
 }
 
@@ -1588,6 +1641,7 @@ MlApi.prototype.updateDataFrameAnalytics = function mlUpdateDataFrameAnalyticsAp
     querystring
   }
 
+  options.api = 'elasticsearch.ml.update_data_frame_analytics'
   return this.transport.request(request, options, callback)
 }
 
@@ -1619,6 +1673,7 @@ MlApi.prototype.updateDatafeed = function mlUpdateDatafeedApi (params, options, 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.update_datafeed'
   return this.transport.request(request, options, callback)
 }
 
@@ -1650,6 +1705,7 @@ MlApi.prototype.updateFilter = function mlUpdateFilterApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.ml.update_filter'
   return this.transport.request(request, options, callback)
 }
 
@@ -1681,6 +1737,7 @@ MlApi.prototype.updateJob = function mlUpdateJobApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.ml.update_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -1722,6 +1779,7 @@ MlApi.prototype.updateModelSnapshot = function mlUpdateModelSnapshotApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.ml.update_model_snapshot'
   return this.transport.request(request, options, callback)
 }
 
@@ -1759,6 +1817,7 @@ MlApi.prototype.upgradeJobSnapshot = function mlUpgradeJobSnapshotApi (params, o
     querystring
   }
 
+  options.api = 'elasticsearch.ml.upgrade_job_snapshot'
   return this.transport.request(request, options, callback)
 }
 
@@ -1786,6 +1845,7 @@ MlApi.prototype.validate = function mlValidateApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ml.validate'
   return this.transport.request(request, options, callback)
 }
 
@@ -1813,6 +1873,7 @@ MlApi.prototype.validateDetector = function mlValidateDetectorApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.ml.validate_detector'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/monitoring.js
+++ b/api/api/monitoring.js
@@ -60,6 +60,7 @@ MonitoringApi.prototype.bulk = function monitoringBulkApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.monitoring.bulk'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/msearch.js
+++ b/api/api/msearch.js
@@ -55,6 +55,7 @@ function msearchApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.msearch'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/msearch_template.js
+++ b/api/api/msearch_template.js
@@ -55,6 +55,7 @@ function msearchTemplateApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.msearch_template'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/mtermvectors.js
+++ b/api/api/mtermvectors.js
@@ -49,6 +49,7 @@ function mtermvectorsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.mtermvectors'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/nodes.js
+++ b/api/api/nodes.js
@@ -54,6 +54,7 @@ NodesApi.prototype.hotThreads = function nodesHotThreadsApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.nodes.hot_threads'
   return this.transport.request(request, options, callback)
 }
 
@@ -86,6 +87,7 @@ NodesApi.prototype.info = function nodesInfoApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.nodes.info'
   return this.transport.request(request, options, callback)
 }
 
@@ -112,6 +114,7 @@ NodesApi.prototype.reloadSecureSettings = function nodesReloadSecureSettingsApi 
     querystring
   }
 
+  options.api = 'elasticsearch.nodes.reload_secure_settings'
   return this.transport.request(request, options, callback)
 }
 
@@ -150,6 +153,7 @@ NodesApi.prototype.stats = function nodesStatsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.nodes.stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -182,6 +186,7 @@ NodesApi.prototype.usage = function nodesUsageApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.nodes.usage'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/open_point_in_time.js
+++ b/api/api/open_point_in_time.js
@@ -49,6 +49,7 @@ function openPointInTimeApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.open_point_in_time'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/ping.js
+++ b/api/api/ping.js
@@ -44,6 +44,7 @@ function pingApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.ping'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/put_script.js
+++ b/api/api/put_script.js
@@ -65,6 +65,7 @@ function putScriptApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.put_script'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/rank_eval.js
+++ b/api/api/rank_eval.js
@@ -55,6 +55,7 @@ function rankEvalApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.rank_eval'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/reindex.js
+++ b/api/api/reindex.js
@@ -50,6 +50,7 @@ function reindexApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.reindex'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/reindex_rethrottle.js
+++ b/api/api/reindex_rethrottle.js
@@ -54,6 +54,7 @@ function reindexRethrottleApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.reindex_rethrottle'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/render_search_template.js
+++ b/api/api/render_search_template.js
@@ -49,6 +49,7 @@ function renderSearchTemplateApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.render_search_template'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/rollup.js
+++ b/api/api/rollup.js
@@ -55,6 +55,7 @@ RollupApi.prototype.deleteJob = function rollupDeleteJobApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.rollup.delete_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -81,6 +82,7 @@ RollupApi.prototype.getJobs = function rollupGetJobsApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.rollup.get_jobs'
   return this.transport.request(request, options, callback)
 }
 
@@ -107,6 +109,7 @@ RollupApi.prototype.getRollupCaps = function rollupGetRollupCapsApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.rollup.get_rollup_caps'
   return this.transport.request(request, options, callback)
 }
 
@@ -134,6 +137,7 @@ RollupApi.prototype.getRollupIndexCaps = function rollupGetRollupIndexCapsApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.rollup.get_rollup_index_caps'
   return this.transport.request(request, options, callback)
 }
 
@@ -165,6 +169,7 @@ RollupApi.prototype.putJob = function rollupPutJobApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.rollup.put_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -196,6 +201,7 @@ RollupApi.prototype.rollup = function rollupRollupApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.rollup.rollup'
   return this.transport.request(request, options, callback)
 }
 
@@ -238,6 +244,7 @@ RollupApi.prototype.rollupSearch = function rollupRollupSearchApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.rollup.rollup_search'
   return this.transport.request(request, options, callback)
 }
 
@@ -265,6 +272,7 @@ RollupApi.prototype.startJob = function rollupStartJobApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.rollup.start_job'
   return this.transport.request(request, options, callback)
 }
 
@@ -292,6 +300,7 @@ RollupApi.prototype.stopJob = function rollupStopJobApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.rollup.stop_job'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/scripts_painless_execute.js
+++ b/api/api/scripts_painless_execute.js
@@ -44,6 +44,7 @@ function scriptsPainlessExecuteApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.scripts_painless_execute'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/scroll.js
+++ b/api/api/scroll.js
@@ -49,6 +49,7 @@ function scrollApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.scroll'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/search.js
+++ b/api/api/search.js
@@ -49,6 +49,7 @@ function searchApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.search'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/search_shards.js
+++ b/api/api/search_shards.js
@@ -49,6 +49,7 @@ function searchShardsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.search_shards'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/search_template.js
+++ b/api/api/search_template.js
@@ -55,6 +55,7 @@ function searchTemplateApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.search_template'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/searchable_snapshots.js
+++ b/api/api/searchable_snapshots.js
@@ -54,6 +54,7 @@ SearchableSnapshotsApi.prototype.clearCache = function searchableSnapshotsClearC
     querystring
   }
 
+  options.api = 'elasticsearch.searchable_snapshots.clear_cache'
   return this.transport.request(request, options, callback)
 }
 
@@ -95,6 +96,7 @@ SearchableSnapshotsApi.prototype.mount = function searchableSnapshotsMountApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.searchable_snapshots.mount'
   return this.transport.request(request, options, callback)
 }
 
@@ -121,6 +123,7 @@ SearchableSnapshotsApi.prototype.stats = function searchableSnapshotsStatsApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.searchable_snapshots.stats'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/security.js
+++ b/api/api/security.js
@@ -49,6 +49,7 @@ SecurityApi.prototype.authenticate = function securityAuthenticateApi (params, o
     querystring
   }
 
+  options.api = 'elasticsearch.security.authenticate'
   return this.transport.request(request, options, callback)
 }
 
@@ -81,6 +82,7 @@ SecurityApi.prototype.changePassword = function securityChangePasswordApi (param
     querystring
   }
 
+  options.api = 'elasticsearch.security.change_password'
   return this.transport.request(request, options, callback)
 }
 
@@ -108,6 +110,7 @@ SecurityApi.prototype.clearApiKeyCache = function securityClearApiKeyCacheApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.security.clear_api_key_cache'
   return this.transport.request(request, options, callback)
 }
 
@@ -135,6 +138,7 @@ SecurityApi.prototype.clearCachedPrivileges = function securityClearCachedPrivil
     querystring
   }
 
+  options.api = 'elasticsearch.security.clear_cached_privileges'
   return this.transport.request(request, options, callback)
 }
 
@@ -162,6 +166,7 @@ SecurityApi.prototype.clearCachedRealms = function securityClearCachedRealmsApi 
     querystring
   }
 
+  options.api = 'elasticsearch.security.clear_cached_realms'
   return this.transport.request(request, options, callback)
 }
 
@@ -189,6 +194,7 @@ SecurityApi.prototype.clearCachedRoles = function securityClearCachedRolesApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.security.clear_cached_roles'
   return this.transport.request(request, options, callback)
 }
 
@@ -216,6 +222,7 @@ SecurityApi.prototype.createApiKey = function securityCreateApiKeyApi (params, o
     querystring
   }
 
+  options.api = 'elasticsearch.security.create_api_key'
   return this.transport.request(request, options, callback)
 }
 
@@ -253,6 +260,7 @@ SecurityApi.prototype.deletePrivileges = function securityDeletePrivilegesApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.security.delete_privileges'
   return this.transport.request(request, options, callback)
 }
 
@@ -280,6 +288,7 @@ SecurityApi.prototype.deleteRole = function securityDeleteRoleApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.security.delete_role'
   return this.transport.request(request, options, callback)
 }
 
@@ -307,6 +316,7 @@ SecurityApi.prototype.deleteRoleMapping = function securityDeleteRoleMappingApi 
     querystring
   }
 
+  options.api = 'elasticsearch.security.delete_role_mapping'
   return this.transport.request(request, options, callback)
 }
 
@@ -334,6 +344,7 @@ SecurityApi.prototype.deleteUser = function securityDeleteUserApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.security.delete_user'
   return this.transport.request(request, options, callback)
 }
 
@@ -361,6 +372,7 @@ SecurityApi.prototype.disableUser = function securityDisableUserApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.security.disable_user'
   return this.transport.request(request, options, callback)
 }
 
@@ -388,6 +400,7 @@ SecurityApi.prototype.enableUser = function securityEnableUserApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.security.enable_user'
   return this.transport.request(request, options, callback)
 }
 
@@ -409,6 +422,7 @@ SecurityApi.prototype.getApiKey = function securityGetApiKeyApi (params, options
     querystring
   }
 
+  options.api = 'elasticsearch.security.get_api_key'
   return this.transport.request(request, options, callback)
 }
 
@@ -430,6 +444,7 @@ SecurityApi.prototype.getBuiltinPrivileges = function securityGetBuiltinPrivileg
     querystring
   }
 
+  options.api = 'elasticsearch.security.get_builtin_privileges'
   return this.transport.request(request, options, callback)
 }
 
@@ -465,6 +480,7 @@ SecurityApi.prototype.getPrivileges = function securityGetPrivilegesApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.security.get_privileges'
   return this.transport.request(request, options, callback)
 }
 
@@ -491,6 +507,7 @@ SecurityApi.prototype.getRole = function securityGetRoleApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.security.get_role'
   return this.transport.request(request, options, callback)
 }
 
@@ -517,6 +534,7 @@ SecurityApi.prototype.getRoleMapping = function securityGetRoleMappingApi (param
     querystring
   }
 
+  options.api = 'elasticsearch.security.get_role_mapping'
   return this.transport.request(request, options, callback)
 }
 
@@ -544,6 +562,7 @@ SecurityApi.prototype.getToken = function securityGetTokenApi (params, options, 
     querystring
   }
 
+  options.api = 'elasticsearch.security.get_token'
   return this.transport.request(request, options, callback)
 }
 
@@ -570,6 +589,7 @@ SecurityApi.prototype.getUser = function securityGetUserApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.security.get_user'
   return this.transport.request(request, options, callback)
 }
 
@@ -591,6 +611,7 @@ SecurityApi.prototype.getUserPrivileges = function securityGetUserPrivilegesApi 
     querystring
   }
 
+  options.api = 'elasticsearch.security.get_user_privileges'
   return this.transport.request(request, options, callback)
 }
 
@@ -618,6 +639,7 @@ SecurityApi.prototype.grantApiKey = function securityGrantApiKeyApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.security.grant_api_key'
   return this.transport.request(request, options, callback)
 }
 
@@ -650,6 +672,7 @@ SecurityApi.prototype.hasPrivileges = function securityHasPrivilegesApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.security.has_privileges'
   return this.transport.request(request, options, callback)
 }
 
@@ -677,6 +700,7 @@ SecurityApi.prototype.invalidateApiKey = function securityInvalidateApiKeyApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.security.invalidate_api_key'
   return this.transport.request(request, options, callback)
 }
 
@@ -704,6 +728,7 @@ SecurityApi.prototype.invalidateToken = function securityInvalidateTokenApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.security.invalidate_token'
   return this.transport.request(request, options, callback)
 }
 
@@ -731,6 +756,7 @@ SecurityApi.prototype.putPrivileges = function securityPutPrivilegesApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.security.put_privileges'
   return this.transport.request(request, options, callback)
 }
 
@@ -762,6 +788,7 @@ SecurityApi.prototype.putRole = function securityPutRoleApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.security.put_role'
   return this.transport.request(request, options, callback)
 }
 
@@ -793,6 +820,7 @@ SecurityApi.prototype.putRoleMapping = function securityPutRoleMappingApi (param
     querystring
   }
 
+  options.api = 'elasticsearch.security.put_role_mapping'
   return this.transport.request(request, options, callback)
 }
 
@@ -824,6 +852,7 @@ SecurityApi.prototype.putUser = function securityPutUserApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.security.put_user'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/slm.js
+++ b/api/api/slm.js
@@ -55,6 +55,7 @@ SlmApi.prototype.deleteLifecycle = function slmDeleteLifecycleApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.slm.delete_lifecycle'
   return this.transport.request(request, options, callback)
 }
 
@@ -82,6 +83,7 @@ SlmApi.prototype.executeLifecycle = function slmExecuteLifecycleApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.slm.execute_lifecycle'
   return this.transport.request(request, options, callback)
 }
 
@@ -103,6 +105,7 @@ SlmApi.prototype.executeRetention = function slmExecuteRetentionApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.slm.execute_retention'
   return this.transport.request(request, options, callback)
 }
 
@@ -129,6 +132,7 @@ SlmApi.prototype.getLifecycle = function slmGetLifecycleApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.slm.get_lifecycle'
   return this.transport.request(request, options, callback)
 }
 
@@ -150,6 +154,7 @@ SlmApi.prototype.getStats = function slmGetStatsApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.slm.get_stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -171,6 +176,7 @@ SlmApi.prototype.getStatus = function slmGetStatusApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.slm.get_status'
   return this.transport.request(request, options, callback)
 }
 
@@ -198,6 +204,7 @@ SlmApi.prototype.putLifecycle = function slmPutLifecycleApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.slm.put_lifecycle'
   return this.transport.request(request, options, callback)
 }
 
@@ -219,6 +226,7 @@ SlmApi.prototype.start = function slmStartApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.slm.start'
   return this.transport.request(request, options, callback)
 }
 
@@ -240,6 +248,7 @@ SlmApi.prototype.stop = function slmStopApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.slm.stop'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/snapshot.js
+++ b/api/api/snapshot.js
@@ -55,6 +55,7 @@ SnapshotApi.prototype.cleanupRepository = function snapshotCleanupRepositoryApi 
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.cleanup_repository'
   return this.transport.request(request, options, callback)
 }
 
@@ -103,6 +104,7 @@ SnapshotApi.prototype.clone = function snapshotCloneApi (params, options, callba
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.clone'
   return this.transport.request(request, options, callback)
 }
 
@@ -140,6 +142,7 @@ SnapshotApi.prototype.create = function snapshotCreateApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.create'
   return this.transport.request(request, options, callback)
 }
 
@@ -171,6 +174,7 @@ SnapshotApi.prototype.createRepository = function snapshotCreateRepositoryApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.create_repository'
   return this.transport.request(request, options, callback)
 }
 
@@ -208,6 +212,7 @@ SnapshotApi.prototype.delete = function snapshotDeleteApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.delete'
   return this.transport.request(request, options, callback)
 }
 
@@ -235,6 +240,7 @@ SnapshotApi.prototype.deleteRepository = function snapshotDeleteRepositoryApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.delete_repository'
   return this.transport.request(request, options, callback)
 }
 
@@ -272,6 +278,7 @@ SnapshotApi.prototype.get = function snapshotGetApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.get'
   return this.transport.request(request, options, callback)
 }
 
@@ -298,6 +305,7 @@ SnapshotApi.prototype.getRepository = function snapshotGetRepositoryApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.get_repository'
   return this.transport.request(request, options, callback)
 }
 
@@ -335,6 +343,7 @@ SnapshotApi.prototype.restore = function snapshotRestoreApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.restore'
   return this.transport.request(request, options, callback)
 }
 
@@ -370,6 +379,7 @@ SnapshotApi.prototype.status = function snapshotStatusApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.status'
   return this.transport.request(request, options, callback)
 }
 
@@ -397,6 +407,7 @@ SnapshotApi.prototype.verifyRepository = function snapshotVerifyRepositoryApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.snapshot.verify_repository'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/sql.js
+++ b/api/api/sql.js
@@ -55,6 +55,7 @@ SqlApi.prototype.clearCursor = function sqlClearCursorApi (params, options, call
     querystring
   }
 
+  options.api = 'elasticsearch.sql.clear_cursor'
   return this.transport.request(request, options, callback)
 }
 
@@ -82,6 +83,7 @@ SqlApi.prototype.query = function sqlQueryApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.sql.query'
   return this.transport.request(request, options, callback)
 }
 
@@ -109,6 +111,7 @@ SqlApi.prototype.translate = function sqlTranslateApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.sql.translate'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/ssl.js
+++ b/api/api/ssl.js
@@ -49,6 +49,7 @@ SslApi.prototype.certificates = function sslCertificatesApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.ssl.certificates'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/tasks.js
+++ b/api/api/tasks.js
@@ -54,6 +54,7 @@ TasksApi.prototype.cancel = function tasksCancelApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.tasks.cancel'
   return this.transport.request(request, options, callback)
 }
 
@@ -81,6 +82,7 @@ TasksApi.prototype.get = function tasksGetApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.tasks.get'
   return this.transport.request(request, options, callback)
 }
 
@@ -102,6 +104,7 @@ TasksApi.prototype.list = function tasksListApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.tasks.list'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/termvectors.js
+++ b/api/api/termvectors.js
@@ -55,6 +55,7 @@ function termvectorsApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.termvectors'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/transform.js
+++ b/api/api/transform.js
@@ -55,6 +55,7 @@ TransformApi.prototype.deleteTransform = function transformDeleteTransformApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.transform.delete_transform'
   return this.transport.request(request, options, callback)
 }
 
@@ -81,6 +82,7 @@ TransformApi.prototype.getTransform = function transformGetTransformApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.transform.get_transform'
   return this.transport.request(request, options, callback)
 }
 
@@ -108,6 +110,7 @@ TransformApi.prototype.getTransformStats = function transformGetTransformStatsAp
     querystring
   }
 
+  options.api = 'elasticsearch.transform.get_transform_stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -135,6 +138,7 @@ TransformApi.prototype.previewTransform = function transformPreviewTransformApi 
     querystring
   }
 
+  options.api = 'elasticsearch.transform.preview_transform'
   return this.transport.request(request, options, callback)
 }
 
@@ -166,6 +170,7 @@ TransformApi.prototype.putTransform = function transformPutTransformApi (params,
     querystring
   }
 
+  options.api = 'elasticsearch.transform.put_transform'
   return this.transport.request(request, options, callback)
 }
 
@@ -193,6 +198,7 @@ TransformApi.prototype.startTransform = function transformStartTransformApi (par
     querystring
   }
 
+  options.api = 'elasticsearch.transform.start_transform'
   return this.transport.request(request, options, callback)
 }
 
@@ -220,6 +226,7 @@ TransformApi.prototype.stopTransform = function transformStopTransformApi (param
     querystring
   }
 
+  options.api = 'elasticsearch.transform.stop_transform'
   return this.transport.request(request, options, callback)
 }
 
@@ -251,6 +258,7 @@ TransformApi.prototype.updateTransform = function transformUpdateTransformApi (p
     querystring
   }
 
+  options.api = 'elasticsearch.transform.update_transform'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/update.js
+++ b/api/api/update.js
@@ -63,6 +63,7 @@ function updateApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.update'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/update_by_query.js
+++ b/api/api/update_by_query.js
@@ -50,6 +50,7 @@ function updateByQueryApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.update_by_query'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/update_by_query_rethrottle.js
+++ b/api/api/update_by_query_rethrottle.js
@@ -54,6 +54,7 @@ function updateByQueryRethrottleApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.update_by_query_rethrottle'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/watcher.js
+++ b/api/api/watcher.js
@@ -66,6 +66,7 @@ WatcherApi.prototype.ackWatch = function watcherAckWatchApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.watcher.ack_watch'
   return this.transport.request(request, options, callback)
 }
 
@@ -93,6 +94,7 @@ WatcherApi.prototype.activateWatch = function watcherActivateWatchApi (params, o
     querystring
   }
 
+  options.api = 'elasticsearch.watcher.activate_watch'
   return this.transport.request(request, options, callback)
 }
 
@@ -120,6 +122,7 @@ WatcherApi.prototype.deactivateWatch = function watcherDeactivateWatchApi (param
     querystring
   }
 
+  options.api = 'elasticsearch.watcher.deactivate_watch'
   return this.transport.request(request, options, callback)
 }
 
@@ -147,6 +150,7 @@ WatcherApi.prototype.deleteWatch = function watcherDeleteWatchApi (params, optio
     querystring
   }
 
+  options.api = 'elasticsearch.watcher.delete_watch'
   return this.transport.request(request, options, callback)
 }
 
@@ -173,6 +177,7 @@ WatcherApi.prototype.executeWatch = function watcherExecuteWatchApi (params, opt
     querystring
   }
 
+  options.api = 'elasticsearch.watcher.execute_watch'
   return this.transport.request(request, options, callback)
 }
 
@@ -200,6 +205,7 @@ WatcherApi.prototype.getWatch = function watcherGetWatchApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.watcher.get_watch'
   return this.transport.request(request, options, callback)
 }
 
@@ -227,6 +233,7 @@ WatcherApi.prototype.putWatch = function watcherPutWatchApi (params, options, ca
     querystring
   }
 
+  options.api = 'elasticsearch.watcher.put_watch'
   return this.transport.request(request, options, callback)
 }
 
@@ -248,6 +255,7 @@ WatcherApi.prototype.start = function watcherStartApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.watcher.start'
   return this.transport.request(request, options, callback)
 }
 
@@ -274,6 +282,7 @@ WatcherApi.prototype.stats = function watcherStatsApi (params, options, callback
     querystring
   }
 
+  options.api = 'elasticsearch.watcher.stats'
   return this.transport.request(request, options, callback)
 }
 
@@ -295,6 +304,7 @@ WatcherApi.prototype.stop = function watcherStopApi (params, options, callback) 
     querystring
   }
 
+  options.api = 'elasticsearch.watcher.stop'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/api/xpack.js
+++ b/api/api/xpack.js
@@ -49,6 +49,7 @@ XpackApi.prototype.info = function xpackInfoApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.xpack.info'
   return this.transport.request(request, options, callback)
 }
 
@@ -70,6 +71,7 @@ XpackApi.prototype.usage = function xpackUsageApi (params, options, callback) {
     querystring
   }
 
+  options.api = 'elasticsearch.xpack.usage'
   return this.transport.request(request, options, callback)
 }
 

--- a/api/utils.js
+++ b/api/utils.js
@@ -50,7 +50,7 @@ function normalizeArguments (params, options, callback) {
     params = {}
     options = {}
   }
-  return [params, options, callback]
+  return [params, options || {}, callback]
 }
 
 function noop () {}

--- a/docs/observability.asciidoc
+++ b/docs/observability.asciidoc
@@ -381,3 +381,27 @@ client.search({
 })
 ----
 
+[discrete]
+=== API name
+
+You can detect which API has been invoked via the `request.options.api` value.
+This value is configured by default by the client unless you are direclty using
+the `transport.request` method.
+
+[source,js]
+----
+const { Client } = require('@elastic/elasticsearch')
+const client = new Client({
+  node: 'http://localhost:9200'
+})
+
+client.on('response', (err, { meta }) => {
+  if (err) {
+    logger.error(err)
+  } else {
+    logger.info(`Api called: ${meta.request.options.api}`) // 'elasticsearch.info'
+  }
+})
+
+client.info(console.log)
+----

--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -112,6 +112,7 @@ export interface TransportRequestOptions {
   context?: Context;
   warnings?: string[];
   opaqueId?: string;
+  api?: string;
 }
 
 export interface TransportRequestCallback {

--- a/scripts/utils/generateApis.js
+++ b/scripts/utils/generateApis.js
@@ -264,6 +264,7 @@ function generateSingleApi (version, spec, common) {
       querystring
     }
 
+    options.api = 'elasticsearch.${api}'
     return this.transport.request(request, options, callback)
   }
   `.trim() // always call trim to avoid newlines

--- a/test/acceptance/observability.test.js
+++ b/test/acceptance/observability.test.js
@@ -401,3 +401,25 @@ test('Client name', t => {
 
   t.end()
 })
+
+test('api name', t => {
+  t.plan(5)
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  client.on('request', (err, { meta }) => {
+    t.error(err)
+    t.strictEqual(meta.request.options.api, 'elasticsearch.info')
+  })
+
+  client.on('response', (err, { meta }) => {
+    t.error(err)
+    t.strictEqual(meta.request.options.api, 'elasticsearch.info')
+  })
+
+  client.info((err, result) => {
+    t.error(err)
+  })
+})


### PR DESCRIPTION
This is very useful if you need to filter logging and you don't want to use regular expressions.

Usage: 
```js
const { Client } = require('@elastic/elasticsearch')
const client = new Client({
  node: 'http://localhost:9200'
})

client.on('response', (err, { meta }) => {
  if (err) {
    logger.error(err)
  } else {
    logger.info(`Api called: ${meta.request.options.api}`) // 'elasticsearch.info'
  }
})

client.info(console.log)
```