### PR TITLE
Bump transport version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "xmlbuilder2": "^3.0.2"
   },
   "dependencies": {
-    "@elastic/transport": "^8.0.1",
+    "@elastic/transport": "^8.0.2",
     "tslib": "^2.3.0"
   },
   "tap": {


### PR DESCRIPTION
As titled.

Adds two fixes:
- Cleanup abort listener [elastic-transport-js#42](https://github.com/elastic/elastic-transport-js/pull/42)
- perf: minor undici tuning [elastic-transport-js#41](https://github.com/elastic/elastic-transport-js/pull/41)