### PR TITLE
Always display request params and options in request event

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -420,8 +420,8 @@ class Transport {
       // handles request timeout
       params.timeout = toMs(options.requestTimeout || this.requestTimeout)
       if (options.asStream === true) params.asStream = true
-      meta.request.params = params
-      meta.request.options = options
+      // meta.request.params = params
+      // meta.request.options = options
 
       // handle compression
       if (params.body !== '' && params.body != null) {
@@ -452,6 +452,8 @@ class Transport {
       }
     }
 
+    meta.request.params = params
+    meta.request.options = options
     // still need to check the product or waiting for the check to finish
     if (this[kProductCheck] === 0 || this[kProductCheck] === 1) {
       // let pass info requests

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -420,8 +420,6 @@ class Transport {
       // handles request timeout
       params.timeout = toMs(options.requestTimeout || this.requestTimeout)
       if (options.asStream === true) params.asStream = true
-      // meta.request.params = params
-      // meta.request.options = options
 
       // handle compression
       if (params.body !== '' && params.body != null) {

--- a/test/acceptance/product-check.test.js
+++ b/test/acceptance/product-check.test.js
@@ -1247,3 +1247,41 @@ test('No multiple checks with child clients', t => {
     })
   }, 100)
 })
+
+test('Observability events should have all the expected properties', t => {
+  t.plan(5)
+  const MockConnection = buildMockConnection({
+    onRequest (params) {
+      return {
+        statusCode: 200,
+        body: {
+          name: '1ef419078577',
+          cluster_name: 'docker-cluster',
+          cluster_uuid: 'cQ5pAMvRRTyEzObH4L5mTA',
+          tagline: 'You Know, for Search'
+        }
+      }
+    }
+  })
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  client.on('request', (e, event) => {
+    t.ok(event.meta.request.params)
+    t.ok(event.meta.request.options)
+  })
+
+  client.search({
+    index: 'foo',
+    body: {
+      query: {
+        match_all: {}
+      }
+    }
+  }, (err, result) => {
+    t.equal(err.message, 'The client noticed that the server is not Elasticsearch and we do not support this unknown product.')
+  })
+})


### PR DESCRIPTION
As titled.

Closes: https://github.com/elastic/elasticsearch-js/issues/1516