### PR TITLE
Show the body as string if the response error can't be read as ES error

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -97,8 +97,10 @@ class ResponseError extends ElasticsearchClientError {
       } else {
         this.message = meta.body.error.type
       }
+    } else if (typeof meta.body === 'object' && meta.body != null) {
+      this.message = JSON.stringify(meta.body)
     } else {
-      this.message = 'Response Error'
+      this.message = meta.body || 'Response Error'
     }
     this.meta = meta
   }

--- a/test/acceptance/product-check.test.js
+++ b/test/acceptance/product-check.test.js
@@ -649,7 +649,7 @@ test('500 error', t => {
       }
     }
   }, (err, result) => {
-    t.equal(err.message, 'Response Error')
+    t.equal(err.message, '{"error":"kaboom"}')
 
     client.search({
       index: 'foo',

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -197,3 +197,29 @@ test('ResponseError with meaningful message / 3', t => {
   t.equal(err.toString(), JSON.stringify(meta.body))
   t.end()
 })
+
+test('ResponseError with meaningful message when body is not json', t => {
+  const meta = {
+    statusCode: 400,
+    body: '<html><body>error!</body></html>',
+    headers: { 'content-type': 'text/html' }
+  }
+  const err = new errors.ResponseError(meta)
+  t.equal(err.name, 'ResponseError')
+  t.equal(err.message, '<html><body>error!</body></html>')
+  t.equal(err.toString(), JSON.stringify(meta.body))
+  t.end()
+})
+
+test('ResponseError with meaningful message when body is falsy', t => {
+  const meta = {
+    statusCode: 400,
+    body: '',
+    headers: { 'content-type': 'text/plain' }
+  }
+  const err = new errors.ResponseError(meta)
+  t.equal(err.name, 'ResponseError')
+  t.equal(err.message, 'Response Error')
+  t.equal(err.toString(), JSON.stringify(meta.body))
+  t.end()
+})


### PR DESCRIPTION
As titled.

Closes: #1507 