### PR TITLE
Fix URLs for trained model deployments

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -7147,7 +7147,7 @@ client.ml.inferTrainedModelDeployment({
   timeout: string
 })
 ----
-link:{ref}/ml-infer-trained-model-deployment.html[Documentation] +
+link:{ref}/ml-df-analytics-apis.html[Documentation] +
 [cols=2*]
 |===
 |`model_id` or `modelId`
@@ -7621,7 +7621,7 @@ client.ml.startTrainedModelDeployment({
   timeout: string
 })
 ----
-link:{ref}/ml-start-trained-model-deployment.html[Documentation] +
+link:{ref}/ml-df-analytics-apis.html[Documentation] +
 [cols=2*]
 |===
 |`model_id` or `modelId`
@@ -7713,7 +7713,7 @@ client.ml.stopTrainedModelDeployment({
   model_id: string
 })
 ----
-link:{ref}/stop-trained-model-deployment.html[Documentation] +
+link:{ref}/ml-df-analytics-apis.html[Documentation] +
 [cols=2*]
 |===
 |`model_id` or `modelId`


### PR DESCRIPTION
Looks like some URLs were broken in the API spec that have been fixed in `elastic/elasticsearch` here: https://github.com/elastic/elasticsearch/pull/75388/files

Doing the same here to fix the docs build.