### PR TITLE
[DOCS] Fixes broken link to 7.x documentation

### DIFF
--- a/docs/authentication.asciidoc
+++ b/docs/authentication.asciidoc
@@ -60,7 +60,7 @@ const client = new Client({
 === ApiKey authentication
 
 You can use the https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-api-create-api-key.html[ApiKey] authentication by passing the `apiKey` parameter via the `auth` option. +
-The `apiKey` parameter can be either a base64 encoded string or an object with the values that you can obtain from the https://www.elastic.co/guide/en/elasticsearch/reference/7.x/security-api-create-api-key.html[create api key endpoint].
+The `apiKey` parameter can be either a base64 encoded string or an object with the values that you can obtain from the {ref-7x}/security-api-create-api-key.html[create api key endpoint].
 
 NOTE: If you provide both basic authentication credentials and the Api Key configuration, the Api Key will take precedence.
 


### PR DESCRIPTION
Fixes broken link in https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/6.x/_apikey_authentication.html#_apikey_authentication
