### PR TITLE
Bulk update improvements

### DIFF
--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -36,6 +36,7 @@ export interface ScrollSearchResponse<TDocument = unknown, TResponse = Record<st
 
 export interface BulkHelper<T> extends Promise<T> {
   abort: () => BulkHelper<T>
+  stats: () => BulkStats
 }
 
 export interface BulkStats {
@@ -43,6 +44,7 @@ export interface BulkStats {
   failed: number
   retry: number
   successful: number
+  noop: number
   time: number
   bytes: number
   aborted: boolean

--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -36,7 +36,7 @@ export interface ScrollSearchResponse<TDocument = unknown, TResponse = Record<st
 
 export interface BulkHelper<T> extends Promise<T> {
   abort: () => BulkHelper<T>
-  stats: () => BulkStats
+  readonly stats: BulkStats
 }
 
 export interface BulkStats {

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -464,6 +464,9 @@ class Helpers {
 
     const p = iterate()
     const helper = {
+      stats () {
+        return stats
+      },
       then (onFulfilled, onRejected) {
         return p.then(onFulfilled, onRejected)
       },

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -456,6 +456,7 @@ class Helpers {
       failed: 0,
       retry: 0,
       successful: 0,
+      noop: 0,
       time: 0,
       bytes: 0,
       aborted: false
@@ -692,6 +693,11 @@ class Helpers {
           if (err) return callback(err, null)
           if (body.errors === false) {
             stats.successful += body.items.length
+            for (const item of body.items) {
+              if (item.update && item.update.result === 'noop') {
+                stats.noop++
+              }
+            }
             return callback(null, [])
           }
           const retry = []

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -464,7 +464,7 @@ class Helpers {
 
     const p = iterate()
     const helper = {
-      stats () {
+      get stats () {
         return stats
       },
       then (onFulfilled, onRejected) {

--- a/test/unit/helpers/bulk.test.js
+++ b/test/unit/helpers/bulk.test.js
@@ -1349,7 +1349,7 @@ test('Flush interval', t => {
 
     t.type(result.time, 'number')
     t.type(result.bytes, 'number')
-    t.match(result, b.stats())
+    t.match(result, b.stats)
     t.match(result, {
       total: 3,
       successful: 3,

--- a/test/unit/helpers/bulk.test.js
+++ b/test/unit/helpers/bulk.test.js
@@ -913,6 +913,55 @@ test('bulk update', t => {
     })
   })
 
+  t.test('Should track the number of noop results', async t => {
+    let count = 0
+    const MockConnection = connection.buildMockConnection({
+      onRequest (params) {
+        t.strictEqual(params.path, '/_bulk')
+        t.match(params.headers, { 'content-type': 'application/x-ndjson' })
+        const [action, payload] = params.body.split('\n')
+        t.deepEqual(JSON.parse(action), { update: { _index: 'test', _id: count } })
+        t.deepEqual(JSON.parse(payload), { doc: dataset[count++], doc_as_upsert: true })
+        return { body: { errors: false, items: [{ update: { result: 'noop' } }] } }
+      }
+    })
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+      Connection: MockConnection
+    })
+    let id = 0
+    const result = await client.helpers.bulk({
+      datasource: dataset.slice(),
+      flushBytes: 1,
+      concurrency: 1,
+      onDocument (doc) {
+        return [{
+          update: {
+            _index: 'test',
+            _id: id++
+          }
+        }, {
+          doc_as_upsert: true
+        }]
+      },
+      onDrop (doc) {
+        t.fail('This should never be called')
+      }
+    })
+
+    t.type(result.time, 'number')
+    t.type(result.bytes, 'number')
+    t.match(result, {
+      total: 3,
+      successful: 3,
+      noop: 3,
+      retry: 0,
+      failed: 0,
+      aborted: false
+    })
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
This exposes a `stats()` function on the operation helper that gets returned by `bulk()`. As well, it tracks the number of `noop` results. Let me know if you have any feedback on this pr, thanks!