### PR TITLE
Fix formatting by removing double backticks

### DIFF
--- a/docs/advanced-config.asciidoc
+++ b/docs/advanced-config.asciidoc
@@ -89,12 +89,12 @@ const client = new Client({
 ==== Migrate to v8
 
 The Node.js client can be configured to emit an HTTP header
-``Accept: application/vnd.elasticsearch+json; compatible-with=7``
+`Accept: application/vnd.elasticsearch+json; compatible-with=7`
 which signals to Elasticsearch that the client is requesting
-``7.x`` version of request and response bodies. This allows for
+`7.x` version of request and response bodies. This allows for
 upgrading from 7.x to 8.x version of Elasticsearch without upgrading
 everything at once. Elasticsearch should be upgraded first after
 the compatibility header is configured and clients should be upgraded
 second.
 To enable to setting, configure the environment variable
-``ELASTIC_CLIENT_APIVERSIONING`` to ``true``.
+`ELASTIC_CLIENT_APIVERSIONING` to `true`.


### PR DESCRIPTION
Just a formatting change of text where <code>``</code> should have been <code>`</code>.

Nor sure what the main branch should be.

- [x] Contributor License Agreement