### PR TITLE
Added x-elastic-client-meta header

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -218,9 +218,14 @@ _Default:_ `null`
 _Default:_ `{}`
 
 |`context`
-|`object` - A custom object that you can use for observability in yoru events.
+|`object` - A custom object that you can use for observability in your events.
 It will be merged with the API level context option. +
 _Default:_ `null`
+
+|`enableMetaHeader`
+|`boolean` - If true, adds an header named `'x-elastic-client-meta'`, containing some minimal telemetry data,
+such as the client and platform version. +
+_Default:_ `true`
 
 |`cloud`
 a|`object` - Custom configuration for connecting to 

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,7 +108,7 @@ interface ClientOptions {
   auth?: BasicAuth | ApiKeyAuth;
   context?: Context;
   proxy?: string | URL;
-  enableMetaHeader: boolean;
+  enableMetaHeader?: boolean;
   cloud?: {
     id: string;
     // TODO: remove username and password here in 8

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,6 +108,7 @@ interface ClientOptions {
   auth?: BasicAuth | ApiKeyAuth;
   context?: Context;
   proxy?: string | URL;
+  enableMetaHeader: boolean;
   cloud?: {
     id: string;
     // TODO: remove username and password here in 8

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ class Client extends ESAPI {
     this.name = options.name
 
     if (options.enableMetaHeader) {
-      options.headers['x-elastic-client-meta'] = `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},t=${clientVersion}`
+      options.headers['x-elastic-client-meta'] = `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion}`
     }
 
     if (opts[kChild] !== undefined) {
@@ -189,7 +189,9 @@ class Client extends ESAPI {
       this.helpers = new Helpers({
         client: this,
         maxRetries: options.maxRetries,
-        enableMetaHeader: options.enableMetaHeader
+        metaHeader: options.enableMetaHeader
+          ? `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion}`
+          : null
       })
     }
   }

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -28,12 +28,16 @@ const { ResponseError, ConfigurationError } = require('./errors')
 const pImmediate = promisify(setImmediate)
 const sleep = promisify(setTimeout)
 const kClient = Symbol('elasticsearch-client')
+const kMetaHeader = Symbol('meta header')
 /* istanbul ignore next */
 const noop = () => {}
 
 class Helpers {
   constructor (opts) {
     this[kClient] = opts.client
+    this[kMetaHeader] = opts.enableMetaHeader
+      ? buildMetaHeader(this[kClient].transport.headers['x-elastic-client-meta'])
+      : null
     this.maxRetries = opts.maxRetries
   }
 
@@ -71,6 +75,10 @@ class Helpers {
    * @return {iterator} the async iterator
    */
   async * scrollSearch (params, options = {}) {
+    if (this[kMetaHeader] !== null) {
+      options.headers = options.headers || {}
+      options.headers['x-elastic-client-meta'] = this[kMetaHeader]('s')
+    }
     // TODO: study scroll search slices
     const wait = options.wait || 5000
     const maxRetries = options.maxRetries || this.maxRetries
@@ -99,7 +107,7 @@ class Helpers {
       stop = true
       await this[kClient].clearScroll(
         { body: { scroll_id } },
-        { ignore: [400] }
+        { ignore: [400], ...options }
       )
     }
 
@@ -414,6 +422,7 @@ class Helpers {
   bulk (options) {
     const client = this[kClient]
     const { serialize, deserialize } = client.serializer
+    const reqOptions = this[kMetaHeader] !== null ? { headers: { 'x-elastic-client-meta': this[kMetaHeader]('bp') } } : {}
     const {
       datasource,
       onDocument,
@@ -676,7 +685,7 @@ class Helpers {
 
       function tryBulk (bulkBody, callback) {
         if (shouldAbort === true) return callback(null, [])
-        client.bulk(Object.assign({}, bulkOptions, { body: bulkBody }), (err, { body }) => {
+        client.bulk(Object.assign({}, bulkOptions, { body: bulkBody }), reqOptions, (err, { body }) => {
           if (err) return callback(err, null)
           if (body.errors === false) {
             stats.successful += body.items.length
@@ -743,6 +752,14 @@ function appendFilterPath (filter, params, force) {
     params.filterPath += ',' + filter
   } else if (force === true) {
     params.filter_path = filter
+  }
+}
+
+function buildMetaHeader (header) {
+  const first = header.slice(0, header.indexOf('t='))
+  const second = header.slice(header.indexOf('t='))
+  return function _buildMetaHeader (name) {
+    return `${first}h=${name},${second}`
   }
 }
 

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -35,9 +35,7 @@ const noop = () => {}
 class Helpers {
   constructor (opts) {
     this[kClient] = opts.client
-    this[kMetaHeader] = opts.enableMetaHeader
-      ? buildMetaHeader(this[kClient].transport.headers['x-elastic-client-meta'])
-      : null
+    this[kMetaHeader] = opts.metaHeader
     this.maxRetries = opts.maxRetries
   }
 
@@ -77,7 +75,7 @@ class Helpers {
   async * scrollSearch (params, options = {}) {
     if (this[kMetaHeader] !== null) {
       options.headers = options.headers || {}
-      options.headers['x-elastic-client-meta'] = this[kMetaHeader]('s')
+      options.headers['x-elastic-client-meta'] = this[kMetaHeader] + ',h=s'
     }
     // TODO: study scroll search slices
     const wait = options.wait || 5000
@@ -422,7 +420,7 @@ class Helpers {
   bulk (options) {
     const client = this[kClient]
     const { serialize, deserialize } = client.serializer
-    const reqOptions = this[kMetaHeader] !== null ? { headers: { 'x-elastic-client-meta': this[kMetaHeader]('bp') } } : {}
+    const reqOptions = this[kMetaHeader] !== null ? { headers: { 'x-elastic-client-meta': this[kMetaHeader] + ',h=bp' } } : {}
     const {
       datasource,
       onDocument,
@@ -752,14 +750,6 @@ function appendFilterPath (filter, params, force) {
     params.filterPath += ',' + filter
   } else if (force === true) {
     params.filter_path = filter
-  }
-}
-
-function buildMetaHeader (header) {
-  const first = header.slice(0, header.indexOf('t='))
-  const second = header.slice(header.indexOf('t='))
-  return function _buildMetaHeader (name) {
-    return `${first}h=${name},${second}`
   }
 }
 

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -44,6 +44,7 @@ class Transport {
     if (typeof opts.compression === 'string' && opts.compression !== 'gzip') {
       throw new ConfigurationError(`Invalid compression: '${opts.compression}'`)
     }
+
     this.emit = opts.emit
     this.connectionPool = opts.connectionPool
     this.serializer = opts.serializer

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1308,7 +1308,7 @@ test('Meta header enabled', t => {
 
   class MockConnection extends Connection {
     request (params, callback) {
-      t.match(params.headers, { 'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},t=${clientVersion}` })
+      t.match(params.headers, { 'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion}` })
       const stream = intoStream(JSON.stringify({ hello: 'world' }))
       stream.statusCode = 200
       stream.headers = {
@@ -1337,7 +1337,7 @@ test('Meta header disabled', t => {
 
   class MockConnection extends Connection {
     request (params, callback) {
-      t.notMatch(params.headers, { 'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},t=${clientVersion}` })
+      t.notMatch(params.headers, { 'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion}` })
       const stream = intoStream(JSON.stringify({ hello: 'world' }))
       stream.statusCode = 200
       stream.headers = {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -26,6 +26,8 @@ const intoStream = require('into-stream')
 const { Client, ConnectionPool, Transport, Connection, errors } = require('../../index')
 const { CloudConnectionPool } = require('../../lib/pool')
 const { buildServer } = require('../utils')
+const clientVersion = require('../../package.json').version
+const nodeVersion = process.versions.node
 
 test('Configure host', t => {
   t.test('Single string', t => {
@@ -1298,5 +1300,64 @@ test('Content length too big (string)', t => {
     t.ok(err instanceof errors.RequestAbortedError)
     t.is(err.message, `The content length (${buffer.constants.MAX_STRING_LENGTH + 10}) is bigger than the maximum allowed string (${buffer.constants.MAX_STRING_LENGTH})`)
     t.strictEqual(result.meta.attempts, 0)
+  })
+})
+
+test('Meta header enabled', t => {
+  t.plan(2)
+
+  class MockConnection extends Connection {
+    request (params, callback) {
+      t.match(params.headers, { 'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},t=${clientVersion}` })
+      const stream = intoStream(JSON.stringify({ hello: 'world' }))
+      stream.statusCode = 200
+      stream.headers = {
+        'content-type': 'application/json;utf=8',
+        'content-length': '17',
+        connection: 'keep-alive',
+        date: new Date().toISOString()
+      }
+      process.nextTick(callback, null, stream)
+      return { abort () {} }
+    }
+  }
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  client.info((err, result) => {
+    t.error(err)
+  })
+})
+
+test('Meta header disabled', t => {
+  t.plan(2)
+
+  class MockConnection extends Connection {
+    request (params, callback) {
+      t.notMatch(params.headers, { 'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},t=${clientVersion}` })
+      const stream = intoStream(JSON.stringify({ hello: 'world' }))
+      stream.statusCode = 200
+      stream.headers = {
+        'content-type': 'application/json;utf=8',
+        'content-length': '17',
+        connection: 'keep-alive',
+        date: new Date().toISOString()
+      }
+      process.nextTick(callback, null, stream)
+      return { abort () {} }
+    }
+  }
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection,
+    enableMetaHeader: false
+  })
+
+  client.info((err, result) => {
+    t.error(err)
   })
 })

--- a/test/unit/helpers/bulk.test.js
+++ b/test/unit/helpers/bulk.test.js
@@ -45,7 +45,7 @@ test('bulk index', t => {
           t.strictEqual(params.path, '/_bulk')
           t.match(params.headers, {
             'content-type': 'application/x-ndjson',
-            'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},h=bp,t=${clientVersion}`
+            'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion},h=bp`
           })
           const [action, payload] = params.body.split('\n')
           t.deepEqual(JSON.parse(action), { index: { _index: 'test' } })
@@ -90,7 +90,7 @@ test('bulk index', t => {
           t.strictEqual(params.path, '/_bulk')
           t.match(params.headers, { 'content-type': 'application/x-ndjson' })
           t.notMatch(params.headers, {
-            'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},h=bp,t=${clientVersion}`
+            'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion},h=bp`
           })
           const [action, payload] = params.body.split('\n')
           t.deepEqual(JSON.parse(action), { index: { _index: 'test' } })

--- a/test/unit/helpers/scroll.test.js
+++ b/test/unit/helpers/scroll.test.js
@@ -22,11 +22,17 @@
 const { test } = require('tap')
 const { Client, errors } = require('../../../')
 const { connection } = require('../../utils')
+const clientVersion = require('../../../package.json').version
+const nodeVersion = process.versions.node
 
 test('Scroll search', async t => {
   var count = 0
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
+      t.match(params.headers, {
+        'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},h=s,t=${clientVersion}`
+      })
+
       count += 1
       if (params.method === 'POST') {
         t.strictEqual(params.querystring, 'scroll=1m')
@@ -73,6 +79,9 @@ test('Clear a scroll search', async t => {
   var count = 0
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
+      t.notMatch(params.headers, {
+        'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},h=s,t=${clientVersion}`
+      })
       if (params.method === 'DELETE') {
         const body = JSON.parse(params.body)
         t.strictEqual(body.scroll_id, 'id')
@@ -95,7 +104,8 @@ test('Clear a scroll search', async t => {
 
   const client = new Client({
     node: 'http://localhost:9200',
-    Connection: MockConnection
+    Connection: MockConnection,
+    enableMetaHeader: false
   })
 
   const scrollSearch = client.helpers.scrollSearch({

--- a/test/unit/helpers/scroll.test.js
+++ b/test/unit/helpers/scroll.test.js
@@ -30,7 +30,7 @@ test('Scroll search', async t => {
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
       t.match(params.headers, {
-        'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},h=s,t=${clientVersion}`
+        'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion},h=s`
       })
 
       count += 1
@@ -80,7 +80,7 @@ test('Clear a scroll search', async t => {
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
       t.notMatch(params.headers, {
-        'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},hc=${nodeVersion},h=s,t=${clientVersion}`
+        'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion},h=s`
       })
       if (params.method === 'DELETE') {
         const body = JSON.parse(params.body)


### PR DESCRIPTION
This pr add a new option named `enableMetaHeader `. If true, adds a header named `'x-elastic-client-meta'`, containing some minimal telemetry data, such as the client and platform version.