### PR TITLE
[7.x] [DOCS] Retitle Elasticsearch JavaScript Client doc book

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-= Elasticsearch Node.js client
+= Elasticsearch JavaScript Client
 
 :branch: 7.x
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]


### PR DESCRIPTION
7.x backport of https://github.com/elastic/elasticsearch-js/pull/1564.

Relates to https://github.com/elastic/docs/pull/2245