### PR TITLE
Drop Node.js v12

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -2,9 +2,9 @@
 
 source /usr/local/bin/bash_standard_lib.sh
 
-DOCKER_IMAGES="node:16-alpine
+DOCKER_IMAGES="node:17-alpine
+node:16-alpine
 node:14-alpine
-node:12-alpine
 "
 
 for di in ${DOCKER_IMAGES}

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -9,7 +9,7 @@ script_path=$(dirname $(realpath -s $0))
 source $script_path/functions/imports.sh
 set -euo pipefail
 
-NODE_JS_VERSION=${NODE_JS_VERSION-12}
+NODE_JS_VERSION=${NODE_JS_VERSION-16}
 ELASTICSEARCH_URL=${ELASTICSEARCH_URL-"$elasticsearch_url"}
 elasticsearch_container=${elasticsearch_container-}
 

--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -3,9 +3,9 @@ STACK_VERSION:
   - 8.3.0-SNAPSHOT
 
 NODE_JS_VERSION:
+  - 17
   - 16
   - 14
-  - 12
 
 TEST_SUITE:
   - free

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 17.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install @elastic/elasticsearch
 
 ### Node.js support
 
-NOTE: The minimum supported version of Node.js is `v12`.
+NOTE: The minimum supported version of Node.js is `v14`.
 
 The client versioning follows the Elastic Stack versioning, this means that
 major, minor, and patch releases are done following a precise schedule that
@@ -44,8 +44,9 @@ of `^7.10.0`).
 | Node.js Version | Node.js EOL date | End of support         |
 | --------------- |------------------| ---------------------- |
 | `8.x`           | `December 2019`  | `7.11` (early 2021)    |
-| `10.x`          | `April 2021`      | `7.12` (mid 2021)     |
-| `12.x`          | `April 2022`      | `8.2` (early 2022)     |
+| `10.x`          | `April 2021`     | `7.12` (mid 2021)      |
+| `12.x`          | `April 2022`     | `8.2` (early 2022)     |
+| `14.x`          | `April 2023`     | `8.8` (early 2023)     |
 
 ### Compatibility
 

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -24,7 +24,7 @@ To learn more about the supported major versions, please refer to the
 [[nodejs-support]]
 === Node.js support
 
-NOTE: The minimum supported version of Node.js is `v12`.
+NOTE: The minimum supported version of Node.js is `v14`.
 
 The client versioning follows the {stack} versioning, this means that
 major, minor, and patch releases are done following a precise schedule that
@@ -60,6 +60,10 @@ of `^7.10.0`).
 |`12.x`
 |April 2022
 |`8.2` (early 2022)
+
+|`14.x`
+|April 2023
+|`8.8` (early 2023)
 |===
 
 [discrete]

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "github:sinonjs/fake-timers#0bfffc1",


### PR DESCRIPTION
As titled, according to our [Node.js support matrix](https://github.com/elastic/elasticsearch-js#nodejs-support).