### PR TITLE
Add support for bearer auth

### DIFF
--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -67,6 +67,13 @@ auth: {
   apiKey: 'base64EncodedKey'
 }
 ----
+Bearer authentication, useful for https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-service-token.html[service account tokens]. Be aware that it does not handle automatic token refresh:
+[source,js]
+----
+auth: {
+  bearer: 'token'
+}
+----
 
 
 |`maxRetries`

--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -93,6 +93,26 @@ const client = new Client({
 })
 ----
 
+[discrete]
+[[auth-bearer]]
+==== Bearer authentication
+
+You can provide your credentials by passing the `bearer` token
+parameter via the `auth` option.
+Useful for https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-service-token.html[service account tokens].
+Be aware that it does not handle automatic token refresh.
+
+[source,js]
+----
+const { Client } = require('@elastic/elasticsearch')
+const client = new Client({
+  node: 'https://localhost:9200',
+  auth: {
+    bearer: 'token'
+  }
+})
+----
+
 
 [discrete]
 [[auth-basic]]

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,8 @@ import {
   CloudConnectionPool,
   ResurrectEvent,
   BasicAuth,
-  ApiKeyAuth
+  ApiKeyAuth,
+  BearerAuth
 } from './lib/pool';
 import Serializer from './lib/Serializer';
 import Helpers from './lib/Helpers';
@@ -106,7 +107,7 @@ interface ClientOptions {
   opaqueIdPrefix?: string;
   generateRequestId?: generateRequestIdFn;
   name?: string | symbol;
-  auth?: BasicAuth | ApiKeyAuth;
+  auth?: BasicAuth | ApiKeyAuth | BearerAuth;
   context?: Context;
   proxy?: string | URL;
   enableMetaHeader?: boolean;

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -331,6 +331,8 @@ function prepareHeaders (headers = {}, auth) {
       } else {
         headers.authorization = `ApiKey ${auth.apiKey}`
       }
+    } else if (auth.bearer) {
+      headers.authorization = `Bearer ${auth.bearer}`
     } else if (auth.username && auth.password) {
       headers.authorization = 'Basic ' + Buffer.from(`${auth.username}:${auth.password}`).toString('base64')
     }

--- a/lib/pool/index.d.ts
+++ b/lib/pool/index.d.ts
@@ -61,6 +61,10 @@ interface BasicAuth {
   password: string;
 }
 
+interface BearerAuth {
+  bearer: string
+}
+
 interface resurrectOptions {
   now?: number;
   requestId: string;

--- a/lib/pool/index.d.ts
+++ b/lib/pool/index.d.ts
@@ -208,6 +208,7 @@ export {
   getConnectionOptions,
   ApiKeyAuth,
   BasicAuth,
+  BearerAuth,
   internals,
   resurrectOptions,
   ResurrectEvent,

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1,4 +1,4 @@
-/*
+/* P
  * Licensed to Elasticsearch B.V. under one or more contributor
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright
@@ -1419,5 +1419,32 @@ test('Disable prototype poisoning protection', t => {
 
   client.info((err, result) => {
     t.error(err)
+  })
+})
+
+test('Bearer auth', t => {
+  t.plan(3)
+
+  function handler (req, res) {
+    t.match(req.headers, {
+      authorization: 'Bearer Zm9vOmJhcg=='
+    })
+    res.setHeader('Content-Type', 'application/json;utf=8')
+    res.end(JSON.stringify({ hello: 'world' }))
+  }
+
+  buildServer(handler, ({ port }, server) => {
+    const client = new Client({
+      node: `http://localhost:${port}`,
+      auth: {
+        bearer: 'Zm9vOmJhcg=='
+      }
+    })
+
+    client.info((err, { body }) => {
+      t.error(err)
+      t.same(body, { hello: 'world' })
+      server.stop()
+    })
   })
 })

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1,4 +1,4 @@
-/* P
+/*
  * Licensed to Elasticsearch B.V. under one or more contributor
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright


### PR DESCRIPTION
As titled.
Supersedes https://github.com/elastic/elasticsearch-js/pull/1481.

Closes: https://github.com/elastic/elasticsearch-js/issues/1477.