### PR TITLE
Aggregations should be a generic in responses

### DIFF
--- a/src/api/api/bulk.ts
+++ b/src/api/api/bulk.ts
@@ -41,7 +41,7 @@ export default async function BulkApi<TSource = unknown> (this: That, params: T.
 export default async function BulkApi<TSource = unknown> (this: That, params: T.BulkRequest<TSource> | TB.BulkRequest<TSource>, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.BulkResponse, unknown>>
 export default async function BulkApi<TSource = unknown> (this: That, params: T.BulkRequest<TSource> | TB.BulkRequest<TSource>, options?: TransportRequestOptions): Promise<T.BulkResponse>
 export default async function BulkApi<TSource = unknown> (this: That, params: T.BulkRequest<TSource> | TB.BulkRequest<TSource>, options?: TransportRequestOptions): Promise<any> {
-  const acceptedPath: string[] = ['index', 'type']
+  const acceptedPath: string[] = ['index']
   const acceptedBody: string[] = ['operations']
   const querystring: Record<string, any> = {}
   // @ts-expect-error
@@ -61,10 +61,7 @@ export default async function BulkApi<TSource = unknown> (this: That, params: T.
 
   let method = ''
   let path = ''
-  if (params.index != null && params.type != null) {
-    method = 'POST'
-    path = `/${encodeURIComponent(params.index.toString())}/${encodeURIComponent(params.type.toString())}/_bulk`
-  } else if (params.index != null) {
+  if (params.index != null) {
     method = 'POST'
     path = `/${encodeURIComponent(params.index.toString())}/_bulk`
   } else {

--- a/src/api/api/create.ts
+++ b/src/api/api/create.ts
@@ -41,7 +41,7 @@ export default async function CreateApi<TDocument = unknown> (this: That, params
 export default async function CreateApi<TDocument = unknown> (this: That, params: T.CreateRequest<TDocument> | TB.CreateRequest<TDocument>, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.CreateResponse, unknown>>
 export default async function CreateApi<TDocument = unknown> (this: That, params: T.CreateRequest<TDocument> | TB.CreateRequest<TDocument>, options?: TransportRequestOptions): Promise<T.CreateResponse>
 export default async function CreateApi<TDocument = unknown> (this: That, params: T.CreateRequest<TDocument> | TB.CreateRequest<TDocument>, options?: TransportRequestOptions): Promise<any> {
-  const acceptedPath: string[] = ['id', 'index', 'type']
+  const acceptedPath: string[] = ['id', 'index']
   const acceptedBody: string[] = ['document']
   const querystring: Record<string, any> = {}
   // @ts-expect-error

--- a/src/api/api/delete.ts
+++ b/src/api/api/delete.ts
@@ -41,7 +41,7 @@ export default async function DeleteApi (this: That, params: T.DeleteRequest | T
 export default async function DeleteApi (this: That, params: T.DeleteRequest | TB.DeleteRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.DeleteResponse, unknown>>
 export default async function DeleteApi (this: That, params: T.DeleteRequest | TB.DeleteRequest, options?: TransportRequestOptions): Promise<T.DeleteResponse>
 export default async function DeleteApi (this: That, params: T.DeleteRequest | TB.DeleteRequest, options?: TransportRequestOptions): Promise<any> {
-  const acceptedPath: string[] = ['id', 'index', 'type']
+  const acceptedPath: string[] = ['id', 'index']
   const querystring: Record<string, any> = {}
   const body = undefined
 

--- a/src/api/api/exists_source.ts
+++ b/src/api/api/exists_source.ts
@@ -41,7 +41,7 @@ export default async function ExistsSourceApi (this: That, params: T.ExistsSourc
 export default async function ExistsSourceApi (this: That, params: T.ExistsSourceRequest | TB.ExistsSourceRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.ExistsSourceResponse, unknown>>
 export default async function ExistsSourceApi (this: That, params: T.ExistsSourceRequest | TB.ExistsSourceRequest, options?: TransportRequestOptions): Promise<T.ExistsSourceResponse>
 export default async function ExistsSourceApi (this: That, params: T.ExistsSourceRequest | TB.ExistsSourceRequest, options?: TransportRequestOptions): Promise<any> {
-  const acceptedPath: string[] = ['id', 'index', 'type']
+  const acceptedPath: string[] = ['id', 'index']
   const querystring: Record<string, any> = {}
   const body = undefined
 

--- a/src/api/api/indices.ts
+++ b/src/api/api/indices.ts
@@ -513,28 +513,6 @@ export default class Indices {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
-  async existsType (this: That, params: T.IndicesExistsTypeRequest | TB.IndicesExistsTypeRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.IndicesExistsTypeResponse>
-  async existsType (this: That, params: T.IndicesExistsTypeRequest | TB.IndicesExistsTypeRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.IndicesExistsTypeResponse, unknown>>
-  async existsType (this: That, params: T.IndicesExistsTypeRequest | TB.IndicesExistsTypeRequest, options?: TransportRequestOptions): Promise<T.IndicesExistsTypeResponse>
-  async existsType (this: That, params: T.IndicesExistsTypeRequest | TB.IndicesExistsTypeRequest, options?: TransportRequestOptions): Promise<any> {
-    const acceptedPath: string[] = ['index', 'type']
-    const querystring: Record<string, any> = {}
-    const body = undefined
-
-    for (const key in params) {
-      if (acceptedPath.includes(key)) {
-        continue
-      } else if (key !== 'body') {
-        // @ts-expect-error
-        querystring[key] = params[key]
-      }
-    }
-
-    const method = 'HEAD'
-    const path = `/${encodeURIComponent(params.index.toString())}/_mapping/${encodeURIComponent(params.type.toString())}`
-    return await this.transport.request({ path, method, querystring, body }, options)
-  }
-
   async fieldUsageStats (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithOutMeta): Promise<T.TODO>
   async fieldUsageStats (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.TODO, unknown>>
   async fieldUsageStats (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<T.TODO>
@@ -1563,7 +1541,7 @@ export default class Indices {
   async validateQuery (this: That, params?: T.IndicesValidateQueryRequest | TB.IndicesValidateQueryRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.IndicesValidateQueryResponse, unknown>>
   async validateQuery (this: That, params?: T.IndicesValidateQueryRequest | TB.IndicesValidateQueryRequest, options?: TransportRequestOptions): Promise<T.IndicesValidateQueryResponse>
   async validateQuery (this: That, params?: T.IndicesValidateQueryRequest | TB.IndicesValidateQueryRequest, options?: TransportRequestOptions): Promise<any> {
-    const acceptedPath: string[] = ['index', 'type']
+    const acceptedPath: string[] = ['index']
     const acceptedBody: string[] = ['query']
     const querystring: Record<string, any> = {}
     // @ts-expect-error

--- a/src/api/api/ml.ts
+++ b/src/api/api/ml.ts
@@ -937,6 +937,28 @@ export default class Ml {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
+  async getModelSnapshotUpgradeStats (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithOutMeta): Promise<T.TODO>
+  async getModelSnapshotUpgradeStats (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.TODO, unknown>>
+  async getModelSnapshotUpgradeStats (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<T.TODO>
+  async getModelSnapshotUpgradeStats (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<any> {
+    const acceptedPath: string[] = ['job_id', 'snapshot_id']
+    const querystring: Record<string, any> = {}
+    const body = undefined
+
+    params = params ?? {}
+    for (const key in params) {
+      if (acceptedPath.includes(key)) {
+        continue
+      } else if (key !== 'body') {
+        querystring[key] = params[key]
+      }
+    }
+
+    const method = 'GET'
+    const path = `/_ml/anomaly_detectors/${encodeURIComponent(params.job_id.toString())}/model_snapshots/${encodeURIComponent(params.snapshot_id.toString())}/_upgrade/_stats`
+    return await this.transport.request({ path, method, querystring, body }, options)
+  }
+
   async getModelSnapshots (this: That, params: T.MlGetModelSnapshotsRequest | TB.MlGetModelSnapshotsRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MlGetModelSnapshotsResponse>
   async getModelSnapshots (this: That, params: T.MlGetModelSnapshotsRequest | TB.MlGetModelSnapshotsRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MlGetModelSnapshotsResponse, unknown>>
   async getModelSnapshots (this: That, params: T.MlGetModelSnapshotsRequest | TB.MlGetModelSnapshotsRequest, options?: TransportRequestOptions): Promise<T.MlGetModelSnapshotsResponse>
@@ -1106,19 +1128,31 @@ export default class Ml {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
-  async inferTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithOutMeta): Promise<T.TODO>
-  async inferTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.TODO, unknown>>
-  async inferTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<T.TODO>
-  async inferTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<any> {
+  async inferTrainedModelDeployment (this: That, params: T.MlInferTrainedModelDeploymentRequest | TB.MlInferTrainedModelDeploymentRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MlInferTrainedModelDeploymentResponse>
+  async inferTrainedModelDeployment (this: That, params: T.MlInferTrainedModelDeploymentRequest | TB.MlInferTrainedModelDeploymentRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MlInferTrainedModelDeploymentResponse, unknown>>
+  async inferTrainedModelDeployment (this: That, params: T.MlInferTrainedModelDeploymentRequest | TB.MlInferTrainedModelDeploymentRequest, options?: TransportRequestOptions): Promise<T.MlInferTrainedModelDeploymentResponse>
+  async inferTrainedModelDeployment (this: That, params: T.MlInferTrainedModelDeploymentRequest | TB.MlInferTrainedModelDeploymentRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = ['model_id']
+    const acceptedBody: string[] = ['docs']
     const querystring: Record<string, any> = {}
-    const body = undefined
+    // @ts-expect-error
+    const userBody: any = params?.body
+    let body: Record<string, any> | string
+    if (typeof userBody === 'string') {
+      body = userBody
+    } else {
+      body = userBody != null ? { ...userBody } : undefined
+    }
 
-    params = params ?? {}
     for (const key in params) {
-      if (acceptedPath.includes(key)) {
+      if (acceptedBody.includes(key)) {
+        body = body ?? {}
+        // @ts-expect-error
+        body[key] = params[key]
+      } else if (acceptedPath.includes(key)) {
         continue
       } else if (key !== 'body') {
+        // @ts-expect-error
         querystring[key] = params[key]
       }
     }
@@ -1578,19 +1612,31 @@ export default class Ml {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
-  async putTrainedModelDefinitionPart (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithOutMeta): Promise<T.TODO>
-  async putTrainedModelDefinitionPart (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.TODO, unknown>>
-  async putTrainedModelDefinitionPart (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<T.TODO>
-  async putTrainedModelDefinitionPart (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<any> {
+  async putTrainedModelDefinitionPart (this: That, params: T.MlPutTrainedModelDefinitionPartRequest | TB.MlPutTrainedModelDefinitionPartRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MlPutTrainedModelDefinitionPartResponse>
+  async putTrainedModelDefinitionPart (this: That, params: T.MlPutTrainedModelDefinitionPartRequest | TB.MlPutTrainedModelDefinitionPartRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MlPutTrainedModelDefinitionPartResponse, unknown>>
+  async putTrainedModelDefinitionPart (this: That, params: T.MlPutTrainedModelDefinitionPartRequest | TB.MlPutTrainedModelDefinitionPartRequest, options?: TransportRequestOptions): Promise<T.MlPutTrainedModelDefinitionPartResponse>
+  async putTrainedModelDefinitionPart (this: That, params: T.MlPutTrainedModelDefinitionPartRequest | TB.MlPutTrainedModelDefinitionPartRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = ['model_id', 'part']
+    const acceptedBody: string[] = ['definition', 'total_definition_length', 'total_parts']
     const querystring: Record<string, any> = {}
-    const body = undefined
+    // @ts-expect-error
+    const userBody: any = params?.body
+    let body: Record<string, any> | string
+    if (typeof userBody === 'string') {
+      body = userBody
+    } else {
+      body = userBody != null ? { ...userBody } : undefined
+    }
 
-    params = params ?? {}
     for (const key in params) {
-      if (acceptedPath.includes(key)) {
+      if (acceptedBody.includes(key)) {
+        body = body ?? {}
+        // @ts-expect-error
+        body[key] = params[key]
+      } else if (acceptedPath.includes(key)) {
         continue
       } else if (key !== 'body') {
+        // @ts-expect-error
         querystring[key] = params[key]
       }
     }
@@ -1600,19 +1646,31 @@ export default class Ml {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
-  async putTrainedModelVocabulary (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithOutMeta): Promise<T.TODO>
-  async putTrainedModelVocabulary (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.TODO, unknown>>
-  async putTrainedModelVocabulary (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<T.TODO>
-  async putTrainedModelVocabulary (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<any> {
+  async putTrainedModelVocabulary (this: That, params: T.MlPutTrainedModelVocabularyRequest | TB.MlPutTrainedModelVocabularyRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MlPutTrainedModelVocabularyResponse>
+  async putTrainedModelVocabulary (this: That, params: T.MlPutTrainedModelVocabularyRequest | TB.MlPutTrainedModelVocabularyRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MlPutTrainedModelVocabularyResponse, unknown>>
+  async putTrainedModelVocabulary (this: That, params: T.MlPutTrainedModelVocabularyRequest | TB.MlPutTrainedModelVocabularyRequest, options?: TransportRequestOptions): Promise<T.MlPutTrainedModelVocabularyResponse>
+  async putTrainedModelVocabulary (this: That, params: T.MlPutTrainedModelVocabularyRequest | TB.MlPutTrainedModelVocabularyRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = ['model_id']
+    const acceptedBody: string[] = ['vocabulary']
     const querystring: Record<string, any> = {}
-    const body = undefined
+    // @ts-expect-error
+    const userBody: any = params?.body
+    let body: Record<string, any> | string
+    if (typeof userBody === 'string') {
+      body = userBody
+    } else {
+      body = userBody != null ? { ...userBody } : undefined
+    }
 
-    params = params ?? {}
     for (const key in params) {
-      if (acceptedPath.includes(key)) {
+      if (acceptedBody.includes(key)) {
+        body = body ?? {}
+        // @ts-expect-error
+        body[key] = params[key]
+      } else if (acceptedPath.includes(key)) {
         continue
       } else if (key !== 'body') {
+        // @ts-expect-error
         querystring[key] = params[key]
       }
     }
@@ -1757,19 +1815,19 @@ export default class Ml {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
-  async startTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithOutMeta): Promise<T.TODO>
-  async startTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.TODO, unknown>>
-  async startTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<T.TODO>
-  async startTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<any> {
+  async startTrainedModelDeployment (this: That, params: T.MlStartTrainedModelDeploymentRequest | TB.MlStartTrainedModelDeploymentRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MlStartTrainedModelDeploymentResponse>
+  async startTrainedModelDeployment (this: That, params: T.MlStartTrainedModelDeploymentRequest | TB.MlStartTrainedModelDeploymentRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MlStartTrainedModelDeploymentResponse, unknown>>
+  async startTrainedModelDeployment (this: That, params: T.MlStartTrainedModelDeploymentRequest | TB.MlStartTrainedModelDeploymentRequest, options?: TransportRequestOptions): Promise<T.MlStartTrainedModelDeploymentResponse>
+  async startTrainedModelDeployment (this: That, params: T.MlStartTrainedModelDeploymentRequest | TB.MlStartTrainedModelDeploymentRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = ['model_id']
     const querystring: Record<string, any> = {}
     const body = undefined
 
-    params = params ?? {}
     for (const key in params) {
       if (acceptedPath.includes(key)) {
         continue
       } else if (key !== 'body') {
+        // @ts-expect-error
         querystring[key] = params[key]
       }
     }
@@ -1835,19 +1893,19 @@ export default class Ml {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
-  async stopTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithOutMeta): Promise<T.TODO>
-  async stopTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.TODO, unknown>>
-  async stopTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<T.TODO>
-  async stopTrainedModelDeployment (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<any> {
+  async stopTrainedModelDeployment (this: That, params: T.MlStopTrainedModelDeploymentRequest | TB.MlStopTrainedModelDeploymentRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MlStopTrainedModelDeploymentResponse>
+  async stopTrainedModelDeployment (this: That, params: T.MlStopTrainedModelDeploymentRequest | TB.MlStopTrainedModelDeploymentRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MlStopTrainedModelDeploymentResponse, unknown>>
+  async stopTrainedModelDeployment (this: That, params: T.MlStopTrainedModelDeploymentRequest | TB.MlStopTrainedModelDeploymentRequest, options?: TransportRequestOptions): Promise<T.MlStopTrainedModelDeploymentResponse>
+  async stopTrainedModelDeployment (this: That, params: T.MlStopTrainedModelDeploymentRequest | TB.MlStopTrainedModelDeploymentRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = ['model_id']
     const querystring: Record<string, any> = {}
     const body = undefined
 
-    params = params ?? {}
     for (const key in params) {
       if (acceptedPath.includes(key)) {
         continue
       } else if (key !== 'body') {
+        // @ts-expect-error
         querystring[key] = params[key]
       }
     }

--- a/src/api/api/msearch.ts
+++ b/src/api/api/msearch.ts
@@ -37,10 +37,10 @@ import * as T from '../types'
 import * as TB from '../typesWithBodyKey'
 interface That { transport: Transport }
 
-export default async function MsearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MsearchResponse<TDocument, TAggregation>>
-export default async function MsearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MsearchResponse<TDocument, TAggregation>, unknown>>
-export default async function MsearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptions): Promise<T.MsearchResponse<TDocument, TAggregation>>
-export default async function MsearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptions): Promise<any> {
+export default async function MsearchApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MsearchResponse<TDocument, TAggregations>>
+export default async function MsearchApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MsearchResponse<TDocument, TAggregations>, unknown>>
+export default async function MsearchApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptions): Promise<T.MsearchResponse<TDocument, TAggregations>>
+export default async function MsearchApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptions): Promise<any> {
   const acceptedPath: string[] = ['index']
   const acceptedBody: string[] = ['searches']
   const querystring: Record<string, any> = {}

--- a/src/api/api/msearch.ts
+++ b/src/api/api/msearch.ts
@@ -37,10 +37,10 @@ import * as T from '../types'
 import * as TB from '../typesWithBodyKey'
 interface That { transport: Transport }
 
-export default async function MsearchApi<TDocument = unknown> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MsearchResponse<TDocument>>
-export default async function MsearchApi<TDocument = unknown> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MsearchResponse<TDocument>, unknown>>
-export default async function MsearchApi<TDocument = unknown> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptions): Promise<T.MsearchResponse<TDocument>>
-export default async function MsearchApi<TDocument = unknown> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptions): Promise<any> {
+export default async function MsearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MsearchResponse<TDocument, TAggregation>>
+export default async function MsearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MsearchResponse<TDocument, TAggregation>, unknown>>
+export default async function MsearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptions): Promise<T.MsearchResponse<TDocument, TAggregation>>
+export default async function MsearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchRequest | TB.MsearchRequest, options?: TransportRequestOptions): Promise<any> {
   const acceptedPath: string[] = ['index']
   const acceptedBody: string[] = ['searches']
   const querystring: Record<string, any> = {}

--- a/src/api/api/msearch_template.ts
+++ b/src/api/api/msearch_template.ts
@@ -37,10 +37,10 @@ import * as T from '../types'
 import * as TB from '../typesWithBodyKey'
 interface That { transport: Transport }
 
-export default async function MsearchTemplateApi<TDocument = unknown> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MsearchTemplateResponse<TDocument>>
-export default async function MsearchTemplateApi<TDocument = unknown> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MsearchTemplateResponse<TDocument>, unknown>>
-export default async function MsearchTemplateApi<TDocument = unknown> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptions): Promise<T.MsearchTemplateResponse<TDocument>>
-export default async function MsearchTemplateApi<TDocument = unknown> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptions): Promise<any> {
+export default async function MsearchTemplateApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MsearchTemplateResponse<TDocument, TAggregation>>
+export default async function MsearchTemplateApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MsearchTemplateResponse<TDocument, TAggregation>, unknown>>
+export default async function MsearchTemplateApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptions): Promise<T.MsearchTemplateResponse<TDocument, TAggregation>>
+export default async function MsearchTemplateApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptions): Promise<any> {
   const acceptedPath: string[] = ['index']
   const acceptedBody: string[] = ['search_templates']
   const querystring: Record<string, any> = {}

--- a/src/api/api/msearch_template.ts
+++ b/src/api/api/msearch_template.ts
@@ -37,10 +37,10 @@ import * as T from '../types'
 import * as TB from '../typesWithBodyKey'
 interface That { transport: Transport }
 
-export default async function MsearchTemplateApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MsearchTemplateResponse<TDocument, TAggregation>>
-export default async function MsearchTemplateApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MsearchTemplateResponse<TDocument, TAggregation>, unknown>>
-export default async function MsearchTemplateApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptions): Promise<T.MsearchTemplateResponse<TDocument, TAggregation>>
-export default async function MsearchTemplateApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptions): Promise<any> {
+export default async function MsearchTemplateApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.MsearchTemplateResponse<TDocument, TAggregations>>
+export default async function MsearchTemplateApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.MsearchTemplateResponse<TDocument, TAggregations>, unknown>>
+export default async function MsearchTemplateApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptions): Promise<T.MsearchTemplateResponse<TDocument, TAggregations>>
+export default async function MsearchTemplateApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.MsearchTemplateRequest | TB.MsearchTemplateRequest, options?: TransportRequestOptions): Promise<any> {
   const acceptedPath: string[] = ['index']
   const acceptedBody: string[] = ['search_templates']
   const querystring: Record<string, any> = {}

--- a/src/api/api/rollup.ts
+++ b/src/api/api/rollup.ts
@@ -208,10 +208,10 @@ export default class Rollup {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
-  async rollupSearch<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.RollupRollupSearchResponse<TDocument, TAggregation>>
-  async rollupSearch<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.RollupRollupSearchResponse<TDocument, TAggregation>, unknown>>
-  async rollupSearch<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<T.RollupRollupSearchResponse<TDocument, TAggregation>>
-  async rollupSearch<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<any> {
+  async rollupSearch<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.RollupRollupSearchResponse<TDocument, TAggregations>>
+  async rollupSearch<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.RollupRollupSearchResponse<TDocument, TAggregations>, unknown>>
+  async rollupSearch<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<T.RollupRollupSearchResponse<TDocument, TAggregations>>
+  async rollupSearch<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = ['index', 'type']
     const acceptedBody: string[] = ['aggregations', 'query', 'size']
     const querystring: Record<string, any> = {}

--- a/src/api/api/rollup.ts
+++ b/src/api/api/rollup.ts
@@ -208,10 +208,10 @@ export default class Rollup {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
-  async rollupSearch<TDocument = unknown> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.RollupRollupSearchResponse<TDocument>>
-  async rollupSearch<TDocument = unknown> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.RollupRollupSearchResponse<TDocument>, unknown>>
-  async rollupSearch<TDocument = unknown> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<T.RollupRollupSearchResponse<TDocument>>
-  async rollupSearch<TDocument = unknown> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<any> {
+  async rollupSearch<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.RollupRollupSearchResponse<TDocument, TAggregation>>
+  async rollupSearch<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.RollupRollupSearchResponse<TDocument, TAggregation>, unknown>>
+  async rollupSearch<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<T.RollupRollupSearchResponse<TDocument, TAggregation>>
+  async rollupSearch<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = ['index', 'type']
     const acceptedBody: string[] = ['aggregations', 'query', 'size']
     const querystring: Record<string, any> = {}

--- a/src/api/api/rollup.ts
+++ b/src/api/api/rollup.ts
@@ -212,7 +212,7 @@ export default class Rollup {
   async rollupSearch<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.RollupRollupSearchResponse<TDocument, TAggregations>, unknown>>
   async rollupSearch<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<T.RollupRollupSearchResponse<TDocument, TAggregations>>
   async rollupSearch<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<any> {
-    const acceptedPath: string[] = ['index', 'type']
+    const acceptedPath: string[] = ['index']
     const acceptedBody: string[] = ['aggregations', 'aggs', 'query', 'size']
     const querystring: Record<string, any> = {}
     // @ts-expect-error

--- a/src/api/api/scroll.ts
+++ b/src/api/api/scroll.ts
@@ -37,10 +37,10 @@ import * as T from '../types'
 import * as TB from '../typesWithBodyKey'
 interface That { transport: Transport }
 
-export default async function ScrollApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.ScrollResponse<TDocument, TAggregation>>
-export default async function ScrollApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.ScrollResponse<TDocument, TAggregation>, unknown>>
-export default async function ScrollApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptions): Promise<T.ScrollResponse<TDocument, TAggregation>>
-export default async function ScrollApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptions): Promise<any> {
+export default async function ScrollApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.ScrollResponse<TDocument, TAggregations>>
+export default async function ScrollApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.ScrollResponse<TDocument, TAggregations>, unknown>>
+export default async function ScrollApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptions): Promise<T.ScrollResponse<TDocument, TAggregations>>
+export default async function ScrollApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptions): Promise<any> {
   const acceptedPath: string[] = []
   const acceptedBody: string[] = ['scroll', 'scroll_id']
   const querystring: Record<string, any> = {}

--- a/src/api/api/scroll.ts
+++ b/src/api/api/scroll.ts
@@ -37,10 +37,10 @@ import * as T from '../types'
 import * as TB from '../typesWithBodyKey'
 interface That { transport: Transport }
 
-export default async function ScrollApi<TDocument = unknown> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.ScrollResponse<TDocument>>
-export default async function ScrollApi<TDocument = unknown> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.ScrollResponse<TDocument>, unknown>>
-export default async function ScrollApi<TDocument = unknown> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptions): Promise<T.ScrollResponse<TDocument>>
-export default async function ScrollApi<TDocument = unknown> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptions): Promise<any> {
+export default async function ScrollApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.ScrollResponse<TDocument, TAggregation>>
+export default async function ScrollApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.ScrollResponse<TDocument, TAggregation>, unknown>>
+export default async function ScrollApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptions): Promise<T.ScrollResponse<TDocument, TAggregation>>
+export default async function ScrollApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.ScrollRequest | TB.ScrollRequest, options?: TransportRequestOptions): Promise<any> {
   const acceptedPath: string[] = []
   const acceptedBody: string[] = ['scroll', 'scroll_id']
   const querystring: Record<string, any> = {}

--- a/src/api/api/search.ts
+++ b/src/api/api/search.ts
@@ -37,10 +37,10 @@ import * as T from '../types'
 import * as TB from '../typesWithBodyKey'
 interface That { transport: Transport }
 
-export default async function SearchApi<TDocument = unknown> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.SearchResponse<TDocument>>
-export default async function SearchApi<TDocument = unknown> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.SearchResponse<TDocument>, unknown>>
-export default async function SearchApi<TDocument = unknown> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptions): Promise<T.SearchResponse<TDocument>>
-export default async function SearchApi<TDocument = unknown> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptions): Promise<any> {
+export default async function SearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.SearchResponse<TDocument, TAggregation>>
+export default async function SearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.SearchResponse<TDocument, TAggregation>, unknown>>
+export default async function SearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptions): Promise<T.SearchResponse<TDocument, TAggregation>>
+export default async function SearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptions): Promise<any> {
   const acceptedPath: string[] = ['index']
   const acceptedBody: string[] = ['aggregations', 'collapse', 'explain', 'from', 'highlight', 'track_total_hits', 'indices_boost', 'docvalue_fields', 'min_score', 'post_filter', 'profile', 'query', 'rescore', 'script_fields', 'search_after', 'size', 'slice', 'sort', '_source', 'fields', 'suggest', 'terminate_after', 'timeout', 'track_scores', 'version', 'seq_no_primary_term', 'stored_fields', 'pit', 'runtime_mappings', 'stats']
   const querystring: Record<string, any> = {}

--- a/src/api/api/search.ts
+++ b/src/api/api/search.ts
@@ -37,10 +37,10 @@ import * as T from '../types'
 import * as TB from '../typesWithBodyKey'
 interface That { transport: Transport }
 
-export default async function SearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.SearchResponse<TDocument, TAggregation>>
-export default async function SearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.SearchResponse<TDocument, TAggregation>, unknown>>
-export default async function SearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptions): Promise<T.SearchResponse<TDocument, TAggregation>>
-export default async function SearchApi<TDocument = unknown, TAggregation = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptions): Promise<any> {
+export default async function SearchApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.SearchResponse<TDocument, TAggregations>>
+export default async function SearchApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.SearchResponse<TDocument, TAggregations>, unknown>>
+export default async function SearchApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptions): Promise<T.SearchResponse<TDocument, TAggregations>>
+export default async function SearchApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptions): Promise<any> {
   const acceptedPath: string[] = ['index']
   const acceptedBody: string[] = ['aggregations', 'collapse', 'explain', 'from', 'highlight', 'track_total_hits', 'indices_boost', 'docvalue_fields', 'min_score', 'post_filter', 'profile', 'query', 'rescore', 'script_fields', 'search_after', 'size', 'slice', 'sort', '_source', 'fields', 'suggest', 'terminate_after', 'timeout', 'track_scores', 'version', 'seq_no_primary_term', 'stored_fields', 'pit', 'runtime_mappings', 'stats']
   const querystring: Record<string, any> = {}

--- a/src/api/api/transform.ts
+++ b/src/api/api/transform.ts
@@ -164,7 +164,7 @@ export default class Transform {
   async putTransform (this: That, params: T.TransformPutTransformRequest | TB.TransformPutTransformRequest, options?: TransportRequestOptions): Promise<T.TransformPutTransformResponse>
   async putTransform (this: That, params: T.TransformPutTransformRequest | TB.TransformPutTransformRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = ['transform_id']
-    const acceptedBody: string[] = ['dest', 'description', 'frequency', 'pivot', 'source', 'settings', 'sync', 'retention_policy', 'latest']
+    const acceptedBody: string[] = ['dest', 'description', 'frequency', 'latest', '_meta', 'pivot', 'retention_policy', 'settings', 'source', 'sync']
     const querystring: Record<string, any> = {}
     // @ts-expect-error
     const userBody: any = params?.body
@@ -190,6 +190,28 @@ export default class Transform {
 
     const method = 'PUT'
     const path = `/_transform/${encodeURIComponent(params.transform_id.toString())}`
+    return await this.transport.request({ path, method, querystring, body }, options)
+  }
+
+  async resetTransform (this: That, params: T.TransformResetTransformRequest | TB.TransformResetTransformRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.TransformResetTransformResponse>
+  async resetTransform (this: That, params: T.TransformResetTransformRequest | TB.TransformResetTransformRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.TransformResetTransformResponse, unknown>>
+  async resetTransform (this: That, params: T.TransformResetTransformRequest | TB.TransformResetTransformRequest, options?: TransportRequestOptions): Promise<T.TransformResetTransformResponse>
+  async resetTransform (this: That, params: T.TransformResetTransformRequest | TB.TransformResetTransformRequest, options?: TransportRequestOptions): Promise<any> {
+    const acceptedPath: string[] = ['transform_id']
+    const querystring: Record<string, any> = {}
+    const body = undefined
+
+    for (const key in params) {
+      if (acceptedPath.includes(key)) {
+        continue
+      } else if (key !== 'body') {
+        // @ts-expect-error
+        querystring[key] = params[key]
+      }
+    }
+
+    const method = 'POST'
+    const path = `/_transform/${encodeURIComponent(params.transform_id.toString())}/_reset`
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
@@ -271,10 +293,10 @@ export default class Transform {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
-  async upgradeTransforms (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithOutMeta): Promise<T.TODO>
-  async upgradeTransforms (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.TODO, unknown>>
-  async upgradeTransforms (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<T.TODO>
-  async upgradeTransforms (this: That, params?: T.TODO | TB.TODO, options?: TransportRequestOptions): Promise<any> {
+  async upgradeTransforms (this: That, params?: T.TransformUpgradeTransformsRequest | TB.TransformUpgradeTransformsRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.TransformUpgradeTransformsResponse>
+  async upgradeTransforms (this: That, params?: T.TransformUpgradeTransformsRequest | TB.TransformUpgradeTransformsRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.TransformUpgradeTransformsResponse, unknown>>
+  async upgradeTransforms (this: That, params?: T.TransformUpgradeTransformsRequest | TB.TransformUpgradeTransformsRequest, options?: TransportRequestOptions): Promise<T.TransformUpgradeTransformsResponse>
+  async upgradeTransforms (this: That, params?: T.TransformUpgradeTransformsRequest | TB.TransformUpgradeTransformsRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = []
     const querystring: Record<string, any> = {}
     const body = undefined
@@ -284,6 +306,7 @@ export default class Transform {
       if (acceptedPath.includes(key)) {
         continue
       } else if (key !== 'body') {
+        // @ts-expect-error
         querystring[key] = params[key]
       }
     }

--- a/src/api/api/update.ts
+++ b/src/api/api/update.ts
@@ -41,7 +41,7 @@ export default async function UpdateApi<TDocument = unknown, TPartialDocument = 
 export default async function UpdateApi<TDocument = unknown, TPartialDocument = unknown, TDocumentR = unknown> (this: That, params: T.UpdateRequest<TDocument, TPartialDocument> | TB.UpdateRequest<TDocument, TPartialDocument>, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.UpdateResponse<TDocumentR>, unknown>>
 export default async function UpdateApi<TDocument = unknown, TPartialDocument = unknown, TDocumentR = unknown> (this: That, params: T.UpdateRequest<TDocument, TPartialDocument> | TB.UpdateRequest<TDocument, TPartialDocument>, options?: TransportRequestOptions): Promise<T.UpdateResponse<TDocumentR>>
 export default async function UpdateApi<TDocument = unknown, TPartialDocument = unknown, TDocumentR = unknown> (this: That, params: T.UpdateRequest<TDocument, TPartialDocument> | TB.UpdateRequest<TDocument, TPartialDocument>, options?: TransportRequestOptions): Promise<any> {
-  const acceptedPath: string[] = ['id', 'index', 'type']
+  const acceptedPath: string[] = ['id', 'index']
   const acceptedBody: string[] = ['detect_noop', 'doc', 'doc_as_upsert', 'script', 'scripted_upsert', '_source', 'upsert']
   const querystring: Record<string, any> = {}
   // @ts-expect-error

--- a/src/api/kibana.ts
+++ b/src/api/kibana.ts
@@ -345,8 +345,8 @@ interface KibanaClient {
   monitoring: {
     bulk: <TSource = unknown, TContext = unknown>(params: T.MonitoringBulkRequest<TSource>| TB.MonitoringBulkRequest<TSource>, options?: TransportRequestOptions) => Promise<TransportResult<T.MonitoringBulkResponse, TContext>>
   }
-  msearch: <TDocument = unknown, TContext = unknown>(params?: T.MsearchRequest| TB.MsearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MsearchResponse<TDocument>, TContext>>
-  msearchTemplate: <TDocument = unknown, TContext = unknown>(params?: T.MsearchTemplateRequest| TB.MsearchTemplateRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MsearchTemplateResponse<TDocument>, TContext>>
+  msearch: <TDocument = unknown, TAggregation = unknown, TContext = unknown>(params?: T.MsearchRequest| TB.MsearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MsearchResponse<TDocument, TAggregation>, TContext>>
+  msearchTemplate: <TDocument = unknown, TAggregation = unknown, TContext = unknown>(params?: T.MsearchTemplateRequest| TB.MsearchTemplateRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MsearchTemplateResponse<TDocument, TAggregation>, TContext>>
   mtermvectors: <TContext = unknown>(params?: T.MtermvectorsRequest| TB.MtermvectorsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MtermvectorsResponse, TContext>>
   nodes: {
     clearRepositoriesMeteringArchive: <TContext = unknown>(params?: T.TODO, options?: TransportRequestOptions) => Promise<TransportResult<T.TODO, unknown>>
@@ -371,13 +371,13 @@ interface KibanaClient {
     getRollupIndexCaps: <TContext = unknown>(params: T.RollupGetRollupIndexCapsRequest| TB.RollupGetRollupIndexCapsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupGetRollupIndexCapsResponse, TContext>>
     putJob: <TContext = unknown>(params: T.RollupPutJobRequest| TB.RollupPutJobRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupPutJobResponse, TContext>>
     rollup: <TContext = unknown>(params: T.RollupRollupRequest| TB.RollupRollupRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupRollupResponse, TContext>>
-    rollupSearch: <TDocument = unknown, TContext = unknown>(params: T.RollupRollupSearchRequest| TB.RollupRollupSearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupRollupSearchResponse<TDocument>, TContext>>
+    rollupSearch: <TDocument = unknown, TAggregation = unknown, TContext = unknown>(params: T.RollupRollupSearchRequest| TB.RollupRollupSearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupRollupSearchResponse<TDocument, TAggregation>, TContext>>
     startJob: <TContext = unknown>(params: T.RollupStartJobRequest| TB.RollupStartJobRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupStartJobResponse, TContext>>
     stopJob: <TContext = unknown>(params: T.RollupStopJobRequest| TB.RollupStopJobRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupStopJobResponse, TContext>>
   }
   scriptsPainlessExecute: <TResult = unknown, TContext = unknown>(params?: T.ScriptsPainlessExecuteRequest| TB.ScriptsPainlessExecuteRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.ScriptsPainlessExecuteResponse<TResult>, TContext>>
-  scroll: <TDocument = unknown, TContext = unknown>(params?: T.ScrollRequest| TB.ScrollRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.ScrollResponse<TDocument>, TContext>>
-  search: <TDocument = unknown, TContext = unknown>(params?: T.SearchRequest| TB.SearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.SearchResponse<TDocument>, TContext>>
+  scroll: <TDocument = unknown, TAggregation = unknown, TContext = unknown>(params?: T.ScrollRequest| TB.ScrollRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.ScrollResponse<TDocument, TAggregation>, TContext>>
+  search: <TDocument = unknown, TAggregation = unknown, TContext = unknown>(params?: T.SearchRequest| TB.SearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.SearchResponse<TDocument, TAggregation>, TContext>>
   searchMvt: <TContext = unknown>(params: T.SearchMvtRequest| TB.SearchMvtRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.SearchMvtResponse, TContext>>
   searchShards: <TContext = unknown>(params?: T.SearchShardsRequest| TB.SearchShardsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.SearchShardsResponse, TContext>>
   searchTemplate: <TDocument = unknown, TContext = unknown>(params?: T.SearchTemplateRequest| TB.SearchTemplateRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.SearchTemplateResponse<TDocument>, TContext>>

--- a/src/api/kibana.ts
+++ b/src/api/kibana.ts
@@ -203,7 +203,6 @@ interface KibanaClient {
     existsAlias: <TContext = unknown>(params: T.IndicesExistsAliasRequest| TB.IndicesExistsAliasRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.IndicesExistsAliasResponse, TContext>>
     existsIndexTemplate: <TContext = unknown>(params: T.IndicesExistsIndexTemplateRequest| TB.IndicesExistsIndexTemplateRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.IndicesExistsIndexTemplateResponse, TContext>>
     existsTemplate: <TContext = unknown>(params: T.IndicesExistsTemplateRequest| TB.IndicesExistsTemplateRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.IndicesExistsTemplateResponse, TContext>>
-    existsType: <TContext = unknown>(params: T.IndicesExistsTypeRequest| TB.IndicesExistsTypeRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.IndicesExistsTypeResponse, TContext>>
     fieldUsageStats: <TContext = unknown>(params?: T.TODO, options?: TransportRequestOptions) => Promise<TransportResult<T.TODO, unknown>>
     flush: <TContext = unknown>(params?: T.IndicesFlushRequest| TB.IndicesFlushRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.IndicesFlushResponse, TContext>>
     forcemerge: <TContext = unknown>(params?: T.IndicesForcemergeRequest| TB.IndicesForcemergeRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.IndicesForcemergeResponse, TContext>>
@@ -301,12 +300,13 @@ interface KibanaClient {
     getInfluencers: <TContext = unknown>(params: T.MlGetInfluencersRequest| TB.MlGetInfluencersRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlGetInfluencersResponse, TContext>>
     getJobStats: <TContext = unknown>(params?: T.MlGetJobStatsRequest| TB.MlGetJobStatsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlGetJobStatsResponse, TContext>>
     getJobs: <TContext = unknown>(params?: T.MlGetJobsRequest| TB.MlGetJobsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlGetJobsResponse, TContext>>
+    getModelSnapshotUpgradeStats: <TContext = unknown>(params?: T.TODO, options?: TransportRequestOptions) => Promise<TransportResult<T.TODO, unknown>>
     getModelSnapshots: <TContext = unknown>(params: T.MlGetModelSnapshotsRequest| TB.MlGetModelSnapshotsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlGetModelSnapshotsResponse, TContext>>
     getOverallBuckets: <TContext = unknown>(params: T.MlGetOverallBucketsRequest| TB.MlGetOverallBucketsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlGetOverallBucketsResponse, TContext>>
     getRecords: <TContext = unknown>(params: T.MlGetRecordsRequest| TB.MlGetRecordsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlGetRecordsResponse, TContext>>
     getTrainedModels: <TContext = unknown>(params?: T.MlGetTrainedModelsRequest| TB.MlGetTrainedModelsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlGetTrainedModelsResponse, TContext>>
     getTrainedModelsStats: <TContext = unknown>(params?: T.MlGetTrainedModelsStatsRequest| TB.MlGetTrainedModelsStatsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlGetTrainedModelsStatsResponse, TContext>>
-    inferTrainedModelDeployment: <TContext = unknown>(params?: T.TODO, options?: TransportRequestOptions) => Promise<TransportResult<T.TODO, unknown>>
+    inferTrainedModelDeployment: <TContext = unknown>(params: T.MlInferTrainedModelDeploymentRequest| TB.MlInferTrainedModelDeploymentRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlInferTrainedModelDeploymentResponse, TContext>>
     info: <TContext = unknown>(params?: T.MlInfoRequest| TB.MlInfoRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlInfoResponse, TContext>>
     openJob: <TContext = unknown>(params: T.MlOpenJobRequest| TB.MlOpenJobRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlOpenJobResponse, TContext>>
     postCalendarEvents: <TContext = unknown>(params: T.MlPostCalendarEventsRequest| TB.MlPostCalendarEventsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlPostCalendarEventsResponse, TContext>>
@@ -321,17 +321,17 @@ interface KibanaClient {
     putJob: <TContext = unknown>(params: T.MlPutJobRequest| TB.MlPutJobRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlPutJobResponse, TContext>>
     putTrainedModel: <TContext = unknown>(params: T.MlPutTrainedModelRequest| TB.MlPutTrainedModelRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlPutTrainedModelResponse, TContext>>
     putTrainedModelAlias: <TContext = unknown>(params: T.MlPutTrainedModelAliasRequest| TB.MlPutTrainedModelAliasRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlPutTrainedModelAliasResponse, TContext>>
-    putTrainedModelDefinitionPart: <TContext = unknown>(params?: T.TODO, options?: TransportRequestOptions) => Promise<TransportResult<T.TODO, unknown>>
-    putTrainedModelVocabulary: <TContext = unknown>(params?: T.TODO, options?: TransportRequestOptions) => Promise<TransportResult<T.TODO, unknown>>
+    putTrainedModelDefinitionPart: <TContext = unknown>(params: T.MlPutTrainedModelDefinitionPartRequest| TB.MlPutTrainedModelDefinitionPartRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlPutTrainedModelDefinitionPartResponse, TContext>>
+    putTrainedModelVocabulary: <TContext = unknown>(params: T.MlPutTrainedModelVocabularyRequest| TB.MlPutTrainedModelVocabularyRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlPutTrainedModelVocabularyResponse, TContext>>
     resetJob: <TContext = unknown>(params: T.MlResetJobRequest| TB.MlResetJobRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlResetJobResponse, TContext>>
     revertModelSnapshot: <TContext = unknown>(params: T.MlRevertModelSnapshotRequest| TB.MlRevertModelSnapshotRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlRevertModelSnapshotResponse, TContext>>
     setUpgradeMode: <TContext = unknown>(params?: T.MlSetUpgradeModeRequest| TB.MlSetUpgradeModeRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlSetUpgradeModeResponse, TContext>>
     startDataFrameAnalytics: <TContext = unknown>(params: T.MlStartDataFrameAnalyticsRequest| TB.MlStartDataFrameAnalyticsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlStartDataFrameAnalyticsResponse, TContext>>
     startDatafeed: <TContext = unknown>(params: T.MlStartDatafeedRequest| TB.MlStartDatafeedRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlStartDatafeedResponse, TContext>>
-    startTrainedModelDeployment: <TContext = unknown>(params?: T.TODO, options?: TransportRequestOptions) => Promise<TransportResult<T.TODO, unknown>>
+    startTrainedModelDeployment: <TContext = unknown>(params: T.MlStartTrainedModelDeploymentRequest| TB.MlStartTrainedModelDeploymentRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlStartTrainedModelDeploymentResponse, TContext>>
     stopDataFrameAnalytics: <TContext = unknown>(params: T.MlStopDataFrameAnalyticsRequest| TB.MlStopDataFrameAnalyticsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlStopDataFrameAnalyticsResponse, TContext>>
     stopDatafeed: <TContext = unknown>(params: T.MlStopDatafeedRequest| TB.MlStopDatafeedRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlStopDatafeedResponse, TContext>>
-    stopTrainedModelDeployment: <TContext = unknown>(params?: T.TODO, options?: TransportRequestOptions) => Promise<TransportResult<T.TODO, unknown>>
+    stopTrainedModelDeployment: <TContext = unknown>(params: T.MlStopTrainedModelDeploymentRequest| TB.MlStopTrainedModelDeploymentRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlStopTrainedModelDeploymentResponse, TContext>>
     updateDataFrameAnalytics: <TContext = unknown>(params: T.MlUpdateDataFrameAnalyticsRequest| TB.MlUpdateDataFrameAnalyticsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlUpdateDataFrameAnalyticsResponse, TContext>>
     updateDatafeed: <TContext = unknown>(params: T.MlUpdateDatafeedRequest| TB.MlUpdateDatafeedRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlUpdateDatafeedResponse, TContext>>
     updateFilter: <TContext = unknown>(params: T.MlUpdateFilterRequest| TB.MlUpdateFilterRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MlUpdateFilterResponse, TContext>>
@@ -488,10 +488,11 @@ interface KibanaClient {
     getTransformStats: <TContext = unknown>(params: T.TransformGetTransformStatsRequest| TB.TransformGetTransformStatsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.TransformGetTransformStatsResponse, TContext>>
     previewTransform: <TTransform = unknown, TContext = unknown>(params?: T.TransformPreviewTransformRequest| TB.TransformPreviewTransformRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.TransformPreviewTransformResponse<TTransform>, TContext>>
     putTransform: <TContext = unknown>(params: T.TransformPutTransformRequest| TB.TransformPutTransformRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.TransformPutTransformResponse, TContext>>
+    resetTransform: <TContext = unknown>(params: T.TransformResetTransformRequest| TB.TransformResetTransformRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.TransformResetTransformResponse, TContext>>
     startTransform: <TContext = unknown>(params: T.TransformStartTransformRequest| TB.TransformStartTransformRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.TransformStartTransformResponse, TContext>>
     stopTransform: <TContext = unknown>(params: T.TransformStopTransformRequest| TB.TransformStopTransformRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.TransformStopTransformResponse, TContext>>
     updateTransform: <TContext = unknown>(params: T.TransformUpdateTransformRequest| TB.TransformUpdateTransformRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.TransformUpdateTransformResponse, TContext>>
-    upgradeTransforms: <TContext = unknown>(params?: T.TODO, options?: TransportRequestOptions) => Promise<TransportResult<T.TODO, unknown>>
+    upgradeTransforms: <TContext = unknown>(params?: T.TransformUpgradeTransformsRequest| TB.TransformUpgradeTransformsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.TransformUpgradeTransformsResponse, TContext>>
   }
   update: <TDocumentR = unknown, TDocument = unknown, TPartialDocument = unknown, TContext = unknown>(params: T.UpdateRequest<TDocument, TPartialDocument>| TB.UpdateRequest<TDocument, TPartialDocument>, options?: TransportRequestOptions) => Promise<TransportResult<T.UpdateResponse<TDocumentR>, TContext>>
   updateByQuery: <TContext = unknown>(params: T.UpdateByQueryRequest| TB.UpdateByQueryRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.UpdateByQueryResponse, TContext>>

--- a/src/api/kibana.ts
+++ b/src/api/kibana.ts
@@ -345,8 +345,8 @@ interface KibanaClient {
   monitoring: {
     bulk: <TSource = unknown, TContext = unknown>(params: T.MonitoringBulkRequest<TSource>| TB.MonitoringBulkRequest<TSource>, options?: TransportRequestOptions) => Promise<TransportResult<T.MonitoringBulkResponse, TContext>>
   }
-  msearch: <TDocument = unknown, TAggregation = unknown, TContext = unknown>(params?: T.MsearchRequest| TB.MsearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MsearchResponse<TDocument, TAggregation>, TContext>>
-  msearchTemplate: <TDocument = unknown, TAggregation = unknown, TContext = unknown>(params?: T.MsearchTemplateRequest| TB.MsearchTemplateRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MsearchTemplateResponse<TDocument, TAggregation>, TContext>>
+  msearch: <TDocument = unknown, TAggregations = unknown, TContext = unknown>(params?: T.MsearchRequest| TB.MsearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MsearchResponse<TDocument, TAggregations>, TContext>>
+  msearchTemplate: <TDocument = unknown, TAggregations = unknown, TContext = unknown>(params?: T.MsearchTemplateRequest| TB.MsearchTemplateRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MsearchTemplateResponse<TDocument, TAggregations>, TContext>>
   mtermvectors: <TContext = unknown>(params?: T.MtermvectorsRequest| TB.MtermvectorsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.MtermvectorsResponse, TContext>>
   nodes: {
     clearRepositoriesMeteringArchive: <TContext = unknown>(params?: T.TODO, options?: TransportRequestOptions) => Promise<TransportResult<T.TODO, unknown>>
@@ -371,13 +371,13 @@ interface KibanaClient {
     getRollupIndexCaps: <TContext = unknown>(params: T.RollupGetRollupIndexCapsRequest| TB.RollupGetRollupIndexCapsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupGetRollupIndexCapsResponse, TContext>>
     putJob: <TContext = unknown>(params: T.RollupPutJobRequest| TB.RollupPutJobRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupPutJobResponse, TContext>>
     rollup: <TContext = unknown>(params: T.RollupRollupRequest| TB.RollupRollupRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupRollupResponse, TContext>>
-    rollupSearch: <TDocument = unknown, TAggregation = unknown, TContext = unknown>(params: T.RollupRollupSearchRequest| TB.RollupRollupSearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupRollupSearchResponse<TDocument, TAggregation>, TContext>>
+    rollupSearch: <TDocument = unknown, TAggregations = unknown, TContext = unknown>(params: T.RollupRollupSearchRequest| TB.RollupRollupSearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupRollupSearchResponse<TDocument, TAggregations>, TContext>>
     startJob: <TContext = unknown>(params: T.RollupStartJobRequest| TB.RollupStartJobRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupStartJobResponse, TContext>>
     stopJob: <TContext = unknown>(params: T.RollupStopJobRequest| TB.RollupStopJobRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.RollupStopJobResponse, TContext>>
   }
   scriptsPainlessExecute: <TResult = unknown, TContext = unknown>(params?: T.ScriptsPainlessExecuteRequest| TB.ScriptsPainlessExecuteRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.ScriptsPainlessExecuteResponse<TResult>, TContext>>
-  scroll: <TDocument = unknown, TAggregation = unknown, TContext = unknown>(params?: T.ScrollRequest| TB.ScrollRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.ScrollResponse<TDocument, TAggregation>, TContext>>
-  search: <TDocument = unknown, TAggregation = unknown, TContext = unknown>(params?: T.SearchRequest| TB.SearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.SearchResponse<TDocument, TAggregation>, TContext>>
+  scroll: <TDocument = unknown, TAggregations = unknown, TContext = unknown>(params?: T.ScrollRequest| TB.ScrollRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.ScrollResponse<TDocument, TAggregations>, TContext>>
+  search: <TDocument = unknown, TAggregations = unknown, TContext = unknown>(params?: T.SearchRequest| TB.SearchRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.SearchResponse<TDocument, TAggregations>, TContext>>
   searchMvt: <TContext = unknown>(params: T.SearchMvtRequest| TB.SearchMvtRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.SearchMvtResponse, TContext>>
   searchShards: <TContext = unknown>(params?: T.SearchShardsRequest| TB.SearchShardsRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.SearchShardsResponse, TContext>>
   searchTemplate: <TDocument = unknown, TContext = unknown>(params?: T.SearchTemplateRequest| TB.SearchTemplateRequest, options?: TransportRequestOptions) => Promise<TransportResult<T.SearchTemplateResponse<TDocument>, TContext>>

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -58,7 +58,6 @@ export type BulkOperationType = 'index' | 'create' | 'update' | 'delete'
 
 export interface BulkRequest<TSource = unknown> extends RequestBase {
   index?: IndexName
-  type?: Type
   pipeline?: string
   refresh?: Refresh
   routing?: Routing
@@ -87,7 +86,6 @@ export interface BulkResponseItem {
   result?: string
   _seq_no?: SequenceNumber
   _shards?: ShardStatistics
-  _type?: string
   _version?: VersionNumber
   forced_refresh?: boolean
   get?: InlineGet<Record<string, any>>
@@ -149,7 +147,6 @@ export interface CountResponse {
 export interface CreateRequest<TDocument = unknown> extends RequestBase {
   id: Id
   index: IndexName
-  type?: Type
   pipeline?: string
   refresh?: Refresh
   routing?: Routing
@@ -166,7 +163,6 @@ export interface CreateResponse extends WriteResponseBase {
 export interface DeleteRequest extends RequestBase {
   id: Id
   index: IndexName
-  type?: Type
   if_primary_term?: long
   if_seq_no?: SequenceNumber
   refresh?: Refresh
@@ -203,12 +199,8 @@ export interface DeleteByQueryRequest extends RequestBase {
   scroll_size?: long
   search_timeout?: Time
   search_type?: SearchType
-  size?: long
   slices?: long
   sort?: string[]
-  _source?: SearchSourceConfigParam
-  _source_excludes?: Fields
-  _source_includes?: Fields
   stats?: string[]
   terminate_after?: long
   timeout?: Time
@@ -273,7 +265,6 @@ export type ExistsResponse = boolean
 export interface ExistsSourceRequest extends RequestBase {
   id: Id
   index: IndexName
-  type?: Type
   preference?: string
   realtime?: boolean
   refresh?: boolean
@@ -319,7 +310,6 @@ export interface ExplainRequest extends RequestBase {
 
 export interface ExplainResponse<TDocument = unknown> {
   _index: IndexName
-  _type?: Type
   _id: Id
   matched: boolean
   explanation?: ExplainExplanationDetail
@@ -362,7 +352,6 @@ export interface GetGetResult<TDocument = unknown> {
   _routing?: string
   _seq_no?: SequenceNumber
   _source?: TDocument
-  _type?: Type
   _version?: VersionNumber
 }
 
@@ -510,7 +499,6 @@ export interface MgetMultiGetError {
   error: ErrorCause
   _id: Id
   _index: IndexName
-  _type?: Type
 }
 
 export interface MgetOperation {
@@ -519,7 +507,6 @@ export interface MgetOperation {
   routing?: Routing
   _source?: SearchSourceConfig
   stored_fields?: Fields
-  _type?: Type
   version?: VersionNumber
   version_type?: VersionType
 }
@@ -591,22 +578,11 @@ export interface MsearchRequest extends RequestBase {
   searches?: MsearchRequestItem[]
 }
 
-<<<<<<< HEAD
-export interface MsearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
-  took: long
-  responses: (MsearchSearchResult<TDocument, TAggregations> | ErrorResponseBase)[]
-}
-
-export interface MsearchSearchResult<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregations> {
-  status: integer
-}
-=======
 export type MsearchRequestItem = MsearchMultisearchHeader | MsearchMultisearchBody
 
-export type MsearchResponse<TDocument = unknown> = MsearchMultiSearchResult<TDocument>
+export type MsearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = MsearchMultiSearchResult<TDocument>
 
 export type MsearchResponseItem<TDocument = unknown> = MsearchMultiSearchItem<TDocument> | ErrorResponseBase
->>>>>>> main
 
 export interface MsearchTemplateRequest extends RequestBase {
   index?: Indices
@@ -618,16 +594,9 @@ export interface MsearchTemplateRequest extends RequestBase {
   search_templates?: MsearchTemplateRequestItem[]
 }
 
-<<<<<<< HEAD
-export interface MsearchTemplateResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
-  responses: (SearchResponse<TDocument, TAggregations> | ErrorResponseBase)[]
-  took: long
-}
-=======
 export type MsearchTemplateRequestItem = MsearchMultisearchHeader | MsearchTemplateTemplateConfig
 
-export type MsearchTemplateResponse<TDocument = unknown> = MsearchMultiSearchResult<TDocument>
->>>>>>> main
+export type MsearchTemplateResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = MsearchMultiSearchResult<TDocument>
 
 export interface MsearchTemplateTemplateConfig {
   explain?: boolean
@@ -718,7 +687,6 @@ export interface RankEvalDocumentRating {
 export interface RankEvalRankEvalHit {
   _id: Id
   _index: IndexName
-  _type?: Type
   _score: double
 }
 
@@ -860,7 +828,7 @@ export interface ReindexSource {
   remote?: ReindexRemoteSource
   size?: integer
   slice?: SlicedScroll
-  sort?: SearchSort
+  sort?: Sort
   _source?: Fields
   runtime_mappings?: MappingRuntimeFields
 }
@@ -997,7 +965,7 @@ export interface SearchRequest extends RequestBase {
   query?: QueryDslQueryContainer
   rescore?: SearchRescore | SearchRescore[]
   script_fields?: Record<string, ScriptField>
-  search_after?: SearchSortResults
+  search_after?: SortResults
   slice?: SlicedScroll
   fields?: (QueryDslFieldAndFormat | Field)[]
   suggest?: SearchSuggester
@@ -1012,7 +980,6 @@ export interface SearchResponse<TDocument = unknown, TAggregations = Record<Aggr
   hits: SearchHitsMetadata<TDocument>
   aggregations?: TAggregations
   _clusters?: ClusterStatistics
-  documents?: TDocument[]
   fields?: Record<string, any>
   max_score?: double
   num_reduce_phases?: long
@@ -1111,7 +1078,6 @@ export interface SearchCompletionSuggestOption<TDocument = unknown> {
   fields?: Record<string, any>
   _id: string
   _index: IndexName
-  _type?: Type
   _routing?: Routing
   _score: double
   _source: TDocument
@@ -1171,18 +1137,6 @@ export interface SearchFieldCollapse {
   max_concurrent_group_searches?: integer
 }
 
-export interface SearchFieldSort {
-  missing?: AggregationsMissing
-  mode?: SearchSortMode
-  nested?: SearchNestedSortValue
-  order?: SearchSortOrder
-  unmapped_type?: MappingFieldType
-  numeric_type?: SearchFieldSortNumericType
-  format?: string
-}
-
-export type SearchFieldSortNumericType = 'long' | 'double' | 'date' | 'date_nanos'
-
 export interface SearchFieldSuggester {
   completion?: SearchCompletionSuggester
   phrase?: SearchPhraseSuggester
@@ -1191,16 +1145,6 @@ export interface SearchFieldSuggester {
   term?: SearchTermSuggester
   text?: string
 }
-
-export interface SearchGeoDistanceSortKeys {
-  mode?: SearchSortMode
-  distance_type?: GeoDistanceType
-  ignore_unmapped?: boolean
-  order?: SearchSortOrder
-  unit?: DistanceUnit
-}
-export type SearchGeoDistanceSort = SearchGeoDistanceSortKeys
-& { [property: string]: GeoLocation | GeoLocation[] | SearchSortMode | GeoDistanceType | boolean | SearchSortOrder | DistanceUnit }
 
 export interface SearchHighlight {
   fields: Record<Field, SearchHighlightField>
@@ -1262,8 +1206,7 @@ export type SearchHighlighterType = SearchBuiltinHighlighterType | string
 export interface SearchHit<TDocument = unknown> {
   _index: IndexName
   _id: Id
-  _score?: double
-  _type?: Type
+  _score?: double | null
   _explanation?: ExplainExplanation
   fields?: Record<string, any>
   highlight?: Record<string, string[]>
@@ -1278,13 +1221,13 @@ export interface SearchHit<TDocument = unknown> {
   _seq_no?: SequenceNumber
   _primary_term?: long
   _version?: VersionNumber
-  sort?: SearchSortResults
+  sort?: SortResults
 }
 
 export interface SearchHitsMetadata<T = unknown> {
-  total: SearchTotalHits | long
+  total?: SearchTotalHits | long
   hits: SearchHit<T>[]
-  max_score?: double
+  max_score?: double | null
 }
 
 export interface SearchInnerHits {
@@ -1299,7 +1242,7 @@ export interface SearchInnerHits {
   script_fields?: Record<Field, ScriptField>
   seq_no_primary_term?: boolean
   fields?: Fields
-  sort?: SearchSort
+  sort?: Sort
   _source?: SearchSourceConfig
   stored_field?: Fields
   track_scores?: boolean
@@ -1324,13 +1267,6 @@ export interface SearchNestedIdentity {
   field: Field
   offset: integer
   _nested?: SearchNestedIdentity
-}
-
-export interface SearchNestedSortValue {
-  filter?: QueryDslQueryContainer
-  max_children?: integer
-  nested?: SearchNestedSortValue
-  path: Field
 }
 
 export interface SearchPhraseSuggestCollate {
@@ -1423,20 +1359,6 @@ export interface SearchRescoreQuery {
 
 export type SearchScoreMode = 'avg' | 'max' | 'min' | 'multiply' | 'total'
 
-export interface SearchScoreSort {
-  order?: SearchSortOrder
-}
-
-export interface SearchScriptSort {
-  order?: SearchSortOrder
-  script: Script
-  type?: SearchScriptSortType
-  mode?: SearchSortMode
-  nested?: SearchNestedSortValue
-}
-
-export type SearchScriptSortType = 'string' | 'number'
-
 export interface SearchSearchProfile {
   collector: SearchCollector[]
   query: SearchQueryProfile[]
@@ -1455,25 +1377,6 @@ export interface SearchSmoothingModelContainer {
   linear_interpolation?: SearchLinearInterpolationSmoothingModel
   stupid_backoff?: SearchStupidBackoffSmoothingModel
 }
-
-export type SearchSort = SearchSortCombinations | SearchSortCombinations[]
-
-export type SearchSortCombinations = Field | SearchSortOptions
-
-export type SearchSortMode = 'min' | 'max' | 'sum' | 'avg' | 'median'
-
-export interface SearchSortOptionsKeys {
-  _score?: SearchScoreSort
-  _doc?: SearchScoreSort
-  _geo_distance?: SearchGeoDistanceSort
-  _script?: SearchScriptSort
-}
-export type SearchSortOptions = SearchSortOptionsKeys
-& { [property: string]: SearchFieldSort | SearchSortOrder | SearchScoreSort | SearchGeoDistanceSort | SearchScriptSort }
-
-export type SearchSortOrder = 'asc' | 'desc'
-
-export type SearchSortResults = (long | double | string | null)[]
 
 export type SearchSourceConfig = boolean | SearchSourceFilter | Fields
 
@@ -1568,7 +1471,7 @@ export interface SearchMvtRequest extends RequestBase {
   fields?: Fields
   query?: QueryDslQueryContainer
   runtime_mappings?: MappingRuntimeFields
-  sort?: SearchSort
+  sort?: Sort
 }
 
 export type SearchMvtResponse = MapboxVectorTiles
@@ -1685,7 +1588,6 @@ export interface TermvectorsResponse {
   _index: IndexName
   term_vectors?: Record<Field, TermvectorsTermVector>
   took: long
-  _type?: Type
   _version: VersionNumber
 }
 
@@ -1712,7 +1614,6 @@ export interface TermvectorsToken {
 export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> extends RequestBase {
   id: Id
   index: IndexName
-  type?: Type
   if_primary_term?: long
   if_seq_no?: SequenceNumber
   lang?: string
@@ -1749,6 +1650,7 @@ export interface UpdateByQueryRequest extends RequestBase {
   from?: long
   ignore_unavailable?: boolean
   lenient?: boolean
+  max_docs?: long
   pipeline?: string
   preference?: string
   refresh?: boolean
@@ -1759,12 +1661,8 @@ export interface UpdateByQueryRequest extends RequestBase {
   scroll_size?: long
   search_timeout?: Time
   search_type?: SearchType
-  size?: long
   slices?: long
   sort?: string[]
-  _source?: SearchSourceConfigParam
-  _source_excludes?: Fields
-  _source_includes?: Fields
   stats?: string[]
   terminate_after?: long
   timeout?: Time
@@ -1772,7 +1670,6 @@ export interface UpdateByQueryRequest extends RequestBase {
   version_type?: boolean
   wait_for_active_shards?: WaitForActiveShards
   wait_for_completion?: boolean
-  max_docs?: long
   query?: QueryDslQueryContainer
   script?: Script
   slice?: SlicedScroll
@@ -1898,7 +1795,7 @@ export type DistanceUnit = 'in' | 'ft' | 'yd' | 'mi' | 'nmi' | 'km' | 'm' | 'cm'
 
 export interface DocStats {
   count: long
-  deleted: long
+  deleted?: long
 }
 
 export interface ElasticsearchVersionInfo {
@@ -1950,6 +1847,18 @@ export interface FieldSizeUsage {
   size_in_bytes: long
 }
 
+export interface FieldSort {
+  missing?: AggregationsMissing
+  mode?: SortMode
+  nested?: NestedSortValue
+  order?: SortOrder
+  unmapped_type?: MappingFieldType
+  numeric_type?: FieldSortNumericType
+  format?: string
+}
+
+export type FieldSortNumericType = 'long' | 'double' | 'date' | 'date_nanos'
+
 export type FieldValue = long | double | string | boolean
 
 export interface FielddataStats {
@@ -1971,6 +1880,16 @@ export interface FlushStats {
 export type Fuzziness = string | integer
 
 export type GeoBounds = CoordsGeoBounds | TopLeftBottomRightGeoBounds | TopRightBottomLeftGeoBounds | WktGeoBounds
+
+export interface GeoDistanceSortKeys {
+  mode?: SortMode
+  distance_type?: GeoDistanceType
+  ignore_unmapped?: boolean
+  order?: SortOrder
+  unit?: DistanceUnit
+}
+export type GeoDistanceSort = GeoDistanceSortKeys
+& { [property: string]: GeoLocation | GeoLocation[] | SortMode | GeoDistanceType | boolean | SortOrder | DistanceUnit }
 
 export type GeoDistanceType = 'arc' | 'plane'
 
@@ -2047,6 +1966,13 @@ export interface IndexingStats {
 
 export type Indices = IndexName | IndexName[]
 
+export interface IndicesOptions {
+  allow_no_indices?: boolean
+  expand_wildcards?: ExpandWildcards
+  ignore_unavailable?: boolean
+  ignore_throttled?: boolean
+}
+
 export interface IndicesResponseBase extends AcknowledgedResponseBase {
   _shards?: ShardStatistics
 }
@@ -2113,6 +2039,13 @@ export type Name = string
 export type Names = Name | Name[]
 
 export type Namespace = string
+
+export interface NestedSortValue {
+  filter?: QueryDslQueryContainer
+  max_children?: integer
+  nested?: NestedSortValue
+  path: Field
+}
 
 export interface NodeAttributes {
   attributes: Record<string, string>
@@ -2216,7 +2149,7 @@ export interface RequestCacheStats {
   miss_count: long
 }
 
-export type Result = 'Error' | 'created' | 'updated' | 'deleted' | 'not_found' | 'noop'
+export type Result = 'created' | 'updated' | 'deleted' | 'not_found' | 'noop'
 
 export interface Retries {
   bulk: long
@@ -2224,6 +2157,10 @@ export interface Retries {
 }
 
 export type Routing = string
+
+export interface ScoreSort {
+  order?: SortOrder
+}
 
 export type Script = InlineScript | string | StoredScriptId
 
@@ -2237,6 +2174,16 @@ export interface ScriptField {
 }
 
 export type ScriptLanguage = BuiltinScriptLanguage | string
+
+export interface ScriptSort {
+  order?: SortOrder
+  script: Script
+  type?: ScriptSortType
+  mode?: SortMode
+  nested?: NestedSortValue
+}
+
+export type ScriptSortType = 'string' | 'number'
 
 export interface ScriptTransform {
   lang: string
@@ -2326,6 +2273,25 @@ export interface SlicedScroll {
   max: integer
 }
 
+export type Sort = SortCombinations | SortCombinations[]
+
+export type SortCombinations = Field | SortOptions
+
+export type SortMode = 'min' | 'max' | 'sum' | 'avg' | 'median'
+
+export interface SortOptionsKeys {
+  _score?: ScoreSort
+  _doc?: ScoreSort
+  _geo_distance?: GeoDistanceSort
+  _script?: ScriptSort
+}
+export type SortOptions = SortOptionsKeys
+& { [property: string]: FieldSort | SortOrder | ScoreSort | GeoDistanceSort | ScriptSort }
+
+export type SortOrder = 'asc' | 'desc'
+
+export type SortResults = (long | double | string | null)[]
+
 export interface StoreStats {
   size?: ByteSize
   size_in_bytes: integer
@@ -2394,10 +2360,6 @@ export interface TranslogStats {
 
 export type TransportAddress = string
 
-export type Type = string
-
-export type Types = Type | Type[]
-
 export type Username = string
 
 export type Uuid = string
@@ -2432,7 +2394,6 @@ export interface WriteResponseBase {
   result: Result
   _seq_no: SequenceNumber
   _shards: ShardStatistics
-  _type?: Type
   _version: VersionNumber
   forced_refresh?: boolean
 }
@@ -2629,7 +2590,7 @@ export interface AggregationsBucketSortAggregation extends AggregationsAggregati
   from?: integer
   gap_policy?: AggregationsGapPolicy
   size?: integer
-  sort?: SearchSort
+  sort?: Sort
 }
 
 export type AggregationsBuckets<TBucket = unknown> = Record<string, TBucket> | TBucket[]
@@ -2903,7 +2864,7 @@ export interface AggregationsGeoLineAggregation {
   point: AggregationsGeoLinePoint
   sort: AggregationsGeoLineSort
   include_sort?: boolean
-  sort_order?: SearchSortOrder
+  sort_order?: SortOrder
   size?: integer
 }
 
@@ -2977,8 +2938,8 @@ export type AggregationsHistogramBucket = AggregationsHistogramBucketKeys
 & { [property: string]: AggregationsAggregate | string | double | long }
 
 export interface AggregationsHistogramOrder {
-  _count?: SearchSortOrder
-  _key?: SearchSortOrder
+  _count?: SortOrder
+  _key?: SortOrder
 }
 
 export interface AggregationsHoltLinearModelSettings {
@@ -3085,11 +3046,11 @@ export interface AggregationsLongTermsAggregate extends AggregationsTermsAggrega
 }
 
 export interface AggregationsLongTermsBucketKeys extends AggregationsTermsBucketBase {
-  key: string
+  key: long
   key_as_string?: string
 }
 export type AggregationsLongTermsBucket = AggregationsLongTermsBucketKeys
-& { [property: string]: AggregationsAggregate | string | long }
+& { [property: string]: AggregationsAggregate | long | string }
 
 export interface AggregationsMatrixAggregation extends AggregationsAggregation {
   fields?: Fields
@@ -3102,7 +3063,7 @@ export interface AggregationsMatrixStatsAggregate extends AggregationsAggregateB
 }
 
 export interface AggregationsMatrixStatsAggregation extends AggregationsMatrixAggregation {
-  mode?: AggregationsMatrixStatsMode
+  mode?: SortMode
 }
 
 export interface AggregationsMatrixStatsFields {
@@ -3115,8 +3076,6 @@ export interface AggregationsMatrixStatsFields {
   covariance: Record<Field, double>
   correlation: Record<Field, double>
 }
-
-export type AggregationsMatrixStatsMode = 'avg' | 'min' | 'max' | 'sum' | 'median'
 
 export interface AggregationsMaxAggregate extends AggregationsSingleMetricAggregateBase {
 }
@@ -3560,7 +3519,7 @@ export type AggregationsTermsAggregationCollectMode = 'depth_first' | 'breadth_f
 
 export type AggregationsTermsAggregationExecutionHint = 'map' | 'global_ordinals' | 'global_ordinals_hash' | 'global_ordinals_low_cardinality'
 
-export type AggregationsTermsAggregationOrder = Record<Field, SearchSortOrder> | Record<Field, SearchSortOrder>[]
+export type AggregationsTermsAggregationOrder = Record<Field, SortOrder> | Record<Field, SortOrder>[]
 
 export interface AggregationsTermsBucketBase extends AggregationsMultiBucketBase {
   doc_count_error?: long
@@ -3592,7 +3551,7 @@ export interface AggregationsTopHitsAggregation extends AggregationsMetricAggreg
   highlight?: SearchHighlight
   script_fields?: Record<string, ScriptField>
   size?: integer
-  sort?: SearchSort
+  sort?: Sort
   _source?: SearchSourceConfig
   stored_fields?: Fields
   track_scores?: boolean
@@ -3611,7 +3570,7 @@ export interface AggregationsTopMetricsAggregate extends AggregationsMultiBucket
 export interface AggregationsTopMetricsAggregation extends AggregationsMetricAggregationBase {
   metrics?: AggregationsTopMetricsValue | AggregationsTopMetricsValue[]
   size?: integer
-  sort?: SearchSort
+  sort?: Sort
 }
 
 export interface AggregationsTopMetricsBucketKeys extends AggregationsMultiBucketBase {
@@ -5069,7 +5028,6 @@ export interface QueryDslLikeDocument {
   doc?: any
   fields?: Field[]
   _id?: Id
-  _type?: Type
   _index?: IndexName
   per_field_analyzer?: Record<Field, string>
   routing?: Routing
@@ -5175,10 +5133,8 @@ export interface QueryDslNestedQuery extends QueryDslQueryBase {
   inner_hits?: SearchInnerHits
   path: Field
   query: QueryDslQueryContainer
-  score_mode?: QueryDslNestedScoreMode
+  score_mode?: QueryDslChildScoreMode
 }
-
-export type QueryDslNestedScoreMode = 'avg' | 'sum' | 'min' | 'max' | 'none'
 
 export interface QueryDslNumberRangeQuery extends QueryDslRangeQueryBase {
   gt?: double
@@ -5289,6 +5245,7 @@ export interface QueryDslQueryContainer {
   terms?: QueryDslTermsQuery
   terms_set?: Partial<Record<Field, QueryDslTermsSetQuery>>
   wildcard?: Partial<Record<Field, QueryDslWildcardQuery | string>>
+  wrapper: QueryDslWrapperQuery
   type?: QueryDslTypeQuery
 }
 
@@ -5518,6 +5475,10 @@ export interface QueryDslWildcardQuery extends QueryDslQueryBase {
   wildcard?: string
 }
 
+export interface QueryDslWrapperQuery extends QueryDslQueryBase {
+  query: string
+}
+
 export type QueryDslZeroTermsQuery = 'all' | 'none'
 
 export interface AsyncSearchAsyncSearch<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
@@ -5634,7 +5595,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   query?: QueryDslQueryContainer
   rescore?: SearchRescore | SearchRescore[]
   script_fields?: Record<string, ScriptField>
-  search_after?: SearchSortResults
+  search_after?: SortResults
   slice?: SlicedScroll
   fields?: (QueryDslFieldAndFormat | Field)[]
   suggest?: SearchSuggester
@@ -6187,8 +6148,8 @@ export type CatMasterResponse = CatMasterMasterRecord[]
 
 export interface CatMlDataFrameAnalyticsDataFrameAnalyticsRecord {
   id?: Id
-  type?: Type
-  t?: Type
+  type?: string
+  t?: string
   create_time?: string
   ct?: string
   createTime?: string
@@ -6558,8 +6519,8 @@ export interface CatNodesNodesRecord {
   v?: VersionString
   flavor?: string
   f?: string
-  type?: Type
-  t?: Type
+  type?: string
+  t?: string
   build?: string
   b?: string
   jdk?: string
@@ -6846,8 +6807,8 @@ export interface CatPluginsPluginsRecord {
   v?: VersionString
   description?: string
   d?: string
-  type?: Type
-  t?: Type
+  type?: string
+  t?: string
 }
 
 export interface CatPluginsRequest extends CatCatRequestBase {
@@ -6873,8 +6834,8 @@ export interface CatRecoveryRecoveryRecord {
   time?: string
   t?: string
   ti?: string
-  type?: Type
-  ty?: Type
+  type?: string
+  ty?: string
   stage?: string
   st?: string
   source_host?: string
@@ -7262,8 +7223,8 @@ export interface CatTasksTasksRecord {
   ti?: Id
   parent_task_id?: string
   pti?: string
-  type?: Type
-  ty?: Type
+  type?: string
+  ty?: string
   start_time?: string
   start?: string
   timestamp?: string
@@ -7311,7 +7272,7 @@ export interface CatTemplatesTemplatesRecord {
 
 export interface CatThreadPoolRequest extends CatCatRequestBase {
   thread_pool_patterns?: Names
-  size?: CatThreadPoolThreadPoolSize
+  time?: Time
 }
 
 export type CatThreadPoolResponse = CatThreadPoolThreadPoolRecord[]
@@ -7358,8 +7319,6 @@ export interface CatThreadPoolThreadPoolRecord {
   keep_alive?: string
   ka?: string
 }
-
-export type CatThreadPoolThreadPoolSize = 'k' | 'm' | 'g' | 't' | 'p'
 
 export interface CatTransformsRequest extends CatCatRequestBase {
   transform_id?: Id
@@ -8801,7 +8760,7 @@ export interface IndicesIndexRoutingAllocation {
 }
 
 export interface IndicesIndexRoutingAllocationDisk {
-  threshold_enabled: boolean | string
+  threshold_enabled?: boolean | string
 }
 
 export interface IndicesIndexRoutingAllocationInclude {
@@ -8824,8 +8783,8 @@ export type IndicesIndexRoutingRebalanceOptions = 'all' | 'primaries' | 'replica
 export interface IndicesIndexSegmentSort {
   field: Fields
   order: IndicesSegmentSortOrder | IndicesSegmentSortOrder[]
-  mode?: IndicesSegmentSortMode
-  missing?: IndicesSegmentSortMissing
+  mode?: IndicesSegmentSortMode | IndicesSegmentSortMode[]
+  missing?: IndicesSegmentSortMissing | IndicesSegmentSortMissing[]
 }
 
 export interface IndicesIndexSettingBlocks {
@@ -8964,6 +8923,7 @@ export interface IndicesIndexState {
   aliases?: Record<IndexName, IndicesAlias>
   mappings?: MappingTypeMapping
   settings?: IndicesIndexSettings
+  defaults?: IndicesIndexSettings
   data_stream?: DataStreamName
 }
 
@@ -9143,7 +9103,6 @@ export interface IndicesCloseResponse extends AcknowledgedResponseBase {
 
 export interface IndicesCreateRequest extends RequestBase {
   index: IndexName
-  include_type_name?: boolean
   master_timeout?: Time
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
@@ -9286,17 +9245,6 @@ export interface IndicesExistsTemplateRequest extends RequestBase {
 
 export type IndicesExistsTemplateResponse = boolean
 
-export interface IndicesExistsTypeRequest extends RequestBase {
-  index: Indices
-  type: Types
-  allow_no_indices?: boolean
-  expand_wildcards?: ExpandWildcards
-  ignore_unavailable?: boolean
-  local?: boolean
-}
-
-export type IndicesExistsTypeResponse = boolean
-
 export interface IndicesFlushRequest extends RequestBase {
   index?: Indices
   allow_no_indices?: boolean
@@ -9329,7 +9277,6 @@ export interface IndicesGetRequest extends RequestBase {
   flat_settings?: boolean
   ignore_unavailable?: boolean
   include_defaults?: boolean
-  include_type_name?: boolean
   local?: boolean
   master_timeout?: Time
 }
@@ -9391,7 +9338,6 @@ export interface IndicesGetFieldMappingRequest extends RequestBase {
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
   include_defaults?: boolean
-  include_type_name?: boolean
   local?: boolean
 }
 
@@ -9428,7 +9374,6 @@ export interface IndicesGetIndexTemplateRequest extends RequestBase {
   name?: Name
   local?: boolean
   flat_settings?: boolean
-  include_type_name?: boolean
   master_timeout?: Time
 }
 
@@ -9446,7 +9391,6 @@ export interface IndicesGetMappingRequest extends RequestBase {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
-  include_type_name?: boolean
   local?: boolean
   master_timeout?: Time
 }
@@ -9472,7 +9416,6 @@ export interface IndicesGetSettingsResponse extends DictionaryResponseBase<Index
 export interface IndicesGetTemplateRequest extends RequestBase {
   name?: Names
   flat_settings?: boolean
-  include_type_name?: boolean
   local?: boolean
   master_timeout?: Time
 }
@@ -9547,7 +9490,6 @@ export interface IndicesPutMappingRequest extends RequestBase {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
-  include_type_name?: boolean
   master_timeout?: Time
   timeout?: Time
   write_index_only?: boolean
@@ -9586,7 +9528,6 @@ export interface IndicesPutTemplateRequest extends RequestBase {
   name: Name
   create?: boolean
   flat_settings?: boolean
-  include_type_name?: boolean
   master_timeout?: Time
   timeout?: Time
   order?: integer
@@ -9686,7 +9627,7 @@ export interface IndicesRecoveryShardRecovery {
   total_time?: DateString
   total_time_in_millis: EpochMillis
   translog: IndicesRecoveryTranslogStatus
-  type: Type
+  type: string
   verify_index: IndicesRecoveryVerifyIndex
 }
 
@@ -9763,19 +9704,16 @@ export interface IndicesResolveIndexResponse {
   data_streams: IndicesResolveIndexResolveIndexDataStreamsItem[]
 }
 
-export type IndicesRolloverIndexRolloverMapping = MappingTypeMapping | Record<string, MappingTypeMapping>
-
 export interface IndicesRolloverRequest extends RequestBase {
   alias: IndexAlias
   new_index?: IndexName
   dry_run?: boolean
-  include_type_name?: boolean
   master_timeout?: Time
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
   aliases?: Record<IndexName, IndicesAlias>
   conditions?: IndicesRolloverRolloverConditions
-  mappings?: IndicesRolloverIndexRolloverMapping
+  mappings?: MappingTypeMapping
   settings?: Record<string, any>
 }
 
@@ -9955,6 +9893,7 @@ export interface IndicesStatsIndexStats {
   flush?: FlushStats
   get?: GetStats
   indexing?: IndexingStats
+  indices?: IndicesStatsIndicesStats
   merges?: MergesStats
   query_cache?: QueryCacheStats
   recovery?: RecoveryStats
@@ -9966,13 +9905,13 @@ export interface IndicesStatsIndexStats {
   translog?: TranslogStats
   warmer?: WarmerStats
   bulk?: BulkStats
-  shards?: IndicesStatsShardsTotalStats
+  shard_stats?: IndicesStatsShardsTotalStats
 }
 
 export interface IndicesStatsIndicesStats {
-  primaries: IndicesStatsIndexStats
+  primaries?: IndicesStatsIndexStats
   shards?: Record<string, IndicesStatsShardStats[]>
-  total: IndicesStatsIndexStats
+  total?: IndicesStatsIndexStats
   uuid?: Uuid
 }
 
@@ -9988,7 +9927,6 @@ export interface IndicesStatsRequest extends RequestBase {
   include_segment_file_sizes?: boolean
   include_unloaded_segments?: boolean
   level?: Level
-  types?: Types
 }
 
 export interface IndicesStatsResponse {
@@ -10058,29 +9996,31 @@ export interface IndicesStatsShardSequenceNumber {
 }
 
 export interface IndicesStatsShardStats {
-  commit: IndicesStatsShardCommit
-  completion: CompletionStats
-  docs: DocStats
-  fielddata: FielddataStats
-  flush: FlushStats
-  get: GetStats
-  indexing: IndexingStats
-  merges: MergesStats
-  shard_path: IndicesStatsShardPath
-  query_cache: IndicesStatsShardQueryCache
-  recovery: RecoveryStats
-  refresh: RefreshStats
-  request_cache: RequestCacheStats
-  retention_leases: IndicesStatsShardRetentionLeases
-  routing: IndicesStatsShardRouting
-  search: SearchStats
-  segments: SegmentsStats
-  seq_no: IndicesStatsShardSequenceNumber
-  store: StoreStats
-  translog: TranslogStats
-  warmer: WarmerStats
+  commit?: IndicesStatsShardCommit
+  completion?: CompletionStats
+  docs?: DocStats
+  fielddata?: FielddataStats
+  flush?: FlushStats
+  get?: GetStats
+  indexing?: IndexingStats
+  merges?: MergesStats
+  shard_path?: IndicesStatsShardPath
+  query_cache?: IndicesStatsShardQueryCache
+  recovery?: RecoveryStats
+  refresh?: RefreshStats
+  request_cache?: RequestCacheStats
+  retention_leases?: IndicesStatsShardRetentionLeases
+  routing?: IndicesStatsShardRouting
+  search?: SearchStats
+  segments?: SegmentsStats
+  seq_no?: IndicesStatsShardSequenceNumber
+  store?: StoreStats
+  translog?: TranslogStats
+  warmer?: WarmerStats
   bulk?: BulkStats
-  shards: IndicesStatsShardsTotalStats
+  shards?: IndicesStatsShardsTotalStats
+  shard_stats?: IndicesStatsShardsTotalStats
+  indices?: IndicesStatsIndicesStats
 }
 
 export interface IndicesStatsShardsTotalStats {
@@ -10151,7 +10091,6 @@ export interface IndicesValidateQueryIndicesValidationExplanation {
 
 export interface IndicesValidateQueryRequest extends RequestBase {
   index?: Indices
-  type?: Types
   allow_no_indices?: boolean
   all_shards?: boolean
   analyzer?: string
@@ -10436,7 +10375,7 @@ export type IngestShapeType = 'geo_shape' | 'shape'
 
 export interface IngestSortProcessor extends IngestProcessorBase {
   field: Field
-  order: SearchSortOrder
+  order: SortOrder
   target_field: Field
 }
 
@@ -10553,7 +10492,6 @@ export interface IngestSimulateDocumentSimulation {
   _parent?: string
   _routing?: string
   _source: Record<string, any>
-  _type?: Type
 }
 
 export interface IngestSimulateIngest {
@@ -10939,7 +10877,7 @@ export interface MlDatafeed {
   scroll_size?: integer
   delayed_data_check_config: MlDelayedDataCheckConfig
   runtime_mappings?: MappingRuntimeFields
-  indices_options?: MlDatafeedIndicesOptions
+  indices_options?: IndicesOptions
 }
 
 export interface MlDatafeedConfig {
@@ -10951,7 +10889,7 @@ export interface MlDatafeedConfig {
   frequency?: Timestamp
   indexes?: string[]
   indices: string[]
-  indices_options?: MlDatafeedIndicesOptions
+  indices_options?: IndicesOptions
   job_id?: Id
   max_empty_searches?: integer
   query: QueryDslQueryContainer
@@ -10959,13 +10897,6 @@ export interface MlDatafeedConfig {
   runtime_mappings?: MappingRuntimeFields
   script_fields?: Record<string, ScriptField>
   scroll_size?: integer
-}
-
-export interface MlDatafeedIndicesOptions {
-  allow_no_indices?: boolean
-  expand_wildcards?: ExpandWildcards
-  ignore_unavailable?: boolean
-  ignore_throttled?: boolean
 }
 
 export type MlDatafeedState = 'started' | 'stopped' | 'starting' | 'stopping'
@@ -11234,6 +11165,8 @@ export interface MlDelayedDataCheckConfig {
   enabled: boolean
 }
 
+export type MlDeploymentState = 'started' | 'starting' | 'fully_allocated'
+
 export interface MlDetectionRule {
   actions?: MlRuleAction[]
   conditions?: MlRuleCondition[]
@@ -11495,6 +11428,10 @@ export interface MlPerPartitionCategorization {
   stop_on_warn?: boolean
 }
 
+export type MlPredictedValue = string | double
+
+export type MlRoutingState = 'failed' | 'started' | 'starting' | 'stopped' | 'stopping'
+
 export type MlRuleAction = 'skip_result' | 'skip_model_update'
 
 export interface MlRuleCondition {
@@ -11506,6 +11443,12 @@ export interface MlRuleCondition {
 export interface MlTimingStats {
   elapsed_time: integer
   iteration_time?: integer
+}
+
+export interface MlTopClassEntry {
+  class_name: string
+  class_probability: double
+  class_score: double
 }
 
 export interface MlTotalFeatureImportance {
@@ -11523,6 +11466,23 @@ export interface MlTotalFeatureImportanceStatistics {
   mean_magnitude: double
   max: integer
   min: integer
+}
+
+export interface MlTrainedModelAllocation {
+  allocation_state: MlDeploymentState
+  routing_table: Record<string, MlTrainedModelAllocationRoutingTable>
+  start_time: DateString
+  task_parameters: MlTrainedModelAllocationTaskParameters
+}
+
+export interface MlTrainedModelAllocationRoutingTable {
+  reason: string
+  routing_state: MlRoutingState
+}
+
+export interface MlTrainedModelAllocationTaskParameters {
+  model_bytes: integer
+  model_id: Id
 }
 
 export interface MlTrainedModelConfig {
@@ -11552,6 +11512,14 @@ export interface MlTrainedModelConfigMetadata {
   feature_importance_baseline?: Record<string, string>
   hyperparameters?: MlHyperparameter[]
   total_feature_importance?: MlTotalFeatureImportance[]
+}
+
+export interface MlTrainedModelEntities {
+  class_name: string
+  class_probability: double
+  entity: string
+  start_pos: integer
+  end_pos: integer
 }
 
 export interface MlTrainedModelInferenceStats {
@@ -11888,8 +11856,8 @@ export interface MlGetCategoriesRequest extends RequestBase {
   job_id: Id
   category_id?: CategoryId
   from?: integer
-  size?: integer
   partition_field_value?: string
+  size?: integer
   page?: MlPage
 }
 
@@ -12074,6 +12042,22 @@ export interface MlGetTrainedModelsStatsResponse {
   trained_model_stats: MlTrainedModelStats[]
 }
 
+export interface MlInferTrainedModelDeploymentRequest extends RequestBase {
+  model_id: Id
+  timeout?: Time
+  docs: Record<string, string>[]
+}
+
+export interface MlInferTrainedModelDeploymentResponse {
+  entities?: MlTrainedModelEntities[]
+  is_truncated?: boolean
+  predicted_value?: MlPredictedValue[]
+  predicted_value_sequence?: string
+  prediction_probability?: double
+  top_classes: MlTopClassEntry[]
+  warning?: string
+}
+
 export interface MlInfoAnomalyDetectors {
   categorization_analyzer: MlCategorizationAnalyzer
   categorization_examples_limit: integer
@@ -12243,7 +12227,7 @@ export interface MlPutDatafeedRequest extends RequestBase {
   frequency?: Time
   indices?: string[]
   indexes?: string[]
-  indices_options?: MlDatafeedIndicesOptions
+  indices_options?: IndicesOptions
   job_id?: Id
   max_empty_searches?: integer
   query?: QueryDslQueryContainer
@@ -12261,7 +12245,7 @@ export interface MlPutDatafeedResponse {
   frequency: Time
   indices: string[]
   job_id: Id
-  indices_options?: MlDatafeedIndicesOptions
+  indices_options?: IndicesOptions
   max_empty_searches: integer
   query: QueryDslQueryContainer
   query_delay: Time
@@ -12424,6 +12408,25 @@ export interface MlPutTrainedModelAliasRequest extends RequestBase {
 export interface MlPutTrainedModelAliasResponse extends AcknowledgedResponseBase {
 }
 
+export interface MlPutTrainedModelDefinitionPartRequest extends RequestBase {
+  model_id: Id
+  part: integer
+  definition: string
+  total_definition_length: long
+  total_parts: integer
+}
+
+export interface MlPutTrainedModelDefinitionPartResponse extends AcknowledgedResponseBase {
+}
+
+export interface MlPutTrainedModelVocabularyRequest extends RequestBase {
+  model_id: Id
+  vocabulary: string[]
+}
+
+export interface MlPutTrainedModelVocabularyResponse extends AcknowledgedResponseBase {
+}
+
 export interface MlResetJobRequest extends RequestBase {
   job_id: Id
   wait_for_completion?: boolean
@@ -12471,6 +12474,19 @@ export interface MlStartDatafeedResponse {
   started: boolean
 }
 
+export interface MlStartTrainedModelDeploymentRequest extends RequestBase {
+  model_id: Id
+  inference_threads?: integer
+  model_threads?: integer
+  queue_capacity?: integer
+  timeout?: Time
+  wait_for?: MlDeploymentState
+}
+
+export interface MlStartTrainedModelDeploymentResponse {
+  allocation: MlTrainedModelAllocation
+}
+
 export interface MlStopDataFrameAnalyticsRequest extends RequestBase {
   id: Id
   allow_no_match?: boolean
@@ -12490,6 +12506,16 @@ export interface MlStopDatafeedRequest extends RequestBase {
 }
 
 export interface MlStopDatafeedResponse {
+  stopped: boolean
+}
+
+export interface MlStopTrainedModelDeploymentRequest extends RequestBase {
+  model_id: Id
+  allow_no_match?: boolean
+  force?: boolean
+}
+
+export interface MlStopTrainedModelDeploymentResponse {
   stopped: boolean
 }
 
@@ -12527,7 +12553,7 @@ export interface MlUpdateDatafeedRequest extends RequestBase {
   frequency?: Time
   indices?: string[]
   indexes?: string[]
-  indices_options?: MlDatafeedIndicesOptions
+  indices_options?: IndicesOptions
   max_empty_searches?: integer
   query?: QueryDslQueryContainer
   query_delay?: Time
@@ -12544,7 +12570,7 @@ export interface MlUpdateDatafeedResponse {
   frequency: Time
   indices: string[]
   job_id: Id
-  indices_options?: MlDatafeedIndicesOptions
+  indices_options?: IndicesOptions
   max_empty_searches: integer
   query: QueryDslQueryContainer
   query_delay: Time
@@ -12668,26 +12694,100 @@ export interface MonitoringBulkResponse {
 }
 
 export interface NodesAdaptiveSelection {
-  avg_queue_size: long
-  avg_response_time: long
-  avg_response_time_ns: long
-  avg_service_time: string
-  avg_service_time_ns: long
-  outgoing_searches: long
-  rank: string
+  avg_queue_size?: long
+  avg_response_time?: long
+  avg_response_time_ns?: long
+  avg_service_time?: string
+  avg_service_time_ns?: long
+  outgoing_searches?: long
+  rank?: string
 }
 
 export interface NodesBreaker {
-  estimated_size: string
-  estimated_size_in_bytes: long
-  limit_size: string
-  limit_size_in_bytes: long
-  overhead: float
-  tripped: float
+  estimated_size?: string
+  estimated_size_in_bytes?: long
+  limit_size?: string
+  limit_size_in_bytes?: long
+  overhead?: float
+  tripped?: float
+}
+
+export interface NodesCgroup {
+  cpuacct?: NodesCpuAcct
+  cpu?: NodesCgroupCpu
+  memory?: NodesCgroupMemory
+}
+
+export interface NodesCgroupCpu {
+  control_group?: string
+  cfs_period_micros?: integer
+  cfs_quota_micros?: integer
+  stat?: NodesCgroupCpuStat
+}
+
+export interface NodesCgroupCpuStat {
+  number_of_elapsed_periods?: long
+  number_of_times_throttled?: long
+  time_throttled_nanos?: long
+}
+
+export interface NodesCgroupMemory {
+  control_group?: string
+  limit_in_bytes?: string
+  usage_in_bytes?: string
+}
+
+export interface NodesClient {
+  id?: long
+  agent?: string
+  local_address?: string
+  remote_address?: string
+  last_uri?: string
+  opened_time_millis?: long
+  closed_time_millis?: long
+  last_request_time_millis?: long
+  request_count?: long
+  request_size_bytes?: long
+  x_opaque_id?: string
+}
+
+export interface NodesClusterAppliedStats {
+  recordings?: NodesRecording[]
+}
+
+export interface NodesClusterStateQueue {
+  total?: long
+  pending?: long
+  committed?: long
+}
+
+export interface NodesClusterStateUpdate {
+  count?: long
+  computation_time?: string
+  computation_time_millis?: long
+  publication_time?: string
+  publication_time_millis?: long
+  context_construction_time?: string
+  context_construction_time_millis?: long
+  commit_time?: string
+  commit_time_millis?: long
+  completion_time?: string
+  completion_time_millis?: long
+  master_apply_time?: string
+  master_apply_time_millis?: long
+  notification_time?: string
+  notification_time_millis?: long
+}
+
+export interface NodesContext {
+  context?: string
+  compilations?: long
+  cache_evictions?: long
+  compilation_limit_triggered?: long
 }
 
 export interface NodesCpu {
-  percent: integer
+  percent?: integer
   sys?: string
   sys_in_millis?: long
   total?: string
@@ -12697,182 +12797,306 @@ export interface NodesCpu {
   load_average?: Record<string, double>
 }
 
+export interface NodesCpuAcct {
+  control_group?: string
+  usage_nanos?: long
+}
+
 export interface NodesDataPathStats {
-  available: string
-  available_in_bytes: long
-  disk_queue: string
-  disk_reads: long
-  disk_read_size: string
-  disk_read_size_in_bytes: long
-  disk_writes: long
-  disk_write_size: string
-  disk_write_size_in_bytes: long
-  free: string
-  free_in_bytes: long
-  mount: string
-  path: string
-  total: string
-  total_in_bytes: long
-  type: string
+  available?: string
+  available_in_bytes?: long
+  disk_queue?: string
+  disk_reads?: long
+  disk_read_size?: string
+  disk_read_size_in_bytes?: long
+  disk_writes?: long
+  disk_write_size?: string
+  disk_write_size_in_bytes?: long
+  free?: string
+  free_in_bytes?: long
+  mount?: string
+  path?: string
+  total?: string
+  total_in_bytes?: long
+  type?: string
+}
+
+export interface NodesDiscovery {
+  cluster_state_queue?: NodesClusterStateQueue
+  published_cluster_states?: NodesPublishedClusterStates
+  cluster_state_update?: Record<string, NodesClusterStateUpdate>
+  serialized_cluster_states?: NodesSerializedClusterState
+  cluster_applier_stats?: NodesClusterAppliedStats
 }
 
 export interface NodesExtendedMemoryStats extends NodesMemoryStats {
-  free_percent: integer
-  used_percent: integer
+  free_percent?: integer
+  used_percent?: integer
 }
 
 export interface NodesFileSystem {
-  data: NodesDataPathStats[]
-  timestamp: long
-  total: NodesFileSystemTotal
+  data?: NodesDataPathStats[]
+  timestamp?: long
+  total?: NodesFileSystemTotal
+  io_stats?: NodesIoStats
 }
 
 export interface NodesFileSystemTotal {
-  available: string
-  available_in_bytes: long
-  free: string
-  free_in_bytes: long
-  total: string
-  total_in_bytes: long
+  available?: string
+  available_in_bytes?: long
+  free?: string
+  free_in_bytes?: long
+  total?: string
+  total_in_bytes?: long
 }
 
 export interface NodesGarbageCollector {
-  collectors: Record<string, NodesGarbageCollectorTotal>
+  collectors?: Record<string, NodesGarbageCollectorTotal>
 }
 
 export interface NodesGarbageCollectorTotal {
-  collection_count: long
-  collection_time: string
-  collection_time_in_millis: long
+  collection_count?: long
+  collection_time?: string
+  collection_time_in_millis?: long
 }
 
 export interface NodesHttp {
-  current_open: integer
-  total_opened: long
+  current_open?: integer
+  total_opened?: long
+  clients?: NodesClient[]
+}
+
+export interface NodesIndexingPressure {
+  memory?: NodesIndexingPressureMemory
+}
+
+export interface NodesIndexingPressureMemory {
+  limit_in_bytes?: long
+  current?: NodesPressureMemory
+  total?: NodesPressureMemory
 }
 
 export interface NodesIngest {
-  pipelines: Record<string, NodesIngestTotal>
-  total: NodesIngestTotal
+  pipelines?: Record<string, NodesIngestTotal>
+  total?: NodesIngestTotal
 }
 
 export interface NodesIngestTotal {
-  count: long
-  current: long
-  failed: long
-  processors: NodesKeyedProcessor[]
-  time_in_millis: long
+  count?: long
+  current?: long
+  failed?: long
+  processors?: Record<string, NodesKeyedProcessor>[]
+  time_in_millis?: long
+}
+
+export interface NodesIoStatDevice {
+  device_name?: string
+  operations?: long
+  read_kilobytes?: long
+  read_operations?: long
+  write_kilobytes?: long
+  write_operations?: long
+}
+
+export interface NodesIoStats {
+  devices?: NodesIoStatDevice[]
+  total?: NodesIoStatDevice
 }
 
 export interface NodesJvm {
-  buffer_pools: Record<string, NodesNodeBufferPool>
-  classes: NodesJvmClasses
-  gc: NodesGarbageCollector
-  mem: NodesMemoryStats
-  threads: NodesJvmThreads
-  timestamp: long
-  uptime: string
-  uptime_in_millis: long
+  buffer_pools?: Record<string, NodesNodeBufferPool>
+  classes?: NodesJvmClasses
+  gc?: NodesGarbageCollector
+  mem?: NodesJvmMemoryStats
+  threads?: NodesJvmThreads
+  timestamp?: long
+  uptime?: string
+  uptime_in_millis?: long
 }
 
 export interface NodesJvmClasses {
-  current_loaded_count: long
-  total_loaded_count: long
-  total_unloaded_count: long
+  current_loaded_count?: long
+  total_loaded_count?: long
+  total_unloaded_count?: long
+}
+
+export interface NodesJvmMemoryStats {
+  heap_used_in_bytes?: long
+  heap_used_percent?: long
+  heap_committed_in_bytes?: long
+  heap_max_in_bytes?: long
+  non_heap_used_in_bytes?: long
+  non_heap_committed_in_bytes?: long
+  pools?: Record<string, NodesPool>
 }
 
 export interface NodesJvmThreads {
-  count: long
-  peak_count: long
+  count?: long
+  peak_count?: long
 }
 
 export interface NodesKeyedProcessor {
-  statistics: NodesProcess
-  type: string
+  stats?: NodesProcessor
+  type?: string
 }
 
 export interface NodesMemoryStats {
+  adjusted_total_in_bytes?: long
   resident?: string
   resident_in_bytes?: long
   share?: string
   share_in_bytes?: long
   total_virtual?: string
   total_virtual_in_bytes?: long
-  total_in_bytes: long
-  free_in_bytes: long
-  used_in_bytes: long
+  total_in_bytes?: long
+  free_in_bytes?: long
+  used_in_bytes?: long
 }
 
 export interface NodesNodeBufferPool {
-  count: long
-  total_capacity: string
-  total_capacity_in_bytes: long
-  used: string
-  used_in_bytes: long
+  count?: long
+  total_capacity?: string
+  total_capacity_in_bytes?: long
+  used?: string
+  used_in_bytes?: long
 }
 
 export interface NodesNodesResponseBase {
-  _nodes: NodeStatistics
+  _nodes?: NodeStatistics
 }
 
 export interface NodesOperatingSystem {
-  cpu: NodesCpu
-  mem: NodesExtendedMemoryStats
-  swap: NodesMemoryStats
-  timestamp: long
+  cpu?: NodesCpu
+  mem?: NodesExtendedMemoryStats
+  swap?: NodesMemoryStats
+  cgroup?: NodesCgroup
+  timestamp?: long
+}
+
+export interface NodesPool {
+  used_in_bytes?: long
+  max_in_bytes?: long
+  peak_used_in_bytes?: long
+  peak_max_in_bytes?: long
+}
+
+export interface NodesPressureMemory {
+  combined_coordinating_and_primary_in_bytes?: long
+  coordinating_in_bytes?: long
+  primary_in_bytes?: long
+  replica_in_bytes?: long
+  all_in_bytes?: long
+  coordinating_rejections?: long
+  primary_rejections?: long
+  replica_rejections?: long
 }
 
 export interface NodesProcess {
-  cpu: NodesCpu
-  mem: NodesMemoryStats
-  open_file_descriptors: integer
-  timestamp: long
+  cpu?: NodesCpu
+  mem?: NodesMemoryStats
+  open_file_descriptors?: integer
+  max_file_descriptors?: integer
+  timestamp?: long
+}
+
+export interface NodesProcessor {
+  count?: long
+  current?: long
+  failed?: long
+  time_in_millis?: long
+}
+
+export interface NodesPublishedClusterStates {
+  full_states?: long
+  incompatible_diffs?: long
+  compatible_diffs?: long
+}
+
+export interface NodesRecording {
+  name?: string
+  cumulative_execution_count?: long
+  cumulative_execution_time?: string
+  cumulative_execution_time_millis?: long
+}
+
+export interface NodesScriptCache {
+  cache_evictions?: long
+  compilation_limit_triggered?: long
+  compilations?: long
+  context?: string
 }
 
 export interface NodesScripting {
-  cache_evictions: long
-  compilations: long
+  cache_evictions?: long
+  compilations?: long
+  compilation_limit_triggered?: long
+  contexts?: NodesContext[]
+}
+
+export interface NodesSerializedClusterState {
+  full_states?: NodesSerializedClusterStateDetail
+  diffs?: NodesSerializedClusterStateDetail
+}
+
+export interface NodesSerializedClusterStateDetail {
+  count?: long
+  uncompressed_size?: string
+  uncompressed_size_in_bytes?: long
+  compressed_size?: string
+  compressed_size_in_bytes?: long
 }
 
 export interface NodesStats {
-  adaptive_selection: Record<string, NodesAdaptiveSelection>
-  breakers: Record<string, NodesBreaker>
-  fs: NodesFileSystem
-  host: Host
-  http: NodesHttp
-  indices: IndicesStatsIndexStats
-  ingest: NodesIngest
-  ip: Ip | Ip[]
-  jvm: NodesJvm
-  name: Name
-  os: NodesOperatingSystem
-  process: NodesProcess
-  roles: NodeRoles
-  script: NodesScripting
-  thread_pool: Record<string, NodesThreadCount>
-  timestamp: long
-  transport: NodesTransport
-  transport_address: TransportAddress
-  attributes: Record<Field, string>
+  adaptive_selection?: Record<string, NodesAdaptiveSelection>
+  breakers?: Record<string, NodesBreaker>
+  fs?: NodesFileSystem
+  host?: Host
+  http?: NodesHttp
+  ingest?: NodesIngest
+  ip?: Ip | Ip[]
+  jvm?: NodesJvm
+  name?: Name
+  os?: NodesOperatingSystem
+  process?: NodesProcess
+  roles?: NodeRoles
+  script?: NodesScripting
+  script_cache?: Record<string, NodesScriptCache | NodesScriptCache[]>
+  thread_pool?: Record<string, NodesThreadCount>
+  timestamp?: long
+  transport?: NodesTransport
+  transport_address?: TransportAddress
+  attributes?: Record<Field, string>
+  discovery?: NodesDiscovery
+  indexing_pressure?: NodesIndexingPressure
+  indices?: IndicesStatsShardStats
 }
 
 export interface NodesThreadCount {
-  active: long
-  completed: long
-  largest: long
-  queue: long
-  rejected: long
-  threads: long
+  active?: long
+  completed?: long
+  largest?: long
+  queue?: long
+  rejected?: long
+  threads?: long
 }
 
 export interface NodesTransport {
-  rx_count: long
-  rx_size: string
-  rx_size_in_bytes: long
-  server_open: integer
-  tx_count: long
-  tx_size: string
-  tx_size_in_bytes: long
+  inbound_handling_time_histogram?: NodesTransportHistogram[]
+  outbound_handling_time_histogram?: NodesTransportHistogram[]
+  rx_count?: long
+  rx_size?: string
+  rx_size_in_bytes?: long
+  server_open?: integer
+  tx_count?: long
+  tx_size?: string
+  tx_size_in_bytes?: long
+  total_outbound_connections?: long
+}
+
+export interface NodesTransportHistogram {
+  count?: long
+  lt_millis?: long
+  ge_millis?: long
 }
 
 export interface NodesHotThreadsHotThread {
@@ -13279,7 +13503,7 @@ export interface NodesStatsRequest extends RequestBase {
 }
 
 export interface NodesStatsResponse extends NodesNodesResponseBase {
-  cluster_name: Name
+  cluster_name?: Name
   nodes: Record<string, NodesStats>
 }
 
@@ -13466,7 +13690,6 @@ export type RollupRollupResponse = any
 
 export interface RollupRollupSearchRequest extends RequestBase {
   index: Indices
-  type?: Type
   rest_total_hits_as_int?: boolean
   typed_keys?: boolean
   aggregations?: Record<string, AggregationsAggregationContainer>
@@ -13631,13 +13854,19 @@ export interface SecurityUser {
   enabled: boolean
 }
 
+export interface SecurityAuthenticateApiKey {
+  id: string
+  name: Name
+}
+
 export interface SecurityAuthenticateRequest extends RequestBase {
 }
 
 export interface SecurityAuthenticateResponse {
+  api_key?: SecurityAuthenticateApiKey
   authentication_realm: SecurityRealmInfo
-  email?: string
-  full_name?: Name
+  email?: string | null
+  full_name?: Name | null
   lookup_realm: SecurityRealmInfo
   metadata: Metadata
   roles: string[]
@@ -13733,6 +13962,7 @@ export interface SecurityCreateApiKeyResponse {
   expiration?: long
   id: Id
   name: Name
+  encoded: string
 }
 
 export interface SecurityCreateApiKeyRoleDescriptor {
@@ -14658,11 +14888,11 @@ export interface SqlTranslateResponse {
   size: long
   _source: SearchSourceConfig
   fields: Record<Field, string>[]
-  sort: SearchSort
+  sort: Sort
 }
 
 export interface SslCertificatesCertificateInformation {
-  alias?: string
+  alias: string | null
   expiry: DateString
   format: string
   has_private_key: boolean
@@ -14842,7 +15072,6 @@ export interface TransformPivot {
   aggregations?: Record<string, AggregationsAggregationContainer>
   aggs?: Record<string, AggregationsAggregationContainer>
   group_by?: Record<string, TransformPivotGroupByContainer>
-  max_page_search_size?: integer
 }
 
 export interface TransformPivotGroupByContainer {
@@ -14862,6 +15091,7 @@ export interface TransformRetentionPolicyContainer {
 }
 
 export interface TransformSettings {
+  align_checkpoints?: boolean
   dates_as_epoch_millis?: boolean
   docs_per_second?: float
   max_page_search_size?: integer
@@ -14877,8 +15107,9 @@ export interface TransformTimeSync {
 }
 
 export interface TransformDeleteTransformRequest extends RequestBase {
-  transform_id: Name
+  transform_id: Id
   force?: boolean
+  timeout?: Time
 }
 
 export interface TransformDeleteTransformResponse extends AcknowledgedResponseBase {
@@ -14963,6 +15194,7 @@ export interface TransformGetTransformStatsTransformStats {
 
 export interface TransformPreviewTransformRequest extends RequestBase {
   transform_id?: Id
+  timeout?: Time
   dest?: ReindexDestination
   description?: string
   frequency?: Time
@@ -14982,22 +15214,32 @@ export interface TransformPreviewTransformResponse<TTransform = unknown> {
 export interface TransformPutTransformRequest extends RequestBase {
   transform_id: Id
   defer_validation?: boolean
+  timeout?: Time
   dest: ReindexDestination
   description?: string
   frequency?: Time
-  pivot?: TransformPivot
-  source: ReindexSource
-  settings?: TransformSettings
-  sync?: TransformSyncContainer
-  retention_policy?: TransformRetentionPolicyContainer
   latest?: TransformLatest
+  _meta?: Record<string, string>
+  pivot?: TransformPivot
+  retention_policy?: TransformRetentionPolicyContainer
+  settings?: TransformSettings
+  source: ReindexSource
+  sync?: TransformSyncContainer
 }
 
 export interface TransformPutTransformResponse extends AcknowledgedResponseBase {
 }
 
+export interface TransformResetTransformRequest extends RequestBase {
+  transform_id: Id
+  force?: boolean
+}
+
+export interface TransformResetTransformResponse extends AcknowledgedResponseBase {
+}
+
 export interface TransformStartTransformRequest extends RequestBase {
-  transform_id: Name
+  transform_id: Id
   timeout?: Time
 }
 
@@ -15019,6 +15261,7 @@ export interface TransformStopTransformResponse extends AcknowledgedResponseBase
 export interface TransformUpdateTransformRequest extends RequestBase {
   transform_id: Id
   defer_validation?: boolean
+  timeout?: Time
   dest?: ReindexDestination
   description?: string
   frequency?: Time
@@ -15034,11 +15277,24 @@ export interface TransformUpdateTransformResponse {
   dest: ReindexDestination
   frequency: Time
   id: Id
-  pivot: TransformPivot
+  latest?: TransformLatest
+  pivot?: TransformPivot
+  retention_policy?: TransformRetentionPolicyContainer
   settings: TransformSettings
   source: ReindexSource
   sync?: TransformSyncContainer
   version: VersionString
+}
+
+export interface TransformUpgradeTransformsRequest extends RequestBase {
+  dry_run?: boolean
+  timeout?: Time
+}
+
+export interface TransformUpgradeTransformsResponse {
+  needs_update: integer
+  no_action: integer
+  updated: integer
 }
 
 export interface WatcherAcknowledgeState {
@@ -15270,14 +15526,6 @@ export interface WatcherIndexResultSummary {
   index: IndexName
   result: Result
   version: VersionNumber
-  type?: Type
-}
-
-export interface WatcherIndicesOptions {
-  allow_no_indices?: boolean
-  expand_wildcards?: ExpandWildcards
-  ignore_unavailable?: boolean
-  ignore_throttled?: boolean
 }
 
 export interface WatcherInputContainer {
@@ -15382,7 +15630,7 @@ export interface WatcherSearchInputRequestBody {
 export interface WatcherSearchInputRequestDefinition {
   body?: WatcherSearchInputRequestBody
   indices?: IndexName[]
-  indices_options?: WatcherIndicesOptions
+  indices_options?: IndicesOptions
   search_type?: SearchType
   template?: SearchTemplateRequest
   rest_total_hits_as_int?: boolean
@@ -15606,8 +15854,8 @@ export interface WatcherQueryWatchesRequest extends RequestBase {
   from?: integer
   size?: integer
   query?: QueryDslQueryContainer
-  sort?: SearchSort
-  search_after?: SearchSortResults
+  sort?: Sort
+  search_after?: SortResults
 }
 
 export interface WatcherQueryWatchesResponse {
@@ -16129,10 +16377,10 @@ export interface XpackUsageWatcherWatchTriggerSchedule extends XpackUsageCounter
   _all: XpackUsageCounter
 }
 
-export interface SpecUtilsAdditionalProperty<TKey = unknown, TValue = unknown> {
+export interface SpecUtilsAdditionalProperties<TKey = unknown, TValue = unknown> {
 }
 
-export interface SpecUtilsAdditionalProperties<TKey = unknown, TValue = unknown> {
+export interface SpecUtilsAdditionalProperty<TKey = unknown, TValue = unknown> {
 }
 
 export interface SpecUtilsCommonQueryParameters {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -5245,7 +5245,7 @@ export interface QueryDslQueryContainer {
   terms?: QueryDslTermsQuery
   terms_set?: Partial<Record<Field, QueryDslTermsSetQuery>>
   wildcard?: Partial<Record<Field, QueryDslWildcardQuery | string>>
-  wrapper: QueryDslWrapperQuery
+  wrapper?: QueryDslWrapperQuery
   type?: QueryDslTypeQuery
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -15087,7 +15087,7 @@ export interface TransformRetentionPolicy {
 }
 
 export interface TransformRetentionPolicyContainer {
-  time: TransformRetentionPolicy
+  time?: TransformRetentionPolicy
 }
 
 export interface TransformSettings {
@@ -15098,7 +15098,7 @@ export interface TransformSettings {
 }
 
 export interface TransformSyncContainer {
-  time: TransformTimeSync
+  time?: TransformTimeSync
 }
 
 export interface TransformTimeSync {
@@ -15709,11 +15709,11 @@ export interface WatcherTimeOfYear {
 }
 
 export interface WatcherTriggerContainer {
-  schedule: WatcherScheduleContainer
+  schedule?: WatcherScheduleContainer
 }
 
 export interface WatcherTriggerEventContainer {
-  schedule: WatcherScheduleTriggerEvent
+  schedule?: WatcherScheduleTriggerEvent
 }
 
 export interface WatcherTriggerEventResult {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -587,12 +587,12 @@ export interface MsearchRequest extends RequestBase {
   searches?: (MsearchHeader | MsearchBody)[]
 }
 
-export interface MsearchResponse<TDocument = unknown> {
+export interface MsearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
   took: long
-  responses: (MsearchSearchResult<TDocument> | ErrorResponseBase)[]
+  responses: (MsearchSearchResult<TDocument, TAggregation> | ErrorResponseBase)[]
 }
 
-export interface MsearchSearchResult<TDocument = unknown> extends SearchResponse<TDocument> {
+export interface MsearchSearchResult<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregation> {
   status: integer
 }
 
@@ -606,8 +606,8 @@ export interface MsearchTemplateRequest extends RequestBase {
   search_templates?: MsearchTemplateTemplateItem[]
 }
 
-export interface MsearchTemplateResponse<TDocument = unknown> {
-  responses: (SearchResponse<TDocument> | ErrorResponseBase)[]
+export interface MsearchTemplateResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
+  responses: (SearchResponse<TDocument, TAggregation> | ErrorResponseBase)[]
   took: long
 }
 
@@ -919,7 +919,7 @@ export interface ScrollRequest extends RequestBase {
   rest_total_hits_as_int?: boolean
 }
 
-export interface ScrollResponse<TDocument = unknown> extends SearchResponse<TDocument> {
+export interface ScrollResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregation> {
 }
 
 export interface SearchRequest extends RequestBase {
@@ -986,12 +986,12 @@ export interface SearchRequest extends RequestBase {
   runtime_mappings?: MappingRuntimeFields
 }
 
-export interface SearchResponse<TDocument = unknown> {
+export interface SearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
   took: long
   timed_out: boolean
   _shards: ShardStatistics
   hits: SearchHitsMetadata<TDocument>
-  aggregations?: Record<AggregateName, AggregationsAggregate>
+  aggregations?: TAggregation
   _clusters?: ClusterStatistics
   documents?: TDocument[]
   fields?: Record<string, any>
@@ -5183,8 +5183,8 @@ export interface QueryDslWildcardQuery extends QueryDslQueryBase {
 
 export type QueryDslZeroTermsQuery = 'all' | 'none'
 
-export interface AsyncSearchAsyncSearch<TDocument = unknown> {
-  aggregations?: Record<AggregateName, AggregationsAggregate>
+export interface AsyncSearchAsyncSearch<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
+  aggregations?: TAggregation
   _clusters?: ClusterStatistics
   fields?: Record<string, any>
   hits: SearchHitsMetadata<TDocument>
@@ -5200,8 +5200,8 @@ export interface AsyncSearchAsyncSearch<TDocument = unknown> {
   took: long
 }
 
-export interface AsyncSearchAsyncSearchDocumentResponseBase<TDocument = unknown> extends AsyncSearchAsyncSearchResponseBase {
-  response: AsyncSearchAsyncSearch<TDocument>
+export interface AsyncSearchAsyncSearchDocumentResponseBase<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends AsyncSearchAsyncSearchResponseBase {
+  response: AsyncSearchAsyncSearch<TDocument, TAggregation>
 }
 
 export interface AsyncSearchAsyncSearchResponseBase {
@@ -13094,13 +13094,13 @@ export interface RollupRollupSearchRequest extends RequestBase {
   size?: integer
 }
 
-export interface RollupRollupSearchResponse<TDocument = unknown> {
+export interface RollupRollupSearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
   took: long
   timed_out: boolean
   terminated_early?: boolean
   _shards: ShardStatistics
   hits: SearchHitsMetadata<TDocument>
-  aggregations?: Record<AggregateName, AggregationsAggregate>
+  aggregations?: TAggregation
 }
 
 export interface RollupStartJobRequest extends RequestBase {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -587,12 +587,12 @@ export interface MsearchRequest extends RequestBase {
   searches?: (MsearchHeader | MsearchBody)[]
 }
 
-export interface MsearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
+export interface MsearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
   took: long
-  responses: (MsearchSearchResult<TDocument, TAggregation> | ErrorResponseBase)[]
+  responses: (MsearchSearchResult<TDocument, TAggregations> | ErrorResponseBase)[]
 }
 
-export interface MsearchSearchResult<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregation> {
+export interface MsearchSearchResult<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregations> {
   status: integer
 }
 
@@ -606,8 +606,8 @@ export interface MsearchTemplateRequest extends RequestBase {
   search_templates?: MsearchTemplateTemplateItem[]
 }
 
-export interface MsearchTemplateResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
-  responses: (SearchResponse<TDocument, TAggregation> | ErrorResponseBase)[]
+export interface MsearchTemplateResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
+  responses: (SearchResponse<TDocument, TAggregations> | ErrorResponseBase)[]
   took: long
 }
 
@@ -919,7 +919,7 @@ export interface ScrollRequest extends RequestBase {
   rest_total_hits_as_int?: boolean
 }
 
-export interface ScrollResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregation> {
+export interface ScrollResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregations> {
 }
 
 export interface SearchRequest extends RequestBase {
@@ -986,12 +986,12 @@ export interface SearchRequest extends RequestBase {
   runtime_mappings?: MappingRuntimeFields
 }
 
-export interface SearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
+export interface SearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
   took: long
   timed_out: boolean
   _shards: ShardStatistics
   hits: SearchHitsMetadata<TDocument>
-  aggregations?: TAggregation
+  aggregations?: TAggregations
   _clusters?: ClusterStatistics
   documents?: TDocument[]
   fields?: Record<string, any>
@@ -5183,8 +5183,8 @@ export interface QueryDslWildcardQuery extends QueryDslQueryBase {
 
 export type QueryDslZeroTermsQuery = 'all' | 'none'
 
-export interface AsyncSearchAsyncSearch<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
-  aggregations?: TAggregation
+export interface AsyncSearchAsyncSearch<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
+  aggregations?: TAggregations
   _clusters?: ClusterStatistics
   fields?: Record<string, any>
   hits: SearchHitsMetadata<TDocument>
@@ -5200,8 +5200,8 @@ export interface AsyncSearchAsyncSearch<TDocument = unknown, TAggregation = Reco
   took: long
 }
 
-export interface AsyncSearchAsyncSearchDocumentResponseBase<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends AsyncSearchAsyncSearchResponseBase {
-  response: AsyncSearchAsyncSearch<TDocument, TAggregation>
+export interface AsyncSearchAsyncSearchDocumentResponseBase<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> extends AsyncSearchAsyncSearchResponseBase {
+  response: AsyncSearchAsyncSearch<TDocument, TAggregations>
 }
 
 export interface AsyncSearchAsyncSearchResponseBase {
@@ -13094,13 +13094,13 @@ export interface RollupRollupSearchRequest extends RequestBase {
   size?: integer
 }
 
-export interface RollupRollupSearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
+export interface RollupRollupSearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
   took: long
   timed_out: boolean
   terminated_early?: boolean
   _shards: ShardStatistics
   hits: SearchHitsMetadata<TDocument>
-  aggregations?: TAggregation
+  aggregations?: TAggregations
 }
 
 export interface RollupStartJobRequest extends RequestBase {

--- a/src/api/typesWithBodyKey.ts
+++ b/src/api/typesWithBodyKey.ts
@@ -617,12 +617,12 @@ export interface MsearchRequest extends RequestBase {
   body?: (MsearchHeader | MsearchBody)[]
 }
 
-export interface MsearchResponse<TDocument = unknown> {
+export interface MsearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
   took: long
-  responses: (MsearchSearchResult<TDocument> | ErrorResponseBase)[]
+  responses: (MsearchSearchResult<TDocument, TAggregation> | ErrorResponseBase)[]
 }
 
-export interface MsearchSearchResult<TDocument = unknown> extends SearchResponse<TDocument> {
+export interface MsearchSearchResult<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregation> {
   status: integer
 }
 
@@ -637,8 +637,8 @@ export interface MsearchTemplateRequest extends RequestBase {
   body?: MsearchTemplateTemplateItem[]
 }
 
-export interface MsearchTemplateResponse<TDocument = unknown> {
-  responses: (SearchResponse<TDocument> | ErrorResponseBase)[]
+export interface MsearchTemplateResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
+  responses: (SearchResponse<TDocument, TAggregation> | ErrorResponseBase)[]
   took: long
 }
 
@@ -974,7 +974,7 @@ export interface ScrollRequest extends RequestBase {
   }
 }
 
-export interface ScrollResponse<TDocument = unknown> extends SearchResponse<TDocument> {
+export interface ScrollResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregation> {
 }
 
 export interface SearchRequest extends RequestBase {
@@ -1058,12 +1058,12 @@ export interface SearchRequest extends RequestBase {
   }
 }
 
-export interface SearchResponse<TDocument = unknown> {
+export interface SearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
   took: long
   timed_out: boolean
   _shards: ShardStatistics
   hits: SearchHitsMetadata<TDocument>
-  aggregations?: Record<AggregateName, AggregationsAggregate>
+  aggregations?: TAggregation
   _clusters?: ClusterStatistics
   documents?: TDocument[]
   fields?: Record<string, any>
@@ -5282,8 +5282,8 @@ export interface QueryDslWildcardQuery extends QueryDslQueryBase {
 
 export type QueryDslZeroTermsQuery = 'all' | 'none'
 
-export interface AsyncSearchAsyncSearch<TDocument = unknown> {
-  aggregations?: Record<AggregateName, AggregationsAggregate>
+export interface AsyncSearchAsyncSearch<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
+  aggregations?: TAggregation
   _clusters?: ClusterStatistics
   fields?: Record<string, any>
   hits: SearchHitsMetadata<TDocument>
@@ -5299,8 +5299,8 @@ export interface AsyncSearchAsyncSearch<TDocument = unknown> {
   took: long
 }
 
-export interface AsyncSearchAsyncSearchDocumentResponseBase<TDocument = unknown> extends AsyncSearchAsyncSearchResponseBase {
-  response: AsyncSearchAsyncSearch<TDocument>
+export interface AsyncSearchAsyncSearchDocumentResponseBase<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends AsyncSearchAsyncSearchResponseBase {
+  response: AsyncSearchAsyncSearch<TDocument, TAggregation>
 }
 
 export interface AsyncSearchAsyncSearchResponseBase {
@@ -13422,13 +13422,13 @@ export interface RollupRollupSearchRequest extends RequestBase {
   }
 }
 
-export interface RollupRollupSearchResponse<TDocument = unknown> {
+export interface RollupRollupSearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
   took: long
   timed_out: boolean
   terminated_early?: boolean
   _shards: ShardStatistics
   hits: SearchHitsMetadata<TDocument>
-  aggregations?: Record<AggregateName, AggregationsAggregate>
+  aggregations?: TAggregation
 }
 
 export interface RollupStartJobRequest extends RequestBase {

--- a/src/api/typesWithBodyKey.ts
+++ b/src/api/typesWithBodyKey.ts
@@ -15525,7 +15525,7 @@ export interface TransformRetentionPolicy {
 }
 
 export interface TransformRetentionPolicyContainer {
-  time: TransformRetentionPolicy
+  time?: TransformRetentionPolicy
 }
 
 export interface TransformSettings {
@@ -15536,7 +15536,7 @@ export interface TransformSettings {
 }
 
 export interface TransformSyncContainer {
-  time: TransformTimeSync
+  time?: TransformTimeSync
 }
 
 export interface TransformTimeSync {
@@ -16156,11 +16156,11 @@ export interface WatcherTimeOfYear {
 }
 
 export interface WatcherTriggerContainer {
-  schedule: WatcherScheduleContainer
+  schedule?: WatcherScheduleContainer
 }
 
 export interface WatcherTriggerEventContainer {
-  schedule: WatcherScheduleTriggerEvent
+  schedule?: WatcherScheduleTriggerEvent
 }
 
 export interface WatcherTriggerEventResult {

--- a/src/api/typesWithBodyKey.ts
+++ b/src/api/typesWithBodyKey.ts
@@ -58,7 +58,6 @@ export type BulkOperationType = 'index' | 'create' | 'update' | 'delete'
 
 export interface BulkRequest<TSource = unknown> extends RequestBase {
   index?: IndexName
-  type?: Type
   pipeline?: string
   refresh?: Refresh
   routing?: Routing
@@ -88,7 +87,6 @@ export interface BulkResponseItem {
   result?: string
   _seq_no?: SequenceNumber
   _shards?: ShardStatistics
-  _type?: string
   _version?: VersionNumber
   forced_refresh?: boolean
   get?: InlineGet<Record<string, any>>
@@ -160,7 +158,6 @@ export interface CountResponse {
 export interface CreateRequest<TDocument = unknown> extends RequestBase {
   id: Id
   index: IndexName
-  type?: Type
   pipeline?: string
   refresh?: Refresh
   routing?: Routing
@@ -178,7 +175,6 @@ export interface CreateResponse extends WriteResponseBase {
 export interface DeleteRequest extends RequestBase {
   id: Id
   index: IndexName
-  type?: Type
   if_primary_term?: long
   if_seq_no?: SequenceNumber
   refresh?: Refresh
@@ -215,12 +211,8 @@ export interface DeleteByQueryRequest extends RequestBase {
   scroll_size?: long
   search_timeout?: Time
   search_type?: SearchType
-  size?: long
   slices?: long
   sort?: string[]
-  _source?: SearchSourceConfigParam
-  _source_excludes?: Fields
-  _source_includes?: Fields
   stats?: string[]
   terminate_after?: long
   timeout?: Time
@@ -289,7 +281,6 @@ export type ExistsResponse = boolean
 export interface ExistsSourceRequest extends RequestBase {
   id: Id
   index: IndexName
-  type?: Type
   preference?: string
   realtime?: boolean
   refresh?: boolean
@@ -338,7 +329,6 @@ export interface ExplainRequest extends RequestBase {
 
 export interface ExplainResponse<TDocument = unknown> {
   _index: IndexName
-  _type?: Type
   _id: Id
   matched: boolean
   explanation?: ExplainExplanationDetail
@@ -384,7 +374,6 @@ export interface GetGetResult<TDocument = unknown> {
   _routing?: string
   _seq_no?: SequenceNumber
   _source?: TDocument
-  _type?: Type
   _version?: VersionNumber
 }
 
@@ -536,7 +525,6 @@ export interface MgetMultiGetError {
   error: ErrorCause
   _id: Id
   _index: IndexName
-  _type?: Type
 }
 
 export interface MgetOperation {
@@ -545,7 +533,6 @@ export interface MgetOperation {
   routing?: Routing
   _source?: SearchSourceConfig
   stored_fields?: Fields
-  _type?: Type
   version?: VersionNumber
   version_type?: VersionType
 }
@@ -621,22 +608,11 @@ export interface MsearchRequest extends RequestBase {
   body?: MsearchRequestItem[]
 }
 
-<<<<<<< HEAD
-export interface MsearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
-  took: long
-  responses: (MsearchSearchResult<TDocument, TAggregations> | ErrorResponseBase)[]
-}
-
-export interface MsearchSearchResult<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregations> {
-  status: integer
-}
-=======
 export type MsearchRequestItem = MsearchMultisearchHeader | MsearchMultisearchBody
 
-export type MsearchResponse<TDocument = unknown> = MsearchMultiSearchResult<TDocument>
+export type MsearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = MsearchMultiSearchResult<TDocument>
 
 export type MsearchResponseItem<TDocument = unknown> = MsearchMultiSearchItem<TDocument> | ErrorResponseBase
->>>>>>> main
 
 export interface MsearchTemplateRequest extends RequestBase {
   index?: Indices
@@ -649,16 +625,9 @@ export interface MsearchTemplateRequest extends RequestBase {
   body?: MsearchTemplateRequestItem[]
 }
 
-<<<<<<< HEAD
-export interface MsearchTemplateResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
-  responses: (SearchResponse<TDocument, TAggregations> | ErrorResponseBase)[]
-  took: long
-}
-=======
 export type MsearchTemplateRequestItem = MsearchMultisearchHeader | MsearchTemplateTemplateConfig
->>>>>>> main
 
-export type MsearchTemplateResponse<TDocument = unknown> = MsearchMultiSearchResult<TDocument>
+export type MsearchTemplateResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = MsearchMultiSearchResult<TDocument>
 
 export interface MsearchTemplateTemplateConfig {
   explain?: boolean
@@ -756,7 +725,6 @@ export interface RankEvalDocumentRating {
 export interface RankEvalRankEvalHit {
   _id: Id
   _index: IndexName
-  _type?: Type
   _score: double
 }
 
@@ -904,7 +872,7 @@ export interface ReindexSource {
   remote?: ReindexRemoteSource
   size?: integer
   slice?: SlicedScroll
-  sort?: SearchSort
+  sort?: Sort
   _source?: Fields
   runtime_mappings?: MappingRuntimeFields
 }
@@ -1058,10 +1026,10 @@ export interface SearchRequest extends RequestBase {
     query?: QueryDslQueryContainer
     rescore?: SearchRescore | SearchRescore[]
     script_fields?: Record<string, ScriptField>
-    search_after?: SearchSortResults
+    search_after?: SortResults
     size?: integer
     slice?: SlicedScroll
-    sort?: SearchSort
+    sort?: Sort
     _source?: SearchSourceConfig
     fields?: (QueryDslFieldAndFormat | Field)[]
     suggest?: SearchSuggester
@@ -1084,7 +1052,6 @@ export interface SearchResponse<TDocument = unknown, TAggregations = Record<Aggr
   hits: SearchHitsMetadata<TDocument>
   aggregations?: TAggregations
   _clusters?: ClusterStatistics
-  documents?: TDocument[]
   fields?: Record<string, any>
   max_score?: double
   num_reduce_phases?: long
@@ -1183,7 +1150,6 @@ export interface SearchCompletionSuggestOption<TDocument = unknown> {
   fields?: Record<string, any>
   _id: string
   _index: IndexName
-  _type?: Type
   _routing?: Routing
   _score: double
   _source: TDocument
@@ -1243,18 +1209,6 @@ export interface SearchFieldCollapse {
   max_concurrent_group_searches?: integer
 }
 
-export interface SearchFieldSort {
-  missing?: AggregationsMissing
-  mode?: SearchSortMode
-  nested?: SearchNestedSortValue
-  order?: SearchSortOrder
-  unmapped_type?: MappingFieldType
-  numeric_type?: SearchFieldSortNumericType
-  format?: string
-}
-
-export type SearchFieldSortNumericType = 'long' | 'double' | 'date' | 'date_nanos'
-
 export interface SearchFieldSuggester {
   completion?: SearchCompletionSuggester
   phrase?: SearchPhraseSuggester
@@ -1263,16 +1217,6 @@ export interface SearchFieldSuggester {
   term?: SearchTermSuggester
   text?: string
 }
-
-export interface SearchGeoDistanceSortKeys {
-  mode?: SearchSortMode
-  distance_type?: GeoDistanceType
-  ignore_unmapped?: boolean
-  order?: SearchSortOrder
-  unit?: DistanceUnit
-}
-export type SearchGeoDistanceSort = SearchGeoDistanceSortKeys
-& { [property: string]: GeoLocation | GeoLocation[] | SearchSortMode | GeoDistanceType | boolean | SearchSortOrder | DistanceUnit }
 
 export interface SearchHighlight {
   fields: Record<Field, SearchHighlightField>
@@ -1334,8 +1278,7 @@ export type SearchHighlighterType = SearchBuiltinHighlighterType | string
 export interface SearchHit<TDocument = unknown> {
   _index: IndexName
   _id: Id
-  _score?: double
-  _type?: Type
+  _score?: double | null
   _explanation?: ExplainExplanation
   fields?: Record<string, any>
   highlight?: Record<string, string[]>
@@ -1350,13 +1293,13 @@ export interface SearchHit<TDocument = unknown> {
   _seq_no?: SequenceNumber
   _primary_term?: long
   _version?: VersionNumber
-  sort?: SearchSortResults
+  sort?: SortResults
 }
 
 export interface SearchHitsMetadata<T = unknown> {
-  total: SearchTotalHits | long
+  total?: SearchTotalHits | long
   hits: SearchHit<T>[]
-  max_score?: double
+  max_score?: double | null
 }
 
 export interface SearchInnerHits {
@@ -1371,7 +1314,7 @@ export interface SearchInnerHits {
   script_fields?: Record<Field, ScriptField>
   seq_no_primary_term?: boolean
   fields?: Fields
-  sort?: SearchSort
+  sort?: Sort
   _source?: SearchSourceConfig
   stored_field?: Fields
   track_scores?: boolean
@@ -1396,13 +1339,6 @@ export interface SearchNestedIdentity {
   field: Field
   offset: integer
   _nested?: SearchNestedIdentity
-}
-
-export interface SearchNestedSortValue {
-  filter?: QueryDslQueryContainer
-  max_children?: integer
-  nested?: SearchNestedSortValue
-  path: Field
 }
 
 export interface SearchPhraseSuggestCollate {
@@ -1495,20 +1431,6 @@ export interface SearchRescoreQuery {
 
 export type SearchScoreMode = 'avg' | 'max' | 'min' | 'multiply' | 'total'
 
-export interface SearchScoreSort {
-  order?: SearchSortOrder
-}
-
-export interface SearchScriptSort {
-  order?: SearchSortOrder
-  script: Script
-  type?: SearchScriptSortType
-  mode?: SearchSortMode
-  nested?: SearchNestedSortValue
-}
-
-export type SearchScriptSortType = 'string' | 'number'
-
 export interface SearchSearchProfile {
   collector: SearchCollector[]
   query: SearchQueryProfile[]
@@ -1527,25 +1449,6 @@ export interface SearchSmoothingModelContainer {
   linear_interpolation?: SearchLinearInterpolationSmoothingModel
   stupid_backoff?: SearchStupidBackoffSmoothingModel
 }
-
-export type SearchSort = SearchSortCombinations | SearchSortCombinations[]
-
-export type SearchSortCombinations = Field | SearchSortOptions
-
-export type SearchSortMode = 'min' | 'max' | 'sum' | 'avg' | 'median'
-
-export interface SearchSortOptionsKeys {
-  _score?: SearchScoreSort
-  _doc?: SearchScoreSort
-  _geo_distance?: SearchGeoDistanceSort
-  _script?: SearchScriptSort
-}
-export type SearchSortOptions = SearchSortOptionsKeys
-& { [property: string]: SearchFieldSort | SearchSortOrder | SearchScoreSort | SearchGeoDistanceSort | SearchScriptSort }
-
-export type SearchSortOrder = 'asc' | 'desc'
-
-export type SearchSortResults = (long | double | string | null)[]
 
 export type SearchSourceConfig = boolean | SearchSourceFilter | Fields
 
@@ -1647,7 +1550,7 @@ export interface SearchMvtRequest extends RequestBase {
     query?: QueryDslQueryContainer
     runtime_mappings?: MappingRuntimeFields
     size?: integer
-    sort?: SearchSort
+    sort?: Sort
   }
 }
 
@@ -1776,7 +1679,6 @@ export interface TermvectorsResponse {
   _index: IndexName
   term_vectors?: Record<Field, TermvectorsTermVector>
   took: long
-  _type?: Type
   _version: VersionNumber
 }
 
@@ -1803,7 +1705,6 @@ export interface TermvectorsToken {
 export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> extends RequestBase {
   id: Id
   index: IndexName
-  type?: Type
   if_primary_term?: long
   if_seq_no?: SequenceNumber
   lang?: string
@@ -1844,6 +1745,7 @@ export interface UpdateByQueryRequest extends RequestBase {
   from?: long
   ignore_unavailable?: boolean
   lenient?: boolean
+  max_docs?: long
   pipeline?: string
   preference?: string
   refresh?: boolean
@@ -1854,12 +1756,8 @@ export interface UpdateByQueryRequest extends RequestBase {
   scroll_size?: long
   search_timeout?: Time
   search_type?: SearchType
-  size?: long
   slices?: long
   sort?: string[]
-  _source?: SearchSourceConfigParam
-  _source_excludes?: Fields
-  _source_includes?: Fields
   stats?: string[]
   terminate_after?: long
   timeout?: Time
@@ -1997,7 +1895,7 @@ export type DistanceUnit = 'in' | 'ft' | 'yd' | 'mi' | 'nmi' | 'km' | 'm' | 'cm'
 
 export interface DocStats {
   count: long
-  deleted: long
+  deleted?: long
 }
 
 export interface ElasticsearchVersionInfo {
@@ -2049,6 +1947,18 @@ export interface FieldSizeUsage {
   size_in_bytes: long
 }
 
+export interface FieldSort {
+  missing?: AggregationsMissing
+  mode?: SortMode
+  nested?: NestedSortValue
+  order?: SortOrder
+  unmapped_type?: MappingFieldType
+  numeric_type?: FieldSortNumericType
+  format?: string
+}
+
+export type FieldSortNumericType = 'long' | 'double' | 'date' | 'date_nanos'
+
 export type FieldValue = long | double | string | boolean
 
 export interface FielddataStats {
@@ -2070,6 +1980,16 @@ export interface FlushStats {
 export type Fuzziness = string | integer
 
 export type GeoBounds = CoordsGeoBounds | TopLeftBottomRightGeoBounds | TopRightBottomLeftGeoBounds | WktGeoBounds
+
+export interface GeoDistanceSortKeys {
+  mode?: SortMode
+  distance_type?: GeoDistanceType
+  ignore_unmapped?: boolean
+  order?: SortOrder
+  unit?: DistanceUnit
+}
+export type GeoDistanceSort = GeoDistanceSortKeys
+& { [property: string]: GeoLocation | GeoLocation[] | SortMode | GeoDistanceType | boolean | SortOrder | DistanceUnit }
 
 export type GeoDistanceType = 'arc' | 'plane'
 
@@ -2146,6 +2066,13 @@ export interface IndexingStats {
 
 export type Indices = IndexName | IndexName[]
 
+export interface IndicesOptions {
+  allow_no_indices?: boolean
+  expand_wildcards?: ExpandWildcards
+  ignore_unavailable?: boolean
+  ignore_throttled?: boolean
+}
+
 export interface IndicesResponseBase extends AcknowledgedResponseBase {
   _shards?: ShardStatistics
 }
@@ -2212,6 +2139,13 @@ export type Name = string
 export type Names = Name | Name[]
 
 export type Namespace = string
+
+export interface NestedSortValue {
+  filter?: QueryDslQueryContainer
+  max_children?: integer
+  nested?: NestedSortValue
+  path: Field
+}
 
 export interface NodeAttributes {
   attributes: Record<string, string>
@@ -2315,7 +2249,7 @@ export interface RequestCacheStats {
   miss_count: long
 }
 
-export type Result = 'Error' | 'created' | 'updated' | 'deleted' | 'not_found' | 'noop'
+export type Result = 'created' | 'updated' | 'deleted' | 'not_found' | 'noop'
 
 export interface Retries {
   bulk: long
@@ -2323,6 +2257,10 @@ export interface Retries {
 }
 
 export type Routing = string
+
+export interface ScoreSort {
+  order?: SortOrder
+}
 
 export type Script = InlineScript | string | StoredScriptId
 
@@ -2336,6 +2274,16 @@ export interface ScriptField {
 }
 
 export type ScriptLanguage = BuiltinScriptLanguage | string
+
+export interface ScriptSort {
+  order?: SortOrder
+  script: Script
+  type?: ScriptSortType
+  mode?: SortMode
+  nested?: NestedSortValue
+}
+
+export type ScriptSortType = 'string' | 'number'
 
 export interface ScriptTransform {
   lang: string
@@ -2425,6 +2373,25 @@ export interface SlicedScroll {
   max: integer
 }
 
+export type Sort = SortCombinations | SortCombinations[]
+
+export type SortCombinations = Field | SortOptions
+
+export type SortMode = 'min' | 'max' | 'sum' | 'avg' | 'median'
+
+export interface SortOptionsKeys {
+  _score?: ScoreSort
+  _doc?: ScoreSort
+  _geo_distance?: GeoDistanceSort
+  _script?: ScriptSort
+}
+export type SortOptions = SortOptionsKeys
+& { [property: string]: FieldSort | SortOrder | ScoreSort | GeoDistanceSort | ScriptSort }
+
+export type SortOrder = 'asc' | 'desc'
+
+export type SortResults = (long | double | string | null)[]
+
 export interface StoreStats {
   size?: ByteSize
   size_in_bytes: integer
@@ -2493,10 +2460,6 @@ export interface TranslogStats {
 
 export type TransportAddress = string
 
-export type Type = string
-
-export type Types = Type | Type[]
-
 export type Username = string
 
 export type Uuid = string
@@ -2531,7 +2494,6 @@ export interface WriteResponseBase {
   result: Result
   _seq_no: SequenceNumber
   _shards: ShardStatistics
-  _type?: Type
   _version: VersionNumber
   forced_refresh?: boolean
 }
@@ -2728,7 +2690,7 @@ export interface AggregationsBucketSortAggregation extends AggregationsAggregati
   from?: integer
   gap_policy?: AggregationsGapPolicy
   size?: integer
-  sort?: SearchSort
+  sort?: Sort
 }
 
 export type AggregationsBuckets<TBucket = unknown> = Record<string, TBucket> | TBucket[]
@@ -3002,7 +2964,7 @@ export interface AggregationsGeoLineAggregation {
   point: AggregationsGeoLinePoint
   sort: AggregationsGeoLineSort
   include_sort?: boolean
-  sort_order?: SearchSortOrder
+  sort_order?: SortOrder
   size?: integer
 }
 
@@ -3076,8 +3038,8 @@ export type AggregationsHistogramBucket = AggregationsHistogramBucketKeys
 & { [property: string]: AggregationsAggregate | string | double | long }
 
 export interface AggregationsHistogramOrder {
-  _count?: SearchSortOrder
-  _key?: SearchSortOrder
+  _count?: SortOrder
+  _key?: SortOrder
 }
 
 export interface AggregationsHoltLinearModelSettings {
@@ -3184,11 +3146,11 @@ export interface AggregationsLongTermsAggregate extends AggregationsTermsAggrega
 }
 
 export interface AggregationsLongTermsBucketKeys extends AggregationsTermsBucketBase {
-  key: string
+  key: long
   key_as_string?: string
 }
 export type AggregationsLongTermsBucket = AggregationsLongTermsBucketKeys
-& { [property: string]: AggregationsAggregate | string | long }
+& { [property: string]: AggregationsAggregate | long | string }
 
 export interface AggregationsMatrixAggregation extends AggregationsAggregation {
   fields?: Fields
@@ -3201,7 +3163,7 @@ export interface AggregationsMatrixStatsAggregate extends AggregationsAggregateB
 }
 
 export interface AggregationsMatrixStatsAggregation extends AggregationsMatrixAggregation {
-  mode?: AggregationsMatrixStatsMode
+  mode?: SortMode
 }
 
 export interface AggregationsMatrixStatsFields {
@@ -3214,8 +3176,6 @@ export interface AggregationsMatrixStatsFields {
   covariance: Record<Field, double>
   correlation: Record<Field, double>
 }
-
-export type AggregationsMatrixStatsMode = 'avg' | 'min' | 'max' | 'sum' | 'median'
 
 export interface AggregationsMaxAggregate extends AggregationsSingleMetricAggregateBase {
 }
@@ -3659,7 +3619,7 @@ export type AggregationsTermsAggregationCollectMode = 'depth_first' | 'breadth_f
 
 export type AggregationsTermsAggregationExecutionHint = 'map' | 'global_ordinals' | 'global_ordinals_hash' | 'global_ordinals_low_cardinality'
 
-export type AggregationsTermsAggregationOrder = Record<Field, SearchSortOrder> | Record<Field, SearchSortOrder>[]
+export type AggregationsTermsAggregationOrder = Record<Field, SortOrder> | Record<Field, SortOrder>[]
 
 export interface AggregationsTermsBucketBase extends AggregationsMultiBucketBase {
   doc_count_error?: long
@@ -3691,7 +3651,7 @@ export interface AggregationsTopHitsAggregation extends AggregationsMetricAggreg
   highlight?: SearchHighlight
   script_fields?: Record<string, ScriptField>
   size?: integer
-  sort?: SearchSort
+  sort?: Sort
   _source?: SearchSourceConfig
   stored_fields?: Fields
   track_scores?: boolean
@@ -3710,7 +3670,7 @@ export interface AggregationsTopMetricsAggregate extends AggregationsMultiBucket
 export interface AggregationsTopMetricsAggregation extends AggregationsMetricAggregationBase {
   metrics?: AggregationsTopMetricsValue | AggregationsTopMetricsValue[]
   size?: integer
-  sort?: SearchSort
+  sort?: Sort
 }
 
 export interface AggregationsTopMetricsBucketKeys extends AggregationsMultiBucketBase {
@@ -5168,7 +5128,6 @@ export interface QueryDslLikeDocument {
   doc?: any
   fields?: Field[]
   _id?: Id
-  _type?: Type
   _index?: IndexName
   per_field_analyzer?: Record<Field, string>
   routing?: Routing
@@ -5274,10 +5233,8 @@ export interface QueryDslNestedQuery extends QueryDslQueryBase {
   inner_hits?: SearchInnerHits
   path: Field
   query: QueryDslQueryContainer
-  score_mode?: QueryDslNestedScoreMode
+  score_mode?: QueryDslChildScoreMode
 }
-
-export type QueryDslNestedScoreMode = 'avg' | 'sum' | 'min' | 'max' | 'none'
 
 export interface QueryDslNumberRangeQuery extends QueryDslRangeQueryBase {
   gt?: double
@@ -5388,6 +5345,7 @@ export interface QueryDslQueryContainer {
   terms?: QueryDslTermsQuery
   terms_set?: Partial<Record<Field, QueryDslTermsSetQuery>>
   wildcard?: Partial<Record<Field, QueryDslWildcardQuery | string>>
+  wrapper: QueryDslWrapperQuery
   type?: QueryDslTypeQuery
 }
 
@@ -5617,6 +5575,10 @@ export interface QueryDslWildcardQuery extends QueryDslQueryBase {
   wildcard?: string
 }
 
+export interface QueryDslWrapperQuery extends QueryDslQueryBase {
+  query: string
+}
+
 export type QueryDslZeroTermsQuery = 'all' | 'none'
 
 export interface AsyncSearchAsyncSearch<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
@@ -5739,10 +5701,10 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     query?: QueryDslQueryContainer
     rescore?: SearchRescore | SearchRescore[]
     script_fields?: Record<string, ScriptField>
-    search_after?: SearchSortResults
+    search_after?: SortResults
     size?: integer
     slice?: SlicedScroll
-    sort?: SearchSort
+    sort?: Sort
     _source?: SearchSourceConfig
     fields?: (QueryDslFieldAndFormat | Field)[]
     suggest?: SearchSuggester
@@ -6304,8 +6266,8 @@ export type CatMasterResponse = CatMasterMasterRecord[]
 
 export interface CatMlDataFrameAnalyticsDataFrameAnalyticsRecord {
   id?: Id
-  type?: Type
-  t?: Type
+  type?: string
+  t?: string
   create_time?: string
   ct?: string
   createTime?: string
@@ -6675,8 +6637,8 @@ export interface CatNodesNodesRecord {
   v?: VersionString
   flavor?: string
   f?: string
-  type?: Type
-  t?: Type
+  type?: string
+  t?: string
   build?: string
   b?: string
   jdk?: string
@@ -6963,8 +6925,8 @@ export interface CatPluginsPluginsRecord {
   v?: VersionString
   description?: string
   d?: string
-  type?: Type
-  t?: Type
+  type?: string
+  t?: string
 }
 
 export interface CatPluginsRequest extends CatCatRequestBase {
@@ -6990,8 +6952,8 @@ export interface CatRecoveryRecoveryRecord {
   time?: string
   t?: string
   ti?: string
-  type?: Type
-  ty?: Type
+  type?: string
+  ty?: string
   stage?: string
   st?: string
   source_host?: string
@@ -7379,8 +7341,8 @@ export interface CatTasksTasksRecord {
   ti?: Id
   parent_task_id?: string
   pti?: string
-  type?: Type
-  ty?: Type
+  type?: string
+  ty?: string
   start_time?: string
   start?: string
   timestamp?: string
@@ -7428,7 +7390,7 @@ export interface CatTemplatesTemplatesRecord {
 
 export interface CatThreadPoolRequest extends CatCatRequestBase {
   thread_pool_patterns?: Names
-  size?: CatThreadPoolThreadPoolSize
+  time?: Time
 }
 
 export type CatThreadPoolResponse = CatThreadPoolThreadPoolRecord[]
@@ -7475,8 +7437,6 @@ export interface CatThreadPoolThreadPoolRecord {
   keep_alive?: string
   ka?: string
 }
-
-export type CatThreadPoolThreadPoolSize = 'k' | 'm' | 'g' | 't' | 'p'
 
 export interface CatTransformsRequest extends CatCatRequestBase {
   transform_id?: Id
@@ -8960,7 +8920,7 @@ export interface IndicesIndexRoutingAllocation {
 }
 
 export interface IndicesIndexRoutingAllocationDisk {
-  threshold_enabled: boolean | string
+  threshold_enabled?: boolean | string
 }
 
 export interface IndicesIndexRoutingAllocationInclude {
@@ -8983,8 +8943,8 @@ export type IndicesIndexRoutingRebalanceOptions = 'all' | 'primaries' | 'replica
 export interface IndicesIndexSegmentSort {
   field: Fields
   order: IndicesSegmentSortOrder | IndicesSegmentSortOrder[]
-  mode?: IndicesSegmentSortMode
-  missing?: IndicesSegmentSortMissing
+  mode?: IndicesSegmentSortMode | IndicesSegmentSortMode[]
+  missing?: IndicesSegmentSortMissing | IndicesSegmentSortMissing[]
 }
 
 export interface IndicesIndexSettingBlocks {
@@ -9123,6 +9083,7 @@ export interface IndicesIndexState {
   aliases?: Record<IndexName, IndicesAlias>
   mappings?: MappingTypeMapping
   settings?: IndicesIndexSettings
+  defaults?: IndicesIndexSettings
   data_stream?: DataStreamName
 }
 
@@ -9308,7 +9269,6 @@ export interface IndicesCloseResponse extends AcknowledgedResponseBase {
 
 export interface IndicesCreateRequest extends RequestBase {
   index: IndexName
-  include_type_name?: boolean
   master_timeout?: Time
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
@@ -9454,17 +9414,6 @@ export interface IndicesExistsTemplateRequest extends RequestBase {
 
 export type IndicesExistsTemplateResponse = boolean
 
-export interface IndicesExistsTypeRequest extends RequestBase {
-  index: Indices
-  type: Types
-  allow_no_indices?: boolean
-  expand_wildcards?: ExpandWildcards
-  ignore_unavailable?: boolean
-  local?: boolean
-}
-
-export type IndicesExistsTypeResponse = boolean
-
 export interface IndicesFlushRequest extends RequestBase {
   index?: Indices
   allow_no_indices?: boolean
@@ -9497,7 +9446,6 @@ export interface IndicesGetRequest extends RequestBase {
   flat_settings?: boolean
   ignore_unavailable?: boolean
   include_defaults?: boolean
-  include_type_name?: boolean
   local?: boolean
   master_timeout?: Time
 }
@@ -9559,7 +9507,6 @@ export interface IndicesGetFieldMappingRequest extends RequestBase {
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
   include_defaults?: boolean
-  include_type_name?: boolean
   local?: boolean
 }
 
@@ -9596,7 +9543,6 @@ export interface IndicesGetIndexTemplateRequest extends RequestBase {
   name?: Name
   local?: boolean
   flat_settings?: boolean
-  include_type_name?: boolean
   master_timeout?: Time
 }
 
@@ -9614,7 +9560,6 @@ export interface IndicesGetMappingRequest extends RequestBase {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
-  include_type_name?: boolean
   local?: boolean
   master_timeout?: Time
 }
@@ -9640,7 +9585,6 @@ export interface IndicesGetSettingsResponse extends DictionaryResponseBase<Index
 export interface IndicesGetTemplateRequest extends RequestBase {
   name?: Names
   flat_settings?: boolean
-  include_type_name?: boolean
   local?: boolean
   master_timeout?: Time
 }
@@ -9721,7 +9665,6 @@ export interface IndicesPutMappingRequest extends RequestBase {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
-  include_type_name?: boolean
   master_timeout?: Time
   timeout?: Time
   write_index_only?: boolean
@@ -9764,7 +9707,6 @@ export interface IndicesPutTemplateRequest extends RequestBase {
   name: Name
   create?: boolean
   flat_settings?: boolean
-  include_type_name?: boolean
   master_timeout?: Time
   timeout?: Time
   order?: integer
@@ -9868,7 +9810,7 @@ export interface IndicesRecoveryShardRecovery {
   total_time?: DateString
   total_time_in_millis: EpochMillis
   translog: IndicesRecoveryTranslogStatus
-  type: Type
+  type: string
   verify_index: IndicesRecoveryVerifyIndex
 }
 
@@ -9945,13 +9887,10 @@ export interface IndicesResolveIndexResponse {
   data_streams: IndicesResolveIndexResolveIndexDataStreamsItem[]
 }
 
-export type IndicesRolloverIndexRolloverMapping = MappingTypeMapping | Record<string, MappingTypeMapping>
-
 export interface IndicesRolloverRequest extends RequestBase {
   alias: IndexAlias
   new_index?: IndexName
   dry_run?: boolean
-  include_type_name?: boolean
   master_timeout?: Time
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
@@ -9959,7 +9898,7 @@ export interface IndicesRolloverRequest extends RequestBase {
   body?: {
     aliases?: Record<IndexName, IndicesAlias>
     conditions?: IndicesRolloverRolloverConditions
-    mappings?: IndicesRolloverIndexRolloverMapping
+    mappings?: MappingTypeMapping
     settings?: Record<string, any>
   }
 }
@@ -10150,6 +10089,7 @@ export interface IndicesStatsIndexStats {
   flush?: FlushStats
   get?: GetStats
   indexing?: IndexingStats
+  indices?: IndicesStatsIndicesStats
   merges?: MergesStats
   query_cache?: QueryCacheStats
   recovery?: RecoveryStats
@@ -10161,13 +10101,13 @@ export interface IndicesStatsIndexStats {
   translog?: TranslogStats
   warmer?: WarmerStats
   bulk?: BulkStats
-  shards?: IndicesStatsShardsTotalStats
+  shard_stats?: IndicesStatsShardsTotalStats
 }
 
 export interface IndicesStatsIndicesStats {
-  primaries: IndicesStatsIndexStats
+  primaries?: IndicesStatsIndexStats
   shards?: Record<string, IndicesStatsShardStats[]>
-  total: IndicesStatsIndexStats
+  total?: IndicesStatsIndexStats
   uuid?: Uuid
 }
 
@@ -10183,7 +10123,6 @@ export interface IndicesStatsRequest extends RequestBase {
   include_segment_file_sizes?: boolean
   include_unloaded_segments?: boolean
   level?: Level
-  types?: Types
 }
 
 export interface IndicesStatsResponse {
@@ -10253,29 +10192,31 @@ export interface IndicesStatsShardSequenceNumber {
 }
 
 export interface IndicesStatsShardStats {
-  commit: IndicesStatsShardCommit
-  completion: CompletionStats
-  docs: DocStats
-  fielddata: FielddataStats
-  flush: FlushStats
-  get: GetStats
-  indexing: IndexingStats
-  merges: MergesStats
-  shard_path: IndicesStatsShardPath
-  query_cache: IndicesStatsShardQueryCache
-  recovery: RecoveryStats
-  refresh: RefreshStats
-  request_cache: RequestCacheStats
-  retention_leases: IndicesStatsShardRetentionLeases
-  routing: IndicesStatsShardRouting
-  search: SearchStats
-  segments: SegmentsStats
-  seq_no: IndicesStatsShardSequenceNumber
-  store: StoreStats
-  translog: TranslogStats
-  warmer: WarmerStats
+  commit?: IndicesStatsShardCommit
+  completion?: CompletionStats
+  docs?: DocStats
+  fielddata?: FielddataStats
+  flush?: FlushStats
+  get?: GetStats
+  indexing?: IndexingStats
+  merges?: MergesStats
+  shard_path?: IndicesStatsShardPath
+  query_cache?: IndicesStatsShardQueryCache
+  recovery?: RecoveryStats
+  refresh?: RefreshStats
+  request_cache?: RequestCacheStats
+  retention_leases?: IndicesStatsShardRetentionLeases
+  routing?: IndicesStatsShardRouting
+  search?: SearchStats
+  segments?: SegmentsStats
+  seq_no?: IndicesStatsShardSequenceNumber
+  store?: StoreStats
+  translog?: TranslogStats
+  warmer?: WarmerStats
   bulk?: BulkStats
-  shards: IndicesStatsShardsTotalStats
+  shards?: IndicesStatsShardsTotalStats
+  shard_stats?: IndicesStatsShardsTotalStats
+  indices?: IndicesStatsIndicesStats
 }
 
 export interface IndicesStatsShardsTotalStats {
@@ -10349,7 +10290,6 @@ export interface IndicesValidateQueryIndicesValidationExplanation {
 
 export interface IndicesValidateQueryRequest extends RequestBase {
   index?: Indices
-  type?: Types
   allow_no_indices?: boolean
   all_shards?: boolean
   analyzer?: string
@@ -10637,7 +10577,7 @@ export type IngestShapeType = 'geo_shape' | 'shape'
 
 export interface IngestSortProcessor extends IngestProcessorBase {
   field: Field
-  order: SearchSortOrder
+  order: SortOrder
   target_field: Field
 }
 
@@ -10757,7 +10697,6 @@ export interface IngestSimulateDocumentSimulation {
   _parent?: string
   _routing?: string
   _source: Record<string, any>
-  _type?: Type
 }
 
 export interface IngestSimulateIngest {
@@ -11150,7 +11089,7 @@ export interface MlDatafeed {
   scroll_size?: integer
   delayed_data_check_config: MlDelayedDataCheckConfig
   runtime_mappings?: MappingRuntimeFields
-  indices_options?: MlDatafeedIndicesOptions
+  indices_options?: IndicesOptions
 }
 
 export interface MlDatafeedConfig {
@@ -11162,7 +11101,7 @@ export interface MlDatafeedConfig {
   frequency?: Timestamp
   indexes?: string[]
   indices: string[]
-  indices_options?: MlDatafeedIndicesOptions
+  indices_options?: IndicesOptions
   job_id?: Id
   max_empty_searches?: integer
   query: QueryDslQueryContainer
@@ -11170,13 +11109,6 @@ export interface MlDatafeedConfig {
   runtime_mappings?: MappingRuntimeFields
   script_fields?: Record<string, ScriptField>
   scroll_size?: integer
-}
-
-export interface MlDatafeedIndicesOptions {
-  allow_no_indices?: boolean
-  expand_wildcards?: ExpandWildcards
-  ignore_unavailable?: boolean
-  ignore_throttled?: boolean
 }
 
 export type MlDatafeedState = 'started' | 'stopped' | 'starting' | 'stopping'
@@ -11445,6 +11377,8 @@ export interface MlDelayedDataCheckConfig {
   enabled: boolean
 }
 
+export type MlDeploymentState = 'started' | 'starting' | 'fully_allocated'
+
 export interface MlDetectionRule {
   actions?: MlRuleAction[]
   conditions?: MlRuleCondition[]
@@ -11706,6 +11640,10 @@ export interface MlPerPartitionCategorization {
   stop_on_warn?: boolean
 }
 
+export type MlPredictedValue = string | double
+
+export type MlRoutingState = 'failed' | 'started' | 'starting' | 'stopped' | 'stopping'
+
 export type MlRuleAction = 'skip_result' | 'skip_model_update'
 
 export interface MlRuleCondition {
@@ -11717,6 +11655,12 @@ export interface MlRuleCondition {
 export interface MlTimingStats {
   elapsed_time: integer
   iteration_time?: integer
+}
+
+export interface MlTopClassEntry {
+  class_name: string
+  class_probability: double
+  class_score: double
 }
 
 export interface MlTotalFeatureImportance {
@@ -11734,6 +11678,23 @@ export interface MlTotalFeatureImportanceStatistics {
   mean_magnitude: double
   max: integer
   min: integer
+}
+
+export interface MlTrainedModelAllocation {
+  allocation_state: MlDeploymentState
+  routing_table: Record<string, MlTrainedModelAllocationRoutingTable>
+  start_time: DateString
+  task_parameters: MlTrainedModelAllocationTaskParameters
+}
+
+export interface MlTrainedModelAllocationRoutingTable {
+  reason: string
+  routing_state: MlRoutingState
+}
+
+export interface MlTrainedModelAllocationTaskParameters {
+  model_bytes: integer
+  model_id: Id
 }
 
 export interface MlTrainedModelConfig {
@@ -11763,6 +11724,14 @@ export interface MlTrainedModelConfigMetadata {
   feature_importance_baseline?: Record<string, string>
   hyperparameters?: MlHyperparameter[]
   total_feature_importance?: MlTotalFeatureImportance[]
+}
+
+export interface MlTrainedModelEntities {
+  class_name: string
+  class_probability: double
+  entity: string
+  start_pos: integer
+  end_pos: integer
 }
 
 export interface MlTrainedModelInferenceStats {
@@ -12146,8 +12115,8 @@ export interface MlGetCategoriesRequest extends RequestBase {
   job_id: Id
   category_id?: CategoryId
   from?: integer
-  size?: integer
   partition_field_value?: string
+  size?: integer
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     page?: MlPage
@@ -12364,6 +12333,25 @@ export interface MlGetTrainedModelsStatsResponse {
   trained_model_stats: MlTrainedModelStats[]
 }
 
+export interface MlInferTrainedModelDeploymentRequest extends RequestBase {
+  model_id: Id
+  timeout?: Time
+  /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
+  body?: {
+    docs: Record<string, string>[]
+  }
+}
+
+export interface MlInferTrainedModelDeploymentResponse {
+  entities?: MlTrainedModelEntities[]
+  is_truncated?: boolean
+  predicted_value?: MlPredictedValue[]
+  predicted_value_sequence?: string
+  prediction_probability?: double
+  top_classes: MlTopClassEntry[]
+  warning?: string
+}
+
 export interface MlInfoAnomalyDetectors {
   categorization_analyzer: MlCategorizationAnalyzer
   categorization_examples_limit: integer
@@ -12555,7 +12543,7 @@ export interface MlPutDatafeedRequest extends RequestBase {
     frequency?: Time
     indices?: string[]
     indexes?: string[]
-    indices_options?: MlDatafeedIndicesOptions
+    indices_options?: IndicesOptions
     job_id?: Id
     max_empty_searches?: integer
     query?: QueryDslQueryContainer
@@ -12574,7 +12562,7 @@ export interface MlPutDatafeedResponse {
   frequency: Time
   indices: string[]
   job_id: Id
-  indices_options?: MlDatafeedIndicesOptions
+  indices_options?: IndicesOptions
   max_empty_searches: integer
   query: QueryDslQueryContainer
   query_delay: Time
@@ -12746,6 +12734,31 @@ export interface MlPutTrainedModelAliasRequest extends RequestBase {
 export interface MlPutTrainedModelAliasResponse extends AcknowledgedResponseBase {
 }
 
+export interface MlPutTrainedModelDefinitionPartRequest extends RequestBase {
+  model_id: Id
+  part: integer
+  /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
+  body?: {
+    definition: string
+    total_definition_length: long
+    total_parts: integer
+  }
+}
+
+export interface MlPutTrainedModelDefinitionPartResponse extends AcknowledgedResponseBase {
+}
+
+export interface MlPutTrainedModelVocabularyRequest extends RequestBase {
+  model_id: Id
+  /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
+  body?: {
+    vocabulary: string[]
+  }
+}
+
+export interface MlPutTrainedModelVocabularyResponse extends AcknowledgedResponseBase {
+}
+
 export interface MlResetJobRequest extends RequestBase {
   job_id: Id
   wait_for_completion?: boolean
@@ -12803,6 +12816,19 @@ export interface MlStartDatafeedResponse {
   started: boolean
 }
 
+export interface MlStartTrainedModelDeploymentRequest extends RequestBase {
+  model_id: Id
+  inference_threads?: integer
+  model_threads?: integer
+  queue_capacity?: integer
+  timeout?: Time
+  wait_for?: MlDeploymentState
+}
+
+export interface MlStartTrainedModelDeploymentResponse {
+  allocation: MlTrainedModelAllocation
+}
+
 export interface MlStopDataFrameAnalyticsRequest extends RequestBase {
   id: Id
   allow_no_match?: boolean
@@ -12828,6 +12854,16 @@ export interface MlStopDatafeedRequest extends RequestBase {
 }
 
 export interface MlStopDatafeedResponse {
+  stopped: boolean
+}
+
+export interface MlStopTrainedModelDeploymentRequest extends RequestBase {
+  model_id: Id
+  allow_no_match?: boolean
+  force?: boolean
+}
+
+export interface MlStopTrainedModelDeploymentResponse {
   stopped: boolean
 }
 
@@ -12870,7 +12906,7 @@ export interface MlUpdateDatafeedRequest extends RequestBase {
     frequency?: Time
     indices?: string[]
     indexes?: string[]
-    indices_options?: MlDatafeedIndicesOptions
+    indices_options?: IndicesOptions
     max_empty_searches?: integer
     query?: QueryDslQueryContainer
     query_delay?: Time
@@ -12888,7 +12924,7 @@ export interface MlUpdateDatafeedResponse {
   frequency: Time
   indices: string[]
   job_id: Id
-  indices_options?: MlDatafeedIndicesOptions
+  indices_options?: IndicesOptions
   max_empty_searches: integer
   query: QueryDslQueryContainer
   query_delay: Time
@@ -13026,26 +13062,100 @@ export interface MonitoringBulkResponse {
 }
 
 export interface NodesAdaptiveSelection {
-  avg_queue_size: long
-  avg_response_time: long
-  avg_response_time_ns: long
-  avg_service_time: string
-  avg_service_time_ns: long
-  outgoing_searches: long
-  rank: string
+  avg_queue_size?: long
+  avg_response_time?: long
+  avg_response_time_ns?: long
+  avg_service_time?: string
+  avg_service_time_ns?: long
+  outgoing_searches?: long
+  rank?: string
 }
 
 export interface NodesBreaker {
-  estimated_size: string
-  estimated_size_in_bytes: long
-  limit_size: string
-  limit_size_in_bytes: long
-  overhead: float
-  tripped: float
+  estimated_size?: string
+  estimated_size_in_bytes?: long
+  limit_size?: string
+  limit_size_in_bytes?: long
+  overhead?: float
+  tripped?: float
+}
+
+export interface NodesCgroup {
+  cpuacct?: NodesCpuAcct
+  cpu?: NodesCgroupCpu
+  memory?: NodesCgroupMemory
+}
+
+export interface NodesCgroupCpu {
+  control_group?: string
+  cfs_period_micros?: integer
+  cfs_quota_micros?: integer
+  stat?: NodesCgroupCpuStat
+}
+
+export interface NodesCgroupCpuStat {
+  number_of_elapsed_periods?: long
+  number_of_times_throttled?: long
+  time_throttled_nanos?: long
+}
+
+export interface NodesCgroupMemory {
+  control_group?: string
+  limit_in_bytes?: string
+  usage_in_bytes?: string
+}
+
+export interface NodesClient {
+  id?: long
+  agent?: string
+  local_address?: string
+  remote_address?: string
+  last_uri?: string
+  opened_time_millis?: long
+  closed_time_millis?: long
+  last_request_time_millis?: long
+  request_count?: long
+  request_size_bytes?: long
+  x_opaque_id?: string
+}
+
+export interface NodesClusterAppliedStats {
+  recordings?: NodesRecording[]
+}
+
+export interface NodesClusterStateQueue {
+  total?: long
+  pending?: long
+  committed?: long
+}
+
+export interface NodesClusterStateUpdate {
+  count?: long
+  computation_time?: string
+  computation_time_millis?: long
+  publication_time?: string
+  publication_time_millis?: long
+  context_construction_time?: string
+  context_construction_time_millis?: long
+  commit_time?: string
+  commit_time_millis?: long
+  completion_time?: string
+  completion_time_millis?: long
+  master_apply_time?: string
+  master_apply_time_millis?: long
+  notification_time?: string
+  notification_time_millis?: long
+}
+
+export interface NodesContext {
+  context?: string
+  compilations?: long
+  cache_evictions?: long
+  compilation_limit_triggered?: long
 }
 
 export interface NodesCpu {
-  percent: integer
+  percent?: integer
   sys?: string
   sys_in_millis?: long
   total?: string
@@ -13055,182 +13165,306 @@ export interface NodesCpu {
   load_average?: Record<string, double>
 }
 
+export interface NodesCpuAcct {
+  control_group?: string
+  usage_nanos?: long
+}
+
 export interface NodesDataPathStats {
-  available: string
-  available_in_bytes: long
-  disk_queue: string
-  disk_reads: long
-  disk_read_size: string
-  disk_read_size_in_bytes: long
-  disk_writes: long
-  disk_write_size: string
-  disk_write_size_in_bytes: long
-  free: string
-  free_in_bytes: long
-  mount: string
-  path: string
-  total: string
-  total_in_bytes: long
-  type: string
+  available?: string
+  available_in_bytes?: long
+  disk_queue?: string
+  disk_reads?: long
+  disk_read_size?: string
+  disk_read_size_in_bytes?: long
+  disk_writes?: long
+  disk_write_size?: string
+  disk_write_size_in_bytes?: long
+  free?: string
+  free_in_bytes?: long
+  mount?: string
+  path?: string
+  total?: string
+  total_in_bytes?: long
+  type?: string
+}
+
+export interface NodesDiscovery {
+  cluster_state_queue?: NodesClusterStateQueue
+  published_cluster_states?: NodesPublishedClusterStates
+  cluster_state_update?: Record<string, NodesClusterStateUpdate>
+  serialized_cluster_states?: NodesSerializedClusterState
+  cluster_applier_stats?: NodesClusterAppliedStats
 }
 
 export interface NodesExtendedMemoryStats extends NodesMemoryStats {
-  free_percent: integer
-  used_percent: integer
+  free_percent?: integer
+  used_percent?: integer
 }
 
 export interface NodesFileSystem {
-  data: NodesDataPathStats[]
-  timestamp: long
-  total: NodesFileSystemTotal
+  data?: NodesDataPathStats[]
+  timestamp?: long
+  total?: NodesFileSystemTotal
+  io_stats?: NodesIoStats
 }
 
 export interface NodesFileSystemTotal {
-  available: string
-  available_in_bytes: long
-  free: string
-  free_in_bytes: long
-  total: string
-  total_in_bytes: long
+  available?: string
+  available_in_bytes?: long
+  free?: string
+  free_in_bytes?: long
+  total?: string
+  total_in_bytes?: long
 }
 
 export interface NodesGarbageCollector {
-  collectors: Record<string, NodesGarbageCollectorTotal>
+  collectors?: Record<string, NodesGarbageCollectorTotal>
 }
 
 export interface NodesGarbageCollectorTotal {
-  collection_count: long
-  collection_time: string
-  collection_time_in_millis: long
+  collection_count?: long
+  collection_time?: string
+  collection_time_in_millis?: long
 }
 
 export interface NodesHttp {
-  current_open: integer
-  total_opened: long
+  current_open?: integer
+  total_opened?: long
+  clients?: NodesClient[]
+}
+
+export interface NodesIndexingPressure {
+  memory?: NodesIndexingPressureMemory
+}
+
+export interface NodesIndexingPressureMemory {
+  limit_in_bytes?: long
+  current?: NodesPressureMemory
+  total?: NodesPressureMemory
 }
 
 export interface NodesIngest {
-  pipelines: Record<string, NodesIngestTotal>
-  total: NodesIngestTotal
+  pipelines?: Record<string, NodesIngestTotal>
+  total?: NodesIngestTotal
 }
 
 export interface NodesIngestTotal {
-  count: long
-  current: long
-  failed: long
-  processors: NodesKeyedProcessor[]
-  time_in_millis: long
+  count?: long
+  current?: long
+  failed?: long
+  processors?: Record<string, NodesKeyedProcessor>[]
+  time_in_millis?: long
+}
+
+export interface NodesIoStatDevice {
+  device_name?: string
+  operations?: long
+  read_kilobytes?: long
+  read_operations?: long
+  write_kilobytes?: long
+  write_operations?: long
+}
+
+export interface NodesIoStats {
+  devices?: NodesIoStatDevice[]
+  total?: NodesIoStatDevice
 }
 
 export interface NodesJvm {
-  buffer_pools: Record<string, NodesNodeBufferPool>
-  classes: NodesJvmClasses
-  gc: NodesGarbageCollector
-  mem: NodesMemoryStats
-  threads: NodesJvmThreads
-  timestamp: long
-  uptime: string
-  uptime_in_millis: long
+  buffer_pools?: Record<string, NodesNodeBufferPool>
+  classes?: NodesJvmClasses
+  gc?: NodesGarbageCollector
+  mem?: NodesJvmMemoryStats
+  threads?: NodesJvmThreads
+  timestamp?: long
+  uptime?: string
+  uptime_in_millis?: long
 }
 
 export interface NodesJvmClasses {
-  current_loaded_count: long
-  total_loaded_count: long
-  total_unloaded_count: long
+  current_loaded_count?: long
+  total_loaded_count?: long
+  total_unloaded_count?: long
+}
+
+export interface NodesJvmMemoryStats {
+  heap_used_in_bytes?: long
+  heap_used_percent?: long
+  heap_committed_in_bytes?: long
+  heap_max_in_bytes?: long
+  non_heap_used_in_bytes?: long
+  non_heap_committed_in_bytes?: long
+  pools?: Record<string, NodesPool>
 }
 
 export interface NodesJvmThreads {
-  count: long
-  peak_count: long
+  count?: long
+  peak_count?: long
 }
 
 export interface NodesKeyedProcessor {
-  statistics: NodesProcess
-  type: string
+  stats?: NodesProcessor
+  type?: string
 }
 
 export interface NodesMemoryStats {
+  adjusted_total_in_bytes?: long
   resident?: string
   resident_in_bytes?: long
   share?: string
   share_in_bytes?: long
   total_virtual?: string
   total_virtual_in_bytes?: long
-  total_in_bytes: long
-  free_in_bytes: long
-  used_in_bytes: long
+  total_in_bytes?: long
+  free_in_bytes?: long
+  used_in_bytes?: long
 }
 
 export interface NodesNodeBufferPool {
-  count: long
-  total_capacity: string
-  total_capacity_in_bytes: long
-  used: string
-  used_in_bytes: long
+  count?: long
+  total_capacity?: string
+  total_capacity_in_bytes?: long
+  used?: string
+  used_in_bytes?: long
 }
 
 export interface NodesNodesResponseBase {
-  _nodes: NodeStatistics
+  _nodes?: NodeStatistics
 }
 
 export interface NodesOperatingSystem {
-  cpu: NodesCpu
-  mem: NodesExtendedMemoryStats
-  swap: NodesMemoryStats
-  timestamp: long
+  cpu?: NodesCpu
+  mem?: NodesExtendedMemoryStats
+  swap?: NodesMemoryStats
+  cgroup?: NodesCgroup
+  timestamp?: long
+}
+
+export interface NodesPool {
+  used_in_bytes?: long
+  max_in_bytes?: long
+  peak_used_in_bytes?: long
+  peak_max_in_bytes?: long
+}
+
+export interface NodesPressureMemory {
+  combined_coordinating_and_primary_in_bytes?: long
+  coordinating_in_bytes?: long
+  primary_in_bytes?: long
+  replica_in_bytes?: long
+  all_in_bytes?: long
+  coordinating_rejections?: long
+  primary_rejections?: long
+  replica_rejections?: long
 }
 
 export interface NodesProcess {
-  cpu: NodesCpu
-  mem: NodesMemoryStats
-  open_file_descriptors: integer
-  timestamp: long
+  cpu?: NodesCpu
+  mem?: NodesMemoryStats
+  open_file_descriptors?: integer
+  max_file_descriptors?: integer
+  timestamp?: long
+}
+
+export interface NodesProcessor {
+  count?: long
+  current?: long
+  failed?: long
+  time_in_millis?: long
+}
+
+export interface NodesPublishedClusterStates {
+  full_states?: long
+  incompatible_diffs?: long
+  compatible_diffs?: long
+}
+
+export interface NodesRecording {
+  name?: string
+  cumulative_execution_count?: long
+  cumulative_execution_time?: string
+  cumulative_execution_time_millis?: long
+}
+
+export interface NodesScriptCache {
+  cache_evictions?: long
+  compilation_limit_triggered?: long
+  compilations?: long
+  context?: string
 }
 
 export interface NodesScripting {
-  cache_evictions: long
-  compilations: long
+  cache_evictions?: long
+  compilations?: long
+  compilation_limit_triggered?: long
+  contexts?: NodesContext[]
+}
+
+export interface NodesSerializedClusterState {
+  full_states?: NodesSerializedClusterStateDetail
+  diffs?: NodesSerializedClusterStateDetail
+}
+
+export interface NodesSerializedClusterStateDetail {
+  count?: long
+  uncompressed_size?: string
+  uncompressed_size_in_bytes?: long
+  compressed_size?: string
+  compressed_size_in_bytes?: long
 }
 
 export interface NodesStats {
-  adaptive_selection: Record<string, NodesAdaptiveSelection>
-  breakers: Record<string, NodesBreaker>
-  fs: NodesFileSystem
-  host: Host
-  http: NodesHttp
-  indices: IndicesStatsIndexStats
-  ingest: NodesIngest
-  ip: Ip | Ip[]
-  jvm: NodesJvm
-  name: Name
-  os: NodesOperatingSystem
-  process: NodesProcess
-  roles: NodeRoles
-  script: NodesScripting
-  thread_pool: Record<string, NodesThreadCount>
-  timestamp: long
-  transport: NodesTransport
-  transport_address: TransportAddress
-  attributes: Record<Field, string>
+  adaptive_selection?: Record<string, NodesAdaptiveSelection>
+  breakers?: Record<string, NodesBreaker>
+  fs?: NodesFileSystem
+  host?: Host
+  http?: NodesHttp
+  ingest?: NodesIngest
+  ip?: Ip | Ip[]
+  jvm?: NodesJvm
+  name?: Name
+  os?: NodesOperatingSystem
+  process?: NodesProcess
+  roles?: NodeRoles
+  script?: NodesScripting
+  script_cache?: Record<string, NodesScriptCache | NodesScriptCache[]>
+  thread_pool?: Record<string, NodesThreadCount>
+  timestamp?: long
+  transport?: NodesTransport
+  transport_address?: TransportAddress
+  attributes?: Record<Field, string>
+  discovery?: NodesDiscovery
+  indexing_pressure?: NodesIndexingPressure
+  indices?: IndicesStatsShardStats
 }
 
 export interface NodesThreadCount {
-  active: long
-  completed: long
-  largest: long
-  queue: long
-  rejected: long
-  threads: long
+  active?: long
+  completed?: long
+  largest?: long
+  queue?: long
+  rejected?: long
+  threads?: long
 }
 
 export interface NodesTransport {
-  rx_count: long
-  rx_size: string
-  rx_size_in_bytes: long
-  server_open: integer
-  tx_count: long
-  tx_size: string
-  tx_size_in_bytes: long
+  inbound_handling_time_histogram?: NodesTransportHistogram[]
+  outbound_handling_time_histogram?: NodesTransportHistogram[]
+  rx_count?: long
+  rx_size?: string
+  rx_size_in_bytes?: long
+  server_open?: integer
+  tx_count?: long
+  tx_size?: string
+  tx_size_in_bytes?: long
+  total_outbound_connections?: long
+}
+
+export interface NodesTransportHistogram {
+  count?: long
+  lt_millis?: long
+  ge_millis?: long
 }
 
 export interface NodesHotThreadsHotThread {
@@ -13640,7 +13874,7 @@ export interface NodesStatsRequest extends RequestBase {
 }
 
 export interface NodesStatsResponse extends NodesNodesResponseBase {
-  cluster_name: Name
+  cluster_name?: Name
   nodes: Record<string, NodesStats>
 }
 
@@ -13831,7 +14065,6 @@ export type RollupRollupResponse = any
 
 export interface RollupRollupSearchRequest extends RequestBase {
   index: Indices
-  type?: Type
   rest_total_hits_as_int?: boolean
   typed_keys?: boolean
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
@@ -14002,13 +14235,19 @@ export interface SecurityUser {
   enabled: boolean
 }
 
+export interface SecurityAuthenticateApiKey {
+  id: string
+  name: Name
+}
+
 export interface SecurityAuthenticateRequest extends RequestBase {
 }
 
 export interface SecurityAuthenticateResponse {
+  api_key?: SecurityAuthenticateApiKey
   authentication_realm: SecurityRealmInfo
-  email?: string
-  full_name?: Name
+  email?: string | null
+  full_name?: Name | null
   lookup_realm: SecurityRealmInfo
   metadata: Metadata
   roles: string[]
@@ -14110,6 +14349,7 @@ export interface SecurityCreateApiKeyResponse {
   expiration?: long
   id: Id
   name: Name
+  encoded: string
 }
 
 export interface SecurityCreateApiKeyRoleDescriptor {
@@ -15085,11 +15325,11 @@ export interface SqlTranslateResponse {
   size: long
   _source: SearchSourceConfig
   fields: Record<Field, string>[]
-  sort: SearchSort
+  sort: Sort
 }
 
 export interface SslCertificatesCertificateInformation {
-  alias?: string
+  alias: string | null
   expiry: DateString
   format: string
   has_private_key: boolean
@@ -15270,7 +15510,6 @@ export interface TransformPivot {
   aggregations?: Record<string, AggregationsAggregationContainer>
   aggs?: Record<string, AggregationsAggregationContainer>
   group_by?: Record<string, TransformPivotGroupByContainer>
-  max_page_search_size?: integer
 }
 
 export interface TransformPivotGroupByContainer {
@@ -15290,6 +15529,7 @@ export interface TransformRetentionPolicyContainer {
 }
 
 export interface TransformSettings {
+  align_checkpoints?: boolean
   dates_as_epoch_millis?: boolean
   docs_per_second?: float
   max_page_search_size?: integer
@@ -15305,8 +15545,9 @@ export interface TransformTimeSync {
 }
 
 export interface TransformDeleteTransformRequest extends RequestBase {
-  transform_id: Name
+  transform_id: Id
   force?: boolean
+  timeout?: Time
 }
 
 export interface TransformDeleteTransformResponse extends AcknowledgedResponseBase {
@@ -15391,6 +15632,7 @@ export interface TransformGetTransformStatsTransformStats {
 
 export interface TransformPreviewTransformRequest extends RequestBase {
   transform_id?: Id
+  timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     dest?: ReindexDestination
@@ -15413,25 +15655,35 @@ export interface TransformPreviewTransformResponse<TTransform = unknown> {
 export interface TransformPutTransformRequest extends RequestBase {
   transform_id: Id
   defer_validation?: boolean
+  timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     dest: ReindexDestination
     description?: string
     frequency?: Time
-    pivot?: TransformPivot
-    source: ReindexSource
-    settings?: TransformSettings
-    sync?: TransformSyncContainer
-    retention_policy?: TransformRetentionPolicyContainer
     latest?: TransformLatest
+    _meta?: Record<string, string>
+    pivot?: TransformPivot
+    retention_policy?: TransformRetentionPolicyContainer
+    settings?: TransformSettings
+    source: ReindexSource
+    sync?: TransformSyncContainer
   }
 }
 
 export interface TransformPutTransformResponse extends AcknowledgedResponseBase {
 }
 
+export interface TransformResetTransformRequest extends RequestBase {
+  transform_id: Id
+  force?: boolean
+}
+
+export interface TransformResetTransformResponse extends AcknowledgedResponseBase {
+}
+
 export interface TransformStartTransformRequest extends RequestBase {
-  transform_id: Name
+  transform_id: Id
   timeout?: Time
 }
 
@@ -15453,6 +15705,7 @@ export interface TransformStopTransformResponse extends AcknowledgedResponseBase
 export interface TransformUpdateTransformRequest extends RequestBase {
   transform_id: Id
   defer_validation?: boolean
+  timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     dest?: ReindexDestination
@@ -15471,11 +15724,24 @@ export interface TransformUpdateTransformResponse {
   dest: ReindexDestination
   frequency: Time
   id: Id
-  pivot: TransformPivot
+  latest?: TransformLatest
+  pivot?: TransformPivot
+  retention_policy?: TransformRetentionPolicyContainer
   settings: TransformSettings
   source: ReindexSource
   sync?: TransformSyncContainer
   version: VersionString
+}
+
+export interface TransformUpgradeTransformsRequest extends RequestBase {
+  dry_run?: boolean
+  timeout?: Time
+}
+
+export interface TransformUpgradeTransformsResponse {
+  needs_update: integer
+  no_action: integer
+  updated: integer
 }
 
 export interface WatcherAcknowledgeState {
@@ -15707,14 +15973,6 @@ export interface WatcherIndexResultSummary {
   index: IndexName
   result: Result
   version: VersionNumber
-  type?: Type
-}
-
-export interface WatcherIndicesOptions {
-  allow_no_indices?: boolean
-  expand_wildcards?: ExpandWildcards
-  ignore_unavailable?: boolean
-  ignore_throttled?: boolean
 }
 
 export interface WatcherInputContainer {
@@ -15819,7 +16077,7 @@ export interface WatcherSearchInputRequestBody {
 export interface WatcherSearchInputRequestDefinition {
   body?: WatcherSearchInputRequestBody
   indices?: IndexName[]
-  indices_options?: WatcherIndicesOptions
+  indices_options?: IndicesOptions
   search_type?: SearchType
   template?: SearchTemplateRequest
   rest_total_hits_as_int?: boolean
@@ -16051,8 +16309,8 @@ export interface WatcherQueryWatchesRequest extends RequestBase {
     from?: integer
     size?: integer
     query?: QueryDslQueryContainer
-    sort?: SearchSort
-    search_after?: SearchSortResults
+    sort?: Sort
+    search_after?: SortResults
   }
 }
 
@@ -16575,10 +16833,10 @@ export interface XpackUsageWatcherWatchTriggerSchedule extends XpackUsageCounter
   _all: XpackUsageCounter
 }
 
-export interface SpecUtilsAdditionalProperty<TKey = unknown, TValue = unknown> {
+export interface SpecUtilsAdditionalProperties<TKey = unknown, TValue = unknown> {
 }
 
-export interface SpecUtilsAdditionalProperties<TKey = unknown, TValue = unknown> {
+export interface SpecUtilsAdditionalProperty<TKey = unknown, TValue = unknown> {
 }
 
 export interface SpecUtilsCommonQueryParameters {

--- a/src/api/typesWithBodyKey.ts
+++ b/src/api/typesWithBodyKey.ts
@@ -617,12 +617,12 @@ export interface MsearchRequest extends RequestBase {
   body?: (MsearchHeader | MsearchBody)[]
 }
 
-export interface MsearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
+export interface MsearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
   took: long
-  responses: (MsearchSearchResult<TDocument, TAggregation> | ErrorResponseBase)[]
+  responses: (MsearchSearchResult<TDocument, TAggregations> | ErrorResponseBase)[]
 }
 
-export interface MsearchSearchResult<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregation> {
+export interface MsearchSearchResult<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregations> {
   status: integer
 }
 
@@ -637,8 +637,8 @@ export interface MsearchTemplateRequest extends RequestBase {
   body?: MsearchTemplateTemplateItem[]
 }
 
-export interface MsearchTemplateResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
-  responses: (SearchResponse<TDocument, TAggregation> | ErrorResponseBase)[]
+export interface MsearchTemplateResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
+  responses: (SearchResponse<TDocument, TAggregations> | ErrorResponseBase)[]
   took: long
 }
 
@@ -974,7 +974,7 @@ export interface ScrollRequest extends RequestBase {
   }
 }
 
-export interface ScrollResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregation> {
+export interface ScrollResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> extends SearchResponse<TDocument, TAggregations> {
 }
 
 export interface SearchRequest extends RequestBase {
@@ -1058,12 +1058,12 @@ export interface SearchRequest extends RequestBase {
   }
 }
 
-export interface SearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
+export interface SearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
   took: long
   timed_out: boolean
   _shards: ShardStatistics
   hits: SearchHitsMetadata<TDocument>
-  aggregations?: TAggregation
+  aggregations?: TAggregations
   _clusters?: ClusterStatistics
   documents?: TDocument[]
   fields?: Record<string, any>
@@ -5282,8 +5282,8 @@ export interface QueryDslWildcardQuery extends QueryDslQueryBase {
 
 export type QueryDslZeroTermsQuery = 'all' | 'none'
 
-export interface AsyncSearchAsyncSearch<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
-  aggregations?: TAggregation
+export interface AsyncSearchAsyncSearch<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
+  aggregations?: TAggregations
   _clusters?: ClusterStatistics
   fields?: Record<string, any>
   hits: SearchHitsMetadata<TDocument>
@@ -5299,8 +5299,8 @@ export interface AsyncSearchAsyncSearch<TDocument = unknown, TAggregation = Reco
   took: long
 }
 
-export interface AsyncSearchAsyncSearchDocumentResponseBase<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> extends AsyncSearchAsyncSearchResponseBase {
-  response: AsyncSearchAsyncSearch<TDocument, TAggregation>
+export interface AsyncSearchAsyncSearchDocumentResponseBase<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> extends AsyncSearchAsyncSearchResponseBase {
+  response: AsyncSearchAsyncSearch<TDocument, TAggregations>
 }
 
 export interface AsyncSearchAsyncSearchResponseBase {
@@ -13422,13 +13422,13 @@ export interface RollupRollupSearchRequest extends RequestBase {
   }
 }
 
-export interface RollupRollupSearchResponse<TDocument = unknown, TAggregation = Record<AggregateName, AggregationsAggregate>> {
+export interface RollupRollupSearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
   took: long
   timed_out: boolean
   terminated_early?: boolean
   _shards: ShardStatistics
   hits: SearchHitsMetadata<TDocument>
-  aggregations?: TAggregation
+  aggregations?: TAggregations
 }
 
 export interface RollupStartJobRequest extends RequestBase {

--- a/src/api/typesWithBodyKey.ts
+++ b/src/api/typesWithBodyKey.ts
@@ -5345,7 +5345,7 @@ export interface QueryDslQueryContainer {
   terms?: QueryDslTermsQuery
   terms_set?: Partial<Record<Field, QueryDslTermsSetQuery>>
   wildcard?: Partial<Record<Field, QueryDslWildcardQuery | string>>
-  wrapper: QueryDslWrapperQuery
+  wrapper?: QueryDslWrapperQuery
   type?: QueryDslTypeQuery
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -37,7 +37,7 @@ export interface ScrollSearchOptions extends TransportRequestOptions {
   wait?: number
 }
 
-export interface ScrollSearchResponse<TDocument, TAggregation> extends TransportResult<T.SearchResponse<TDocument, TAggregation>, unknown> {
+export interface ScrollSearchResponse<TDocument, TAggregations> extends TransportResult<T.SearchResponse<TDocument, TAggregations>, unknown> {
   clear: () => Promise<void>
   documents: TDocument[]
 }
@@ -170,7 +170,7 @@ export default class Helpers {
    * @param {object} options - The client optional configuration for this request.
    * @return {iterator} the async iterator
    */
-  async * scrollSearch<TDocument = unknown, TAggregation = unknown> (params: T.SearchRequest, options: ScrollSearchOptions = {}): AsyncIterable<ScrollSearchResponse<TDocument, TAggregation>> {
+  async * scrollSearch<TDocument = unknown, TAggregations = unknown> (params: T.SearchRequest, options: ScrollSearchOptions = {}): AsyncIterable<ScrollSearchResponse<TDocument, TAggregations>> {
     options.meta = true
     if (this[kMetaHeader] !== null) {
       options.headers = options.headers ?? {}
@@ -186,9 +186,9 @@ export default class Helpers {
     params.scroll = params.scroll ?? '1m'
     appendFilterPath('_scroll_id', params, false)
 
-    let response: TransportResult<T.SearchResponse<TDocument, TAggregation>, unknown> | undefined
+    let response: TransportResult<T.SearchResponse<TDocument, TAggregations>, unknown> | undefined
     for (let i = 0; i <= maxRetries; i++) {
-      response = await this[kClient].search<TDocument, TAggregation>(params, options as TransportRequestOptionsWithMeta)
+      response = await this[kClient].search<TDocument, TAggregations>(params, options as TransportRequestOptionsWithMeta)
       if (response.statusCode !== 429) break
       await sleep(wait)
     }
@@ -213,7 +213,7 @@ export default class Helpers {
       scroll_id = response.body._scroll_id
       // @ts-expect-error
       response.clear = clear
-      addDocumentsGetter<TDocument, TAggregation>(response)
+      addDocumentsGetter<TDocument, TAggregations>(response)
 
       // @ts-expect-error
       yield response
@@ -229,7 +229,7 @@ export default class Helpers {
           scroll_id
         }, options as TransportRequestOptionsWithMeta)
         // @ts-expect-error
-        response = r as TransportResult<T.ScrollResponse<TDocument, TAggregation>, unknown>
+        response = r as TransportResult<T.ScrollResponse<TDocument, TAggregations>, unknown>
         assert(response !== undefined, 'The response is undefined, please file a bug report')
         if (response.statusCode !== 429) break
         await sleep(wait)
@@ -865,7 +865,7 @@ export default class Helpers {
 
 // Using a getter will improve the overall performances of the code,
 // as we will reed the documents only if needed.
-function addDocumentsGetter<TDocument, TAggregation> (result: TransportResult<T.SearchResponse<TDocument, TAggregation>, unknown>): void {
+function addDocumentsGetter<TDocument, TAggregations> (result: TransportResult<T.SearchResponse<TDocument, TAggregations>, unknown>): void {
   Object.defineProperty(result, 'documents', {
     get () {
       if (this.body.hits?.hits != null) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -37,7 +37,7 @@ export interface ScrollSearchOptions extends TransportRequestOptions {
   wait?: number
 }
 
-export interface ScrollSearchResponse<TDocument> extends TransportResult<T.SearchResponse<TDocument>, unknown> {
+export interface ScrollSearchResponse<TDocument, TAggregation> extends TransportResult<T.SearchResponse<TDocument, TAggregation>, unknown> {
   clear: () => Promise<void>
   documents: TDocument[]
 }
@@ -170,7 +170,7 @@ export default class Helpers {
    * @param {object} options - The client optional configuration for this request.
    * @return {iterator} the async iterator
    */
-  async * scrollSearch<TDocument = unknown> (params: T.SearchRequest, options: ScrollSearchOptions = {}): AsyncIterable<ScrollSearchResponse<TDocument>> {
+  async * scrollSearch<TDocument = unknown, TAggregation = unknown> (params: T.SearchRequest, options: ScrollSearchOptions = {}): AsyncIterable<ScrollSearchResponse<TDocument, TAggregation>> {
     options.meta = true
     if (this[kMetaHeader] !== null) {
       options.headers = options.headers ?? {}
@@ -186,9 +186,9 @@ export default class Helpers {
     params.scroll = params.scroll ?? '1m'
     appendFilterPath('_scroll_id', params, false)
 
-    let response: TransportResult<T.SearchResponse<TDocument>, unknown> | undefined
+    let response: TransportResult<T.SearchResponse<TDocument, TAggregation>, unknown> | undefined
     for (let i = 0; i <= maxRetries; i++) {
-      response = await this[kClient].search<TDocument>(params, options as TransportRequestOptionsWithMeta)
+      response = await this[kClient].search<TDocument, TAggregation>(params, options as TransportRequestOptionsWithMeta)
       if (response.statusCode !== 429) break
       await sleep(wait)
     }
@@ -213,7 +213,7 @@ export default class Helpers {
       scroll_id = response.body._scroll_id
       // @ts-expect-error
       response.clear = clear
-      addDocumentsGetter<TDocument>(response)
+      addDocumentsGetter<TDocument, TAggregation>(response)
 
       // @ts-expect-error
       yield response
@@ -228,7 +228,8 @@ export default class Helpers {
           rest_total_hits_as_int: params.rest_total_hits_as_int,
           scroll_id
         }, options as TransportRequestOptionsWithMeta)
-        response = r as TransportResult<T.ScrollResponse<TDocument>, unknown>
+        // @ts-expect-error
+        response = r as TransportResult<T.ScrollResponse<TDocument, TAggregation>, unknown>
         assert(response !== undefined, 'The response is undefined, please file a bug report')
         if (response.statusCode !== 429) break
         await sleep(wait)
@@ -864,7 +865,7 @@ export default class Helpers {
 
 // Using a getter will improve the overall performances of the code,
 // as we will reed the documents only if needed.
-function addDocumentsGetter<TDocument> (result: TransportResult<T.SearchResponse<TDocument>, unknown>): void {
+function addDocumentsGetter<TDocument, TAggregation> (result: TransportResult<T.SearchResponse<TDocument, TAggregation>, unknown>): void {
   Object.defineProperty(result, 'documents', {
     get () {
       if (this.body.hits?.hits != null) {


### PR DESCRIPTION
As titled, this allows to write code like this:
```ts
import { Client } from '@elastic/elasticsearch'
import * as T from '@elastic/elasticsearch/lib/api/types'

const client = new Client({
  node: 'http://localhost:9200'
})

interface Document {
  world: number
}

interface Aggregation {
  hello: T.AggregationsValueAggregate
}

async function run () {
  const result = await client.search<Document, Aggregation>({
    index: 'foo',
    query: { match_all: {} },
    aggregations: {
      hello: {
        avg: {
          field: 'world'
        }
      }
    }
  })

  result.aggregations.hello // autocompletes to AggregationsValueAggregate
}
```