### PR TITLE
Support CA fingerprint validation

### DIFF
--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -255,4 +255,8 @@ const client = new Client({
 |`boolean`, `'proto'`, `'constructor'` - By the default the client will protect you against prototype poisoning attacks. Read https://web.archive.org/web/20200319091159/https://hueniverse.com/square-brackets-are-the-enemy-ff5b9fd8a3e8?gi=184a27ee2a08[this article] to learn more. If needed you can disable prototype poisoning protection entirely or one of the two checks. Read the `secure-json-parse` https://github.com/fastify/secure-json-parse[documentation] to learn more. +
 _Default:_ `false`
 
+|`caFingerprint`
+|`string` - If configured, verify the supplied certificate authority fingerprint. +
+_Default:_ `null`
+
 |===

--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -256,7 +256,7 @@ const client = new Client({
 _Default:_ `false`
 
 |`caFingerprint`
-|`string` - If configured, verify the supplied CA certificate fingerprint. You must configure a SHA256 diagest. +
+|`string` - If configured, verify that the fingerprint of the CA certificate that has signed the certificate of the server matches the supplied fingerprint. Only accepts SHA256 digest fingerprints. +
 _Default:_ `null`
 
 |===

--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -256,7 +256,7 @@ const client = new Client({
 _Default:_ `false`
 
 |`caFingerprint`
-|`string` - If configured, verify the supplied certificate authority fingerprint. +
+|`string` - If configured, verify the supplied CA certificate fingerprint. +
 _Default:_ `null`
 
 |===
@@ -280,4 +280,3 @@ const client = new Client({
   disablePrototypePoisoningProtection: true
 })
 ----
-

--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -256,7 +256,7 @@ const client = new Client({
 _Default:_ `false`
 
 |`caFingerprint`
-|`string` - If configured, verify the supplied CA certificate fingerprint. +
+|`string` - If configured, verify the supplied CA certificate fingerprint. You must configure a SHA256 diagest. +
 _Default:_ `null`
 
 |===

--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -180,7 +180,7 @@ const client = new Client({
 [[auth-ca-fingerprint]]
 ==== CA fingerprint
 
-To improve the security of your connection to Elasticsearch, you can provide
+You can configure <not sure how we refer to the client in docs here> to only trust  certificates that are signed by a specific CA certificate ( CA certificate pinning ) by providing a `caFingerprint` option. This will verify that the fingerprint of the CA certificate that has signed the certificate of the server matches the supplied value.
 a `caFingerprint` option, which will verify the supplied certificate authority fingerprint.
 You must configure a SHA256 digest.
 

--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -176,6 +176,28 @@ const client = new Client({
 })
 ----
 
+[discrete]
+[[auth-ca-fingerprint]]
+==== CA fingerprint
+
+To improve the security of your connection to Elasticsearch, you can provide
+a `caFingerprint` option, which will verify the supplied certificate authority fingerprint.
+
+[source,js]
+----
+const { Client } = require('@elastic/elasticsearch')
+const client = new Client({
+  node: 'https://example.com'
+  auth: { ... },
+  // the fingerprint (SHA256) of the CA certificate that is used to sign the certificate that the Elasticsearch node presents for TLS.
+  caFingerprint: 'SHA-256-DER',
+  ssl: {
+    // might be required if it's a self-signed certificate
+    rejectUnauthorized: false
+  }
+})
+----
+
 
 [discrete]
 [[client-usage]]

--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -180,7 +180,7 @@ const client = new Client({
 [[auth-ca-fingerprint]]
 ==== CA fingerprint
 
-You can configure <not sure how we refer to the client in docs here> to only trust  certificates that are signed by a specific CA certificate ( CA certificate pinning ) by providing a `caFingerprint` option. This will verify that the fingerprint of the CA certificate that has signed the certificate of the server matches the supplied value.
+You can configure the client to only trust certificates that are signed by a specific CA certificate ( CA certificate pinning ) by providing a `caFingerprint` option. This will verify that the fingerprint of the CA certificate that has signed the certificate of the server matches the supplied value.
 a `caFingerprint` option, which will verify the supplied certificate authority fingerprint.
 You must configure a SHA256 digest.
 

--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -182,6 +182,7 @@ const client = new Client({
 
 To improve the security of your connection to Elasticsearch, you can provide
 a `caFingerprint` option, which will verify the supplied certificate authority fingerprint.
+You must configure a SHA256 digest.
 
 [source,js]
 ----

--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -190,7 +190,7 @@ const client = new Client({
   node: 'https://example.com'
   auth: { ... },
   // the fingerprint (SHA256) of the CA certificate that is used to sign the certificate that the Elasticsearch node presents for TLS.
-  caFingerprint: 'SHA-256-DER',
+  caFingerprint: '20:0D:CA:FA:76:...',
   ssl: {
     // might be required if it's a self-signed certificate
     rejectUnauthorized: false

--- a/index.d.ts
+++ b/index.d.ts
@@ -118,6 +118,7 @@ interface ClientOptions {
     password?: string;
   };
   disablePrototypePoisoningProtection?: boolean | 'proto' | 'constructor';
+  caFingerprint?: string;
 }
 
 declare class Client {

--- a/index.js
+++ b/index.js
@@ -323,12 +323,7 @@ function getAuth (node) {
 
 function isHttpConnection (node) {
   if (Array.isArray(node)) {
-    for (const n of node) {
-      if (new URL(n).protocol === 'http:') {
-        return true
-      }
-    }
-    return false
+    return node.some((n) => new URL(n).protocol === 'http:')
   } else {
     return new URL(node).protocol === 'http:'
   }

--- a/index.js
+++ b/index.js
@@ -102,6 +102,7 @@ class Client extends ESAPI {
         suggestCompression: false,
         compression: false,
         ssl: null,
+        certFingerprint: null,
         agent: null,
         headers: {},
         nodeFilter: null,
@@ -146,6 +147,7 @@ class Client extends ESAPI {
         Connection: options.Connection,
         auth: options.auth,
         emit: this[kEventEmitter].emit.bind(this[kEventEmitter]),
+        certFingerprint: options.certFingerprint,
         sniffEnabled: options.sniffInterval !== false ||
                       options.sniffOnStart !== false ||
                       options.sniffOnConnectionFault !== false

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ class Client extends ESAPI {
         suggestCompression: false,
         compression: false,
         ssl: null,
-        certFingerprint: null,
+        caFingerprint: null,
         agent: null,
         headers: {},
         nodeFilter: null,
@@ -147,7 +147,7 @@ class Client extends ESAPI {
         Connection: options.Connection,
         auth: options.auth,
         emit: this[kEventEmitter].emit.bind(this[kEventEmitter]),
-        certFingerprint: options.certFingerprint,
+        caFingerprint: options.caFingerprint,
         sniffEnabled: options.sniffInterval !== false ||
                       options.sniffOnStart !== false ||
                       options.sniffOnConnectionFault !== false

--- a/index.js
+++ b/index.js
@@ -117,6 +117,10 @@ class Client extends ESAPI {
         disablePrototypePoisoningProtection: false
       }, opts)
 
+    if (options.caFingerprint !== null && isHttpConnection(opts.node || opts.nodes)) {
+      throw new ConfigurationError('You can\'t configure the caFingerprint with a http connection')
+    }
+
     if (process.env.ELASTIC_CLIENT_APIVERSIONING === 'true') {
       options.headers = Object.assign({ accept: 'application/vnd.elasticsearch+json; compatible-with=7' }, options.headers)
     }
@@ -314,6 +318,19 @@ function getAuth (node) {
         password: decodeURIComponent(node.url.password)
       }
     }
+  }
+}
+
+function isHttpConnection (node) {
+  if (Array.isArray(node)) {
+    for (const n of node) {
+      if (new URL(n).protocol === 'http:') {
+        return true
+      }
+    }
+    return false
+  } else {
+    return new URL(node).protocol === 'http:'
   }
 }
 

--- a/lib/Connection.d.ts
+++ b/lib/Connection.d.ts
@@ -40,6 +40,7 @@ export interface ConnectionOptions {
   roles?: ConnectionRoles;
   auth?: BasicAuth | ApiKeyAuth;
   proxy?: string | URL;
+  caFingerprint?: string;
 }
 
 interface ConnectionRoles {

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -139,7 +139,7 @@ class Connection {
           // Check if fingerprint matches
           /* istanbul ignore else */
           if (this.caFingerprint !== issuerCertificate.fingerprint256) {
-            onError(new Error('Server certificate CA fingerprint does not match the value configured in  caFingerprint'))
+            onError(new Error('Server certificate CA fingerprint does not match the value configured in caFingerprint'))
             request.once('error', () => {}) // we need to catch the request aborted error
             return request.abort()
           }

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -42,6 +42,7 @@ class Connection {
     this.headers = prepareHeaders(opts.headers, opts.auth)
     this.deadCount = 0
     this.resurrectTimeout = 0
+    this.certFingerprint = opts.certFingerprint
 
     this._openRequests = 0
     this._status = opts.status || Connection.statuses.ALIVE
@@ -123,10 +124,34 @@ class Connection {
       callback(new RequestAbortedError(), null)
     }
 
+    const onSocket = socket => {
+      /* istanbul ignore else */
+      if (!socket.isSessionReused()) {
+        socket.once('secureConnect', () => {
+          // Check if certificate is valid
+          if (socket.authorized === false) {
+            onError(new Error(socket.authorizationError))
+            request.once('error', () => {}) // we need to catch the request aborted error
+            return request.abort()
+          }
+
+          // Check if fingerprint matches
+          if (this.certFingerprint !== socket.getPeerCertificate().fingerprint) {
+            onError(new Error('Fingerprint does not match'))
+            request.once('error', () => {}) // we need to catch the request aborted error
+            return request.abort()
+          }
+        })
+      }
+    }
+
     request.on('response', onResponse)
     request.on('timeout', onTimeout)
     request.on('error', onError)
     request.on('abort', onAbort)
+    if (this.certFingerprint != null) {
+      request.on('socket', onSocket)
+    }
 
     // Disables the Nagle algorithm
     request.setNoDelay(true)
@@ -152,6 +177,7 @@ class Connection {
       request.removeListener('timeout', onTimeout)
       request.removeListener('error', onError)
       request.removeListener('abort', onAbort)
+      request.removeListener('socket', onSocket)
       cleanedListeners = true
     }
   }

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -131,7 +131,7 @@ class Connection {
           // Check if fingerprint matches
           /* istanbul ignore else */
           if (this.caFingerprint !== getIssuerCertificate(socket).fingerprint256) {
-            onError(new Error('Fingerprint does not match'))
+            onError(new Error('Server certificate CA fingerprint does not match the value configured in  caFingerprint'))
             request.once('error', () => {}) // we need to catch the request aborted error
             return request.abort()
           }

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -129,6 +129,7 @@ class Connection {
       if (!socket.isSessionReused()) {
         socket.once('secureConnect', () => {
           // Check if fingerprint matches
+          /* istanbul ignore else */
           if (this.caFingerprint !== getIssuerCertificate(socket).fingerprint256) {
             onError(new Error('Fingerprint does not match'))
             request.once('error', () => {}) // we need to catch the request aborted error
@@ -362,11 +363,14 @@ function prepareHeaders (headers = {}, auth) {
 function getIssuerCertificate (socket) {
   let certificate = socket.getPeerCertificate(true)
   while (certificate && Object.keys(certificate).length > 0) {
+    /* istanbul ignore else */
     if (certificate.issuerCertificate !== undefined) {
       // For self-signed certificates, `issuerCertificate` may be a circular reference.
+      /* istanbul ignore else */
       if (certificate.fingerprint256 === certificate.issuerCertificate.fingerprint256) {
         break
       }
+      /* istanbul ignore next */
       certificate = certificate.issuerCertificate
     } else {
       break

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -376,17 +376,8 @@ function getIssuerCertificate (socket) {
       return null
     }
 
-    // we have reached the root certificate
-    if (certificate.subject.C === certificate.issuer.C &&
-        certificate.subject.ST === certificate.issuer.ST &&
-        certificate.subject.L === certificate.issuer.L &&
-        certificate.subject.O === certificate.issuer.O &&
-        certificate.subject.OU === certificate.issuer.OU &&
-        certificate.subject.CN === certificate.issuer.CN) {
-      break
-    }
-
-    // For self-signed certificates, `issuerCertificate` may be a circular reference.
+    // We have reached the root certificate.
+    // In case of self-signed certificates, `issuerCertificate` may be a circular reference.
     if (certificate.fingerprint256 === certificate.issuerCertificate.fingerprint256) {
       break
     }

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -42,7 +42,7 @@ class Connection {
     this.headers = prepareHeaders(opts.headers, opts.auth)
     this.deadCount = 0
     this.resurrectTimeout = 0
-    this.certFingerprint = opts.certFingerprint
+    this.caFingerprint = opts.caFingerprint
 
     this._openRequests = 0
     this._status = opts.status || Connection.statuses.ALIVE
@@ -128,15 +128,8 @@ class Connection {
       /* istanbul ignore else */
       if (!socket.isSessionReused()) {
         socket.once('secureConnect', () => {
-          // Check if certificate is valid
-          if (socket.authorized === false) {
-            onError(new Error(socket.authorizationError))
-            request.once('error', () => {}) // we need to catch the request aborted error
-            return request.abort()
-          }
-
           // Check if fingerprint matches
-          if (this.certFingerprint !== socket.getPeerCertificate().fingerprint) {
+          if (this.caFingerprint !== getIssuerCertificate(socket).fingerprint256) {
             onError(new Error('Fingerprint does not match'))
             request.once('error', () => {}) // we need to catch the request aborted error
             return request.abort()
@@ -149,7 +142,7 @@ class Connection {
     request.on('timeout', onTimeout)
     request.on('error', onError)
     request.on('abort', onAbort)
-    if (this.certFingerprint != null) {
+    if (this.caFingerprint != null) {
       request.on('socket', onSocket)
     }
 
@@ -364,6 +357,22 @@ function prepareHeaders (headers = {}, auth) {
     }
   }
   return headers
+}
+
+function getIssuerCertificate (socket) {
+  let certificate = socket.getPeerCertificate(true)
+  while (certificate && Object.keys(certificate).length > 0) {
+    if (certificate.issuerCertificate !== undefined) {
+      // For self-signed certificates, `issuerCertificate` may be a circular reference.
+      if (certificate.fingerprint256 === certificate.issuerCertificate.fingerprint256) {
+        break
+      }
+      certificate = certificate.issuerCertificate
+    } else {
+      break
+    }
+  }
+  return certificate
 }
 
 module.exports = Connection

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -128,9 +128,17 @@ class Connection {
       /* istanbul ignore else */
       if (!socket.isSessionReused()) {
         socket.once('secureConnect', () => {
+          const issuerCertificate = getIssuerCertificate(socket)
+          /* istanbul ignore next */
+          if (issuerCertificate == null) {
+            onError(new Error('Invalid or malformed certificate'))
+            request.once('error', () => {}) // we need to catch the request aborted error
+            return request.abort()
+          }
+
           // Check if fingerprint matches
           /* istanbul ignore else */
-          if (this.caFingerprint !== getIssuerCertificate(socket).fingerprint256) {
+          if (this.caFingerprint !== issuerCertificate.fingerprint256) {
             onError(new Error('Server certificate CA fingerprint does not match the value configured in  caFingerprint'))
             request.once('error', () => {}) // we need to catch the request aborted error
             return request.abort()
@@ -363,21 +371,31 @@ function prepareHeaders (headers = {}, auth) {
 function getIssuerCertificate (socket) {
   let certificate = socket.getPeerCertificate(true)
   while (certificate && Object.keys(certificate).length > 0) {
-    /* istanbul ignore else */
-    if (certificate.issuerCertificate !== undefined) {
-      // For self-signed certificates, `issuerCertificate` may be a circular reference.
-      /* istanbul ignore else */
-      if (certificate.fingerprint256 === certificate.issuerCertificate.fingerprint256) {
-        break
-      }
-      /* istanbul ignore next */
-      certificate = certificate.issuerCertificate
-    } else {
+    // invalid certificate
+    if (certificate.issuerCertificate == null) {
+      return null
+    }
+
+    // we have reached the root certificate
+    if (certificate.subject.C === certificate.issuer.C &&
+        certificate.subject.ST === certificate.issuer.ST &&
+        certificate.subject.L === certificate.issuer.L &&
+        certificate.subject.O === certificate.issuer.O &&
+        certificate.subject.OU === certificate.issuer.OU &&
+        certificate.subject.CN === certificate.issuer.CN) {
       break
     }
+
+    // For self-signed certificates, `issuerCertificate` may be a circular reference.
+    if (certificate.fingerprint256 === certificate.issuerCertificate.fingerprint256) {
+      break
+    }
+
+    // continue the loop
+    certificate = certificate.issuerCertificate
   }
   return certificate
 }
 
 module.exports = Connection
-module.exports.internals = { prepareHeaders }
+module.exports.internals = { prepareHeaders, getIssuerCertificate }

--- a/lib/pool/BaseConnectionPool.js
+++ b/lib/pool/BaseConnectionPool.js
@@ -36,6 +36,7 @@ class BaseConnectionPool {
     this._ssl = opts.ssl
     this._agent = opts.agent
     this._proxy = opts.proxy || null
+    this._certFingerprint = opts.certFingerprint || null
   }
 
   getConnection () {
@@ -72,6 +73,8 @@ class BaseConnectionPool {
     if (opts.agent == null) opts.agent = this._agent
     /* istanbul ignore else */
     if (opts.proxy == null) opts.proxy = this._proxy
+    /* istanbul ignore else */
+    if (opts.certFingerprint == null) opts.certFingerprint = this._certFingerprint
 
     const connection = new this.Connection(opts)
 

--- a/lib/pool/BaseConnectionPool.js
+++ b/lib/pool/BaseConnectionPool.js
@@ -36,7 +36,7 @@ class BaseConnectionPool {
     this._ssl = opts.ssl
     this._agent = opts.agent
     this._proxy = opts.proxy || null
-    this._certFingerprint = opts.certFingerprint || null
+    this._certFingerprint = opts.caFingerprint || null
   }
 
   getConnection () {
@@ -74,7 +74,7 @@ class BaseConnectionPool {
     /* istanbul ignore else */
     if (opts.proxy == null) opts.proxy = this._proxy
     /* istanbul ignore else */
-    if (opts.certFingerprint == null) opts.certFingerprint = this._certFingerprint
+    if (opts.caFingerprint == null) opts.caFingerprint = this._certFingerprint
 
     const connection = new this.Connection(opts)
 

--- a/lib/pool/BaseConnectionPool.js
+++ b/lib/pool/BaseConnectionPool.js
@@ -36,7 +36,7 @@ class BaseConnectionPool {
     this._ssl = opts.ssl
     this._agent = opts.agent
     this._proxy = opts.proxy || null
-    this._certFingerprint = opts.caFingerprint || null
+    this._caFingerprint = opts.caFingerprint || null
   }
 
   getConnection () {
@@ -74,7 +74,7 @@ class BaseConnectionPool {
     /* istanbul ignore else */
     if (opts.proxy == null) opts.proxy = this._proxy
     /* istanbul ignore else */
-    if (opts.caFingerprint == null) opts.caFingerprint = this._certFingerprint
+    if (opts.caFingerprint == null) opts.caFingerprint = this._caFingerprint
 
     const connection = new this.Connection(opts)
 

--- a/lib/pool/index.d.ts
+++ b/lib/pool/index.d.ts
@@ -31,6 +31,7 @@ interface BaseConnectionPoolOptions {
   auth?: BasicAuth | ApiKeyAuth;
   emit: (event: string | symbol, ...args: any[]) => boolean;
   Connection: typeof Connection;
+  caFingerprint?: string;
 }
 
 interface ConnectionPoolOptions extends BaseConnectionPoolOptions {

--- a/test/acceptance/sniff.test.js
+++ b/test/acceptance/sniff.test.js
@@ -77,6 +77,7 @@ test('Should update the connection pool', t => {
           t.same(hosts[i], {
             url: new URL(nodes[id].url),
             id: id,
+            caFingerprint: null,
             roles: {
               master: true,
               data: true,

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1535,7 +1535,7 @@ test('Check server fingerprint (failure)', t => {
 
     client.info((err, res) => {
       t.ok(err instanceof errors.ConnectionError)
-      t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in  caFingerprint')
+      t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in caFingerprint')
       server.stop()
     })
   })

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -26,6 +26,7 @@ const intoStream = require('into-stream')
 const { ConnectionPool, Transport, Connection, errors } = require('../../index')
 const { CloudConnectionPool } = require('../../lib/pool')
 const { Client, buildServer } = require('../utils')
+
 let clientVersion = require('../../package.json').version
 if (clientVersion.includes('-')) {
   clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
@@ -1538,4 +1539,48 @@ test('Check server fingerprint (failure)', t => {
       server.stop()
     })
   })
+})
+
+test('caFingerprint can\'t be configured over http / 1', t => {
+  t.plan(2)
+
+  try {
+    new Client({ // eslint-disable-line
+      node: 'http://localhost:9200',
+      caFingerprint: 'FO:OB:AR'
+    })
+    t.fail('shuld throw')
+  } catch (err) {
+    t.ok(err instanceof errors.ConfigurationError)
+    t.equal(err.message, 'You can\'t configure the caFingerprint with a http connection')
+  }
+})
+
+test('caFingerprint can\'t be configured over http / 2', t => {
+  t.plan(2)
+
+  try {
+    new Client({ // eslint-disable-line
+      nodes: ['http://localhost:9200'],
+      caFingerprint: 'FO:OB:AR'
+    })
+    t.fail('shuld throw')
+  } catch (err) {
+    t.ok(err instanceof errors.ConfigurationError)
+    t.equal(err.message, 'You can\'t configure the caFingerprint with a http connection')
+  }
+})
+
+test('caFingerprint can\'t be configured over http / 3', t => {
+  t.plan(1)
+
+  try {
+    new Client({ // eslint-disable-line
+      nodes: ['https://localhost:9200'],
+      caFingerprint: 'FO:OB:AR'
+    })
+    t.pass('should not throw')
+  } catch (err) {
+    t.fail('shuld not throw')
+  }
 })

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1564,7 +1564,7 @@ test('caFingerprint can\'t be configured over http / 2', t => {
       nodes: ['http://localhost:9200'],
       caFingerprint: 'FO:OB:AR'
     })
-    t.fail('shuld throw')
+    t.fail('should throw')
   } catch (err) {
     t.ok(err instanceof errors.ConfigurationError)
     t.equal(err.message, 'You can\'t configure the caFingerprint with a http connection')

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1535,7 +1535,7 @@ test('Check server fingerprint (failure)', t => {
 
     client.info((err, res) => {
       t.ok(err instanceof errors.ConnectionError)
-      t.equal(err.message, 'Fingerprint does not match')
+      t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in  caFingerprint')
       server.stop()
     })
   })

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1498,3 +1498,44 @@ test('Bearer auth', t => {
     })
   })
 })
+
+test('Check server fingerprint (success)', t => {
+  t.plan(1)
+
+  function handler (req, res) {
+    res.end('ok')
+  }
+
+  buildServer(handler, { secure: true }, ({ port, caFingerprint }, server) => {
+    const client = new Client({
+      node: `https://localhost:${port}`,
+      caFingerprint
+    })
+
+    client.info((err, res) => {
+      t.error(err)
+      server.stop()
+    })
+  })
+})
+
+test('Check server fingerprint (failure)', t => {
+  t.plan(2)
+
+  function handler (req, res) {
+    res.end('ok')
+  }
+
+  buildServer(handler, { secure: true }, ({ port }, server) => {
+    const client = new Client({
+      node: `https://localhost:${port}`,
+      caFingerprint: 'FO:OB:AR'
+    })
+
+    client.info((err, res) => {
+      t.ok(err instanceof errors.ConnectionError)
+      t.equal(err.message, 'Fingerprint does not match')
+      server.stop()
+    })
+  })
+})

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -955,10 +955,10 @@ test('Check server fingerprint (success)', t => {
     res.end('ok')
   }
 
-  buildServer(handler, { secure: true }, ({ port, certFingerprint }, server) => {
+  buildServer(handler, { secure: true }, ({ port, caFingerprint }, server) => {
     const connection = new Connection({
       url: new URL(`https://localhost:${port}`),
-      certFingerprint
+      caFingerprint
     })
 
     connection.request({
@@ -989,7 +989,7 @@ test('Check server fingerprint (failure)', t => {
   buildServer(handler, { secure: true }, ({ port }, server) => {
     const connection = new Connection({
       url: new URL(`https://localhost:${port}`),
-      certFingerprint: 'FO:OB:AR'
+      caFingerprint: 'FO:OB:AR'
     })
 
     connection.request({

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -998,7 +998,7 @@ test('Check server fingerprint (failure)', t => {
       method: 'GET'
     }, (err, res) => {
       t.ok(err instanceof ConnectionError)
-      t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in  caFingerprint')
+      t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in caFingerprint')
       server.stop()
     })
   })

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -28,7 +28,7 @@ const hpagent = require('hpagent')
 const intoStream = require('into-stream')
 const { buildServer } = require('../utils')
 const Connection = require('../../lib/Connection')
-const { TimeoutError, ConfigurationError, RequestAbortedError } = require('../../lib/errors')
+const { TimeoutError, ConfigurationError, RequestAbortedError, ConnectionError } = require('../../lib/errors')
 
 test('Basic (http)', t => {
   t.plan(4)
@@ -946,4 +946,59 @@ test('Abort with a slow body', t => {
   })
 
   setImmediate(() => request.abort())
+})
+
+test('Check server fingerprint (success)', t => {
+  t.plan(2)
+
+  function handler (req, res) {
+    res.end('ok')
+  }
+
+  buildServer(handler, { secure: true }, ({ port, certFingerprint }, server) => {
+    const connection = new Connection({
+      url: new URL(`https://localhost:${port}`),
+      certFingerprint
+    })
+
+    connection.request({
+      path: '/hello',
+      method: 'GET'
+    }, (err, res) => {
+      t.error(err)
+
+      let payload = ''
+      res.setEncoding('utf8')
+      res.on('data', chunk => { payload += chunk })
+      res.on('error', err => t.fail(err))
+      res.on('end', () => {
+        t.equal(payload, 'ok')
+        server.stop()
+      })
+    })
+  })
+})
+
+test('Check server fingerprint (failure)', t => {
+  t.plan(2)
+
+  function handler (req, res) {
+    res.end('ok')
+  }
+
+  buildServer(handler, { secure: true }, ({ port }, server) => {
+    const connection = new Connection({
+      url: new URL(`https://localhost:${port}`),
+      certFingerprint: 'FO:OB:AR'
+    })
+
+    connection.request({
+      path: '/hello',
+      method: 'GET'
+    }, (err, res) => {
+      t.ok(err instanceof ConnectionError)
+      t.equal(err.message, 'Fingerprint does not match')
+      server.stop()
+    })
+  })
 })

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -1004,7 +1004,7 @@ test('Check server fingerprint (failure)', t => {
   })
 })
 
-test('getIssuerCertificate returns the root CA / 1', t => {
+test('getIssuerCertificate returns the root CA', t => {
   t.plan(2)
   const issuerCertificate = {
     fingerprint256: 'BA:ZF:AZ',
@@ -1053,107 +1053,6 @@ test('getIssuerCertificate returns the root CA / 1', t => {
     }
   }
   t.same(getIssuerCertificate(socket), issuerCertificate)
-})
-
-test('getIssuerCertificate returns the root CA / 2', t => {
-  t.plan(2)
-  const issuerCertificate = {
-    subject: {
-      C: '1',
-      ST: '1',
-      L: '1',
-      O: '1',
-      OU: '1',
-      CN: '1'
-    },
-    issuer: {
-      C: '1',
-      ST: '1',
-      L: '1',
-      O: '1',
-      OU: '1',
-      CN: '1'
-    }
-  }
-  issuerCertificate.issuerCertificate = issuerCertificate
-
-  const socket = {
-    getPeerCertificate (bool) {
-      t.ok(bool)
-      return {
-        fingerprint256: 'FO:OB:AR',
-        subject: {
-          C: '1',
-          ST: '1',
-          L: '1',
-          O: '1',
-          OU: '1',
-          CN: '1'
-        },
-        issuer: {
-          C: '2',
-          ST: '2',
-          L: '2',
-          O: '2',
-          OU: '2',
-          CN: '2'
-        },
-        issuerCertificate
-      }
-    }
-  }
-  t.same(getIssuerCertificate(socket), issuerCertificate)
-})
-
-test('getIssuerCertificate returns the root CA / 3', t => {
-  t.plan(2)
-  const issuerCertificate = {
-    fingerprint256: 'FO:OB:AR',
-    subject: {
-      C: '1',
-      ST: '1',
-      L: '1',
-      O: '1',
-      OU: '1',
-      CN: '1'
-    },
-    issuer: {
-      C: '1',
-      ST: '1',
-      L: '1',
-      O: '1',
-      OU: '1',
-      CN: '1'
-    }
-  }
-  issuerCertificate.issuerCertificate = issuerCertificate
-
-  const socket = {
-    getPeerCertificate (bool) {
-      t.ok(bool)
-      return {
-        fingerprint256: 'FO:OB:AR',
-        subject: {
-          C: '1',
-          ST: '1',
-          L: '1',
-          O: '1',
-          OU: '1',
-          CN: '1'
-        },
-        issuer: {
-          C: '2',
-          ST: '2',
-          L: '2',
-          O: '2',
-          OU: '2',
-          CN: '2'
-        },
-        issuerCertificate
-      }
-    }
-  }
-  t.equal(getIssuerCertificate(socket).fingerprint256, 'FO:OB:AR')
 })
 
 test('getIssuerCertificate detects invalid/malformed certificates', t => {

--- a/test/utils/buildServer.js
+++ b/test/utils/buildServer.js
@@ -36,7 +36,7 @@ const secureOpts = {
   cert: readFileSync(join(__dirname, '..', 'fixtures', 'https.cert'), 'utf8')
 }
 
-const certFingerprint = getFingerprint(secureOpts.cert
+const caFingerprint = getFingerprint(secureOpts.cert
   .split('\n')
   .slice(1, -1)
   .map(line => line.trim())
@@ -66,7 +66,7 @@ function buildServer (handler, opts, cb) {
       server.listen(0, () => {
         const port = server.address().port
         debug(`Server '${serverId}' booted on port ${port}`)
-        resolve([Object.assign({}, secureOpts, { port, certFingerprint }), server])
+        resolve([Object.assign({}, secureOpts, { port, caFingerprint }), server])
       })
     })
   } else {
@@ -79,7 +79,7 @@ function buildServer (handler, opts, cb) {
 }
 
 function getFingerprint (content, inputEncoding = 'base64', outputEncoding = 'hex') {
-  const shasum = crypto.createHash('sha1')
+  const shasum = crypto.createHash('sha256')
   shasum.update(content, inputEncoding)
   const res = shasum.digest(outputEncoding)
   return res.toUpperCase().match(/.{1,2}/g).join(':')

--- a/test/utils/buildServer.js
+++ b/test/utils/buildServer.js
@@ -19,6 +19,7 @@
 
 'use strict'
 
+const crypto = require('crypto')
 const debug = require('debug')('elasticsearch-test')
 const stoppable = require('stoppable')
 
@@ -34,6 +35,13 @@ const secureOpts = {
   key: readFileSync(join(__dirname, '..', 'fixtures', 'https.key'), 'utf8'),
   cert: readFileSync(join(__dirname, '..', 'fixtures', 'https.cert'), 'utf8')
 }
+
+const certFingerprint = getFingerprint(secureOpts.cert
+  .split('\n')
+  .slice(1, -1)
+  .map(line => line.trim())
+  .join('')
+)
 
 let id = 0
 function buildServer (handler, opts, cb) {
@@ -58,7 +66,7 @@ function buildServer (handler, opts, cb) {
       server.listen(0, () => {
         const port = server.address().port
         debug(`Server '${serverId}' booted on port ${port}`)
-        resolve([Object.assign({}, secureOpts, { port }), server])
+        resolve([Object.assign({}, secureOpts, { port, certFingerprint }), server])
       })
     })
   } else {
@@ -68,6 +76,13 @@ function buildServer (handler, opts, cb) {
       cb(Object.assign({}, secureOpts, { port }), server)
     })
   }
+}
+
+function getFingerprint (content, inputEncoding = 'base64', outputEncoding = 'hex') {
+  const shasum = crypto.createHash('sha1')
+  shasum.update(content, inputEncoding)
+  const res = shasum.digest(outputEncoding)
+  return res.toUpperCase().match(/.{1,2}/g).join(':')
 }
 
 module.exports = buildServer


### PR DESCRIPTION
As titled.

Usage: 
```js
const client = new Client({
  node: 'https://localhost:9200',
  caFingerprint: 'string'
})
```

TODO:
- [x] More unit test
- [x] Docs
- [ ] ~~Integration test with Elasticsearch~~
