### PR TITLE
Always emit request aborted event

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -182,6 +182,7 @@ class Transport {
 
     const makeRequest = () => {
       if (meta.aborted === true) {
+        this.emit('request', new RequestAbortedError(), result)
         return process.nextTick(callback, new RequestAbortedError(), result)
       }
       meta.connection = this.getConnection({ requestId: meta.request.id })

--- a/test/acceptance/product-check.test.js
+++ b/test/acceptance/product-check.test.js
@@ -20,7 +20,7 @@
 'use strict'
 
 const { test } = require('tap')
-const { Client } = require('../../')
+const { Client, errors } = require('../../')
 const {
   connection: {
     MockConnectionTimeout,
@@ -1246,4 +1246,65 @@ test('No multiple checks with child clients', t => {
       t.error(err)
     })
   }, 100)
+})
+
+test('Abort a request while running the product check', t => {
+  t.plan(4)
+  const MockConnection = buildMockConnection({
+    onRequest (params) {
+      return {
+        statusCode: 200,
+        headers: {
+          'x-elastic-product': 'Elasticsearch'
+        },
+        body: {
+          name: '1ef419078577',
+          cluster_name: 'docker-cluster',
+          cluster_uuid: 'cQ5pAMvRRTyEzObH4L5mTA',
+          version: {
+            number: '8.0.0-SNAPSHOT',
+            build_flavor: 'default',
+            build_type: 'docker',
+            build_hash: '5fb4c050958a6b0b6a70a6fb3e616d0e390eaac3',
+            build_date: '2021-07-10T01:45:02.136546168Z',
+            build_snapshot: true,
+            lucene_version: '8.9.0',
+            minimum_wire_compatibility_version: '7.15.0',
+            minimum_index_compatibility_version: '7.0.0'
+          },
+          tagline: 'You Know, for Search'
+        }
+      }
+    }
+  })
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  client.on('request', (err, event) => {
+    if (event.meta.request.params.path.includes('search')) {
+      t.ok(err instanceof errors.RequestAbortedError)
+    }
+  })
+
+  // the response event won't be executed for the search
+  client.on('response', (err, event) => {
+    t.error(err)
+    t.equal(event.meta.request.params.path, '/')
+  })
+
+  const req = client.search({
+    index: 'foo',
+    body: {
+      query: {
+        match_all: {}
+      }
+    }
+  }, (err, result) => {
+    t.ok(err instanceof errors.RequestAbortedError)
+  })
+
+  setImmediate(() => req.abort())
 })


### PR DESCRIPTION
If the client is busy running an async operation, the `.abort()` call might be executed before sending the actual request. In such case, the error was swallowed, now it will always be emitted, either in the `request` or `response` event.

Closes: #1517