### PR TITLE
Prereleases in meta header should be displayed as p

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,12 @@ const Serializer = require('./lib/Serializer')
 const errors = require('./lib/errors')
 const { ConfigurationError } = errors
 const { prepareHeaders } = Connection.internals
-const clientVersion = require('./package.json').version
+let clientVersion = require('./package.json').version
+/* istanbul ignore next */
+if (clientVersion.includes('-')) {
+  // clean prerelease
+  clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
+}
 const nodeVersion = process.versions.node
 
 const kInitialOptions = Symbol('elasticsearchjs-initial-options')

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -26,7 +26,10 @@ const intoStream = require('into-stream')
 const { Client, ConnectionPool, Transport, Connection, errors } = require('../../index')
 const { CloudConnectionPool } = require('../../lib/pool')
 const { buildServer } = require('../utils')
-const clientVersion = require('../../package.json').version
+let clientVersion = require('../../package.json').version
+if (clientVersion.includes('-')) {
+  clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
+}
 const nodeVersion = process.versions.node
 
 test('Configure host', t => {

--- a/test/unit/helpers/bulk.test.js
+++ b/test/unit/helpers/bulk.test.js
@@ -27,7 +27,10 @@ const semver = require('semver')
 const { test } = require('tap')
 const { Client, errors } = require('../../../')
 const { buildServer, connection } = require('../../utils')
-const clientVersion = require('../../../package.json').version
+let clientVersion = require('../../../package.json').version
+if (clientVersion.includes('-')) {
+  clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
+}
 const nodeVersion = process.versions.node
 
 const dataset = [

--- a/test/unit/helpers/scroll.test.js
+++ b/test/unit/helpers/scroll.test.js
@@ -22,7 +22,10 @@
 const { test } = require('tap')
 const { Client, errors } = require('../../../')
 const { connection } = require('../../utils')
-const clientVersion = require('../../../package.json').version
+let clientVersion = require('../../../package.json').version
+if (clientVersion.includes('-')) {
+  clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
+}
 const nodeVersion = process.versions.node
 
 test('Scroll search', async t => {


### PR DESCRIPTION
As titled.

Related: https://github.com/elastic/elasticsearch-js/pull/1373