### PR TITLE
Support authentication via service account tokens

### DIFF
--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -46,8 +46,8 @@ node: {
 ----
 
 |`auth`
-a|Your authentication data. You can use both basic authentication and 
-{ref}/security-api-create-api-key.html[ApiKey]. +
+a|Your authentication data. You can authenticate via basic authentication (username/password),  
+{ref}/security-api-create-api-key.html[api key], or  {ref}/security-api-create-service-token.html[service account token]+
 See https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/auth-reference.html[Authentication] 
 for more details. +
 _Default:_ `null`

--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -47,7 +47,7 @@ node: {
 
 |`auth`
 a|Your authentication data. You can authenticate via basic authentication (username/password),  
-{ref}/security-api-create-api-key.html[api key], or  {ref}/security-api-create-service-token.html[service account token]+
+{ref}/security-api-create-api-key.html[api key], or  {ref}/security-api-create-service-token.html[service account token] +
 See https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/auth-reference.html[Authentication] 
 for more details. +
 _Default:_ `null`
@@ -67,7 +67,13 @@ auth: {
   apiKey: 'base64EncodedKey'
 }
 ----
-
+{ref}/security-api-create-service-token.html[Service account token] authentication:
+[source,js]
+----
+auth: {
+  serviceAccountToken: 'secretTokenValue'
+}
+----
 
 |`maxRetries`
 |`number` - Max number of retries for each request. +

--- a/lib/Connection.d.ts
+++ b/lib/Connection.d.ts
@@ -22,7 +22,7 @@
 import { URL } from 'url';
 import { inspect, InspectOptions } from 'util'
 import { Readable as ReadableStream } from 'stream';
-import { ApiKeyAuth, BasicAuth } from './pool'
+import { ApiKeyAuth, BasicAuth, ServiceAccountTokenAuth } from './pool'
 import * as http from 'http'
 import * as https from 'https'
 import * as hpagent from 'hpagent'
@@ -38,7 +38,7 @@ export interface ConnectionOptions {
   agent?: AgentOptions | agentFn;
   status?: string;
   roles?: ConnectionRoles;
-  auth?: BasicAuth | ApiKeyAuth;
+  auth?: BasicAuth | ApiKeyAuth | ServiceAccountTokenAuth;
   proxy?: string | URL;
 }
 

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -331,6 +331,8 @@ function prepareHeaders (headers = {}, auth) {
       } else {
         headers.authorization = `ApiKey ${auth.apiKey}`
       }
+    } else if (auth.serviceAccountToken) {
+      headers.authorization = `Bearer ${auth.serviceAccountToken}`
     } else if (auth.username && auth.password) {
       headers.authorization = 'Basic ' + Buffer.from(`${auth.username}:${auth.password}`).toString('base64')
     }

--- a/lib/pool/index.d.ts
+++ b/lib/pool/index.d.ts
@@ -28,7 +28,7 @@ interface BaseConnectionPoolOptions {
   ssl?: SecureContextOptions;
   agent?: AgentOptions;
   proxy?: string | URL;
-  auth?: BasicAuth | ApiKeyAuth;
+  auth?: BasicAuth | ApiKeyAuth | ServiceAccountTokenAuth;
   emit: (event: string | symbol, ...args: any[]) => boolean;
   Connection: typeof Connection;
 }
@@ -59,6 +59,10 @@ interface ApiKeyAuth {
 interface BasicAuth {
   username: string;
   password: string;
+}
+
+interface ServiceAccountTokenAuth {
+  serviceAccountToken: string;
 }
 
 interface resurrectOptions {
@@ -204,6 +208,7 @@ export {
   getConnectionOptions,
   ApiKeyAuth,
   BasicAuth,
+  ServiceAccountTokenAuth,
   internals,
   resurrectOptions,
   ResurrectEvent,

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -82,6 +82,7 @@ const platinumBlackList = {
   ],
   // The cleanup fails with a index not found when retrieving the jobs
   'ml/get_datafeed_stats.yml': ['Test get datafeed stats when total_search_time_ms mapping is missing'],
+  'ml/bucket_correlation_agg.yml': ['Test correlation bucket agg simple'],
   'ml/preview_datafeed.yml': ['*'],
   // Investigate why is failing
   'ml/inference_crud.yml': ['*'],
@@ -94,6 +95,7 @@ const platinumBlackList = {
   // the body is correct, but the regex is failing
   'sql/sql.yml': ['Getting textual representation'],
   'searchable_snapshots/10_usage.yml': ['*'],
+  'service_accounts/10_basic.yml': ['*'],
   // we are setting two certificates in the docker config
   'ssl/10_basic.yml': ['*'],
   // very likely, the index template has not been loaded yet.

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -822,6 +822,17 @@ test('Authorization header', t => {
     t.end()
   })
 
+  t.test('Service account token', t => {
+    const connection = new Connection({
+      url: new URL('http://localhost:9200'),
+      auth: { serviceAccountToken: 'ABCZm9vOmJhcg==' }
+    })
+
+    t.same(connection.headers, { authorization: 'Bearer ABCZm9vOmJhcg==' })
+
+    t.end()
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
Introduces support for authenticating via [Service Account Tokens](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-service-token.html):

```ts
const { Client } = require('@elastic/elasticsearch')
const client = new Client({
  node: 'https://localhost:9200',
  auth: {
    serviceAccountToken: 'AAEAAWVsYXN0aWM...vZmxlZXQtc2VydmVyL3Rva2VuMTo3TFdaSDZ'
  }
})
```

Resolves #1477 
