### PR TITLE
Replace deprecated ssl to tls

### DIFF
--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -157,11 +157,9 @@ const client = new Client({
 
 Without any additional configuration you can specify `https://` node urls, and 
 the certificates used to sign these requests will be verified. To turn off 
-certificate verification, you must specify an `ssl` object in the top level 
-config and set `rejectUnauthorized: false`. The default `ssl` values are the 
-same that Node.js's 
-https://nodejs.org/api/tls.html#tls_tls_connect_options_callback[`tls.connect()`] 
-uses.
+certificate verification, you must specify an `tls` object in the top level 
+config and set `rejectUnauthorized: false`. The default `tls` values are the 
+same that https://github.com/nodejs/undici[undici] uses.
 
 [source,js]
 ----
@@ -172,7 +170,7 @@ const client = new Client({
     username: 'elastic',
     password: 'changeme'
   },
-  ssl: {
+  tls: {
     ca: fs.readFileSync('./cacert.pem'),
     rejectUnauthorized: false
   }
@@ -195,7 +193,7 @@ const client = new Client({
   auth: { ... },
   // the fingerprint (SHA256) of the CA certificate that is used to sign the certificate that the Elasticsearch node presents for TLS.
   caFingerprint: '20:0D:CA:FA:76:...',
-  ssl: {
+  tls: {
     // might be required if it's a self-signed certificate
     rejectUnauthorized: false
   }

--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -96,7 +96,7 @@ const b = client.helpers.bulk({
 ----
 
 |`flushBytes`
-a|The size of the bulk body in bytes to reach before to send it. Default of 5MB. +
+a|The size of the bulk body in bytes to reach before sending it. Default of 5MB. +
 _Default:_ `5000000`
 [source,js]
 ----


### PR DESCRIPTION
It took me a few hours to realize the docs were not up to date.

> ### Rename `ssl` option to `tls`
> 
> *Breaking: Yes* | *Migration effort: Small*
> 
> People usually refers to this as `tls`, furthermore, internally we use the tls API and Node.js refers to it as tls everywhere.
> [source,js]
> 
> ```js
> // before
> const client = new Client({
>   node: 'https://localhost:9200',
>   ssl: {
>     rejectUnauthorized: false
>   }
> })
> 
> // after
> const client = new Client({
>   node: 'https://localhost:9200',
>   tls: {
>     rejectUnauthorized: false
>   }
> })
> ```

https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/8.0/changelog-client.html#_rename_ssl_option_to_tls


<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->
