### PR TITLE
Fix non-working example

### DIFF
--- a/docs/examples/bulk.asciidoc
+++ b/docs/examples/bulk.asciidoc
@@ -20,7 +20,7 @@ const client = new Client({
 async function run () {
   await client.indices.create({
     index: 'tweets',
-    operations: {
+    body: {
       mappings: {
         properties: {
           id: { type: 'integer' },


### PR DESCRIPTION
the call as depicted with `index` and `operations` fails. The second parameter should be `body` instead. I had to Google examples for this.

