### PR TITLE
Update TypeScript docs and export estypes

### DIFF
--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -51,5 +51,6 @@ Paste the results here:
 
 - *node version*: 6,8,10
 - `@elastic/elasticsearch` *version*: >=7.0.0
+- *typescript version*: 4.x (if applicable)
 - *os*: Mac, Windows, Linux
 - *any other relevant information*

--- a/docs/typescript.asciidoc
+++ b/docs/typescript.asciidoc
@@ -7,6 +7,10 @@ of type definitions of Elasticsearch's API surface.
 The types are not 100% complete yet. Some APIs are missing (the newest ones, e.g. EQL),
 and others may contain some errors, but we are continuously pushing fixes & improvements.
 
+NOTE: The client is developed against the https://www.npmjs.com/package/typescript?activeTab=versions[latest]
+version of TypeScript. Furthermore, unless you have set `skipLibCheck` to `true`,
+you should configure `esModuleInterop` to `true`.
+
 [discrete]
 ==== Example
 
@@ -76,4 +80,11 @@ You can import the full TypeScript requests & responses definitions as it follow
 [source,ts]
 ----
 import { estypes } from '@elastic/elasticsearch'
+----
+
+If you need the legacy definitions with the body, you can do the following:
+
+[source,ts]
+----
+import { estypesWithBody } from '@elastic/elasticsearch'
 ----

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,5 +21,7 @@ import Client from './lib/client'
 import SniffingTransport from './lib/sniffingTransport'
 
 export * from '@elastic/transport'
+export * as estypes from './lib/api/types'
+export * as estypesWithBody from './lib/api/types'
 export { Client, SniffingTransport }
 export type { ClientOptions, NodeOptions } from './lib/client'


### PR DESCRIPTION
As titled.

Related: https://github.com/elastic/elasticsearch-js/issues/1665 https://github.com/elastic/elasticsearch-js/issues/1673