### PR TITLE
Catch HEAD errors

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -306,8 +306,8 @@ class Transport {
           return callback(err, result)
         }
       } else {
-        // cast to boolean if the request method was HEAD
-        result.body = isHead === true ? true : payload
+        // cast to boolean if the request method was HEAD and there was no error
+        result.body = isHead === true && result.statusCode < 400 ? true : payload
       }
 
       // we should ignore the statusCode if the user has configured the `ignore` field with

--- a/test/unit/transport.test.js
+++ b/test/unit/transport.test.js
@@ -1613,7 +1613,7 @@ test('Should cast to boolean HEAD request', t => {
   })
 
   t.test('4xx response', t => {
-    t.plan(2)
+    t.plan(3)
 
     const pool = new ConnectionPool({ Connection: MockConnection })
     pool.addConnection('http://localhost:9200')
@@ -1633,12 +1633,13 @@ test('Should cast to boolean HEAD request', t => {
       path: '/400'
     }, (err, { body, statusCode }) => {
       t.ok(err instanceof ResponseError)
+      t.false(typeof err.body === 'boolean')
       t.strictEqual(statusCode, 400)
     })
   })
 
   t.test('5xx response', t => {
-    t.plan(2)
+    t.plan(3)
     const pool = new ConnectionPool({ Connection: MockConnection })
     pool.addConnection('http://localhost:9200')
 
@@ -1657,6 +1658,7 @@ test('Should cast to boolean HEAD request', t => {
       path: '/500'
     }, (err, { body, statusCode }) => {
       t.ok(err instanceof ResponseError)
+      t.false(typeof err.body === 'boolean')
       t.strictEqual(statusCode, 500)
     })
   })


### PR DESCRIPTION
In case of an HTTP error and a `HEAD` request, the body should not be cast to boolean (unless the error is a 404).

Related: https://github.com/elastic/kibana/issues/98890