### PR TITLE
Hard code jsclient links to 7.x

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -3,6 +3,11 @@
 :branch: 7.16
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
+// 7.x exists in this repo but not in stack repos
+// This line overwrites the jsclient attribute so it can point to 7.x, but stack links can point to 7.16
+// Remove this line when a 7.16 branch exists in this repo
+:jsclient: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/7.x
+
 include::introduction.asciidoc[]
 include::installation.asciidoc[]
 include::connecting.asciidoc[]


### PR DESCRIPTION
`7.x` exists in the JS Client, but not in the stack docs. This PR allows stack links to point to `7.16` and JS client links to point to `7.x`.

This addition should be reverted when this repo's `7.x` branch is renamed to `7.16`.