### PR TITLE
Add metadata_field to FieldCapsFieldCapability

### DIFF
--- a/api/types.d.ts
+++ b/api/types.d.ts
@@ -374,6 +374,7 @@ export interface FieldCapsFieldCapability {
   non_searchable_indices?: Indices
   searchable: boolean
   type: string
+  metadata_field?: boolean
 }
 
 export interface FieldCapsRequest extends RequestBase {


### PR DESCRIPTION
Update typescript type info to account for `metadata_field` on `FieldCapsFieldCapability`