### PR TITLE
[DOCS] Removes link from API reference that breaks the docs build

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -9330,8 +9330,6 @@ link:{ref}/security-api-enable-user.html[Documentation] +
 ----
 client.security.enrollNode()
 ----
-link:{ref}/security-api-enroll-node.html[Documentation] +
-
 
 [discrete]
 === security.getApiKey


### PR DESCRIPTION
## Overview

Removes a link from the generated API docs that makes the docs build to fail.