### PR TITLE
[DOCS] Adds a link to the Quick Start section that points to an EC ingest example

### DIFF
--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -133,7 +133,8 @@ async function run () {
 run().catch(console.log)
 ----
 
-For a more elaborate example of how to ingest data into Elastic Cloud,refer to 
+TIP: For a more elaborate example of how to ingest data into Elastic Cloud, 
+refer to {cloud}/ec-getting-started-node-js.html[this page].
 
 [discrete]
 ==== Install multiple versions

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -134,7 +134,6 @@ run().catch(console.log)
 ----
 
 For a more elaborate example of how to ingest data into Elastic Cloud,refer to 
-{cloud}/ec-getting-started-node-js.html[this page].
 
 [discrete]
 ==== Install multiple versions

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -133,7 +133,7 @@ async function run () {
 run().catch(console.log)
 ----
 
-TIP: For a more elaborate example of how to ingest data into Elastic Cloud, 
+TIP: For an elaborate example of how to ingest data into Elastic Cloud, 
 refer to {cloud}/ec-getting-started-node-js.html[this page].
 
 [discrete]

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -133,6 +133,9 @@ async function run () {
 run().catch(console.log)
 ----
 
+For a more elaborate example of how to ingest data into Elastic Cloud,refer to 
+{cloud}/ec-getting-started-node-js.html[this page].
+
 [discrete]
 ==== Install multiple versions
 


### PR DESCRIPTION
## Overview

As the title states.

### Preview

[Quick Start](https://elasticsearch-js_1546.docs-preview.app.elstc.co/guide/en/elasticsearch/client/javascript-api/master/introduction.html#_quick_start)