### PR TITLE
Types: move query keys to body

### DIFF
--- a/src/api/api/async_search.ts
+++ b/src/api/api/async_search.ts
@@ -130,7 +130,8 @@ export default class AsyncSearch {
       if (acceptedBody.includes(key)) {
         body = body ?? {}
         // @ts-expect-error
-        if (key === 'sort' && typeof params[key] === 'string' && params[key].includes(':')) {
+        if (key === 'sort' && typeof params[key] === 'string' && params[key].includes(':')) { // eslint-disable-line
+          // @ts-expect-error
           querystring[key] = params[key]
         } else {
           // @ts-expect-error

--- a/src/api/api/search.ts
+++ b/src/api/api/search.ts
@@ -58,7 +58,8 @@ export default async function SearchApi<TDocument = unknown, TAggregations = Rec
     if (acceptedBody.includes(key)) {
       body = body ?? {}
       // @ts-expect-error
-      if (key === 'sort' && typeof params[key] === 'string' && params[key].includes(':')) {
+      if (key === 'sort' && typeof params[key] === 'string' && params[key].includes(':')) { // eslint-disable-line
+        // @ts-expect-error
         querystring[key] = params[key]
       } else {
         // @ts-expect-error

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -196,7 +196,6 @@ export interface DeleteByQueryRequest extends RequestBase {
   from?: long
   ignore_unavailable?: boolean
   lenient?: boolean
-  max_docs?: long
   preference?: string
   refresh?: boolean
   request_cache?: boolean
@@ -215,6 +214,7 @@ export interface DeleteByQueryRequest extends RequestBase {
   version?: boolean
   wait_for_active_shards?: WaitForActiveShards
   wait_for_completion?: boolean
+  max_docs?: long
   query?: QueryDslQueryContainer
   slice?: SlicedScroll
 }
@@ -636,7 +636,6 @@ export interface MtermvectorsOperation {
 
 export interface MtermvectorsRequest extends RequestBase {
   index?: IndexName
-  ids?: Id[]
   fields?: Fields
   field_statistics?: boolean
   offsets?: boolean
@@ -649,6 +648,7 @@ export interface MtermvectorsRequest extends RequestBase {
   version?: VersionNumber
   version_type?: VersionType
   docs?: MtermvectorsOperation[]
+  ids?: Id[]
 }
 
 export interface MtermvectorsResponse {
@@ -913,9 +913,9 @@ export interface ScriptsPainlessExecuteResponse<TResult = unknown> {
 }
 
 export interface ScrollRequest extends RequestBase {
-  scroll_id?: ScrollId
-  scroll?: Time
   rest_total_hits_as_int?: boolean
+  scroll?: Time
+  scroll_id: ScrollId
 }
 
 export type ScrollResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = SearchResponseBody<TDocument, TAggregations>
@@ -930,9 +930,7 @@ export interface SearchRequest extends RequestBase {
   ccs_minimize_roundtrips?: boolean
   default_operator?: QueryDslOperator
   df?: string
-  docvalue_fields?: Fields
   expand_wildcards?: ExpandWildcards
-  explain?: boolean
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
   lenient?: boolean
@@ -944,32 +942,24 @@ export interface SearchRequest extends RequestBase {
   routing?: Routing
   scroll?: Time
   search_type?: SearchType
-  stats?: string[]
-  stored_fields?: Fields
   suggest_field?: Field
   suggest_mode?: SuggestMode
   suggest_size?: long
   suggest_text?: string
-  terminate_after?: long
-  timeout?: Time
-  track_total_hits?: SearchTrackHits
-  track_scores?: boolean
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
-  version?: boolean
-  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
-  seq_no_primary_term?: boolean
   q?: string
-  size?: integer
-  from?: integer
-  sort?: string | string[]
   aggregations?: Record<string, AggregationsAggregationContainer>
   aggs?: Record<string, AggregationsAggregationContainer>
   collapse?: SearchFieldCollapse
+  explain?: boolean
+  from?: integer
   highlight?: SearchHighlight
+  track_total_hits?: SearchTrackHits
   indices_boost?: Record<IndexName, double>[]
+  docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   min_score?: double
   post_filter?: QueryDslQueryContainer
   profile?: boolean
@@ -977,11 +967,21 @@ export interface SearchRequest extends RequestBase {
   rescore?: SearchRescore | SearchRescore[]
   script_fields?: Record<string, ScriptField>
   search_after?: SortResults
+  size?: integer
   slice?: SlicedScroll
+  sort?: Sort
+  _source?: SearchSourceConfig
   fields?: (QueryDslFieldAndFormat | Field)[]
   suggest?: SearchSuggester
+  terminate_after?: long
+  timeout?: string
+  track_scores?: boolean
+  version?: boolean
+  seq_no_primary_term?: boolean
+  stored_fields?: Fields
   pit?: SearchPointInTimeReference
   runtime_mappings?: MappingRuntimeFields
+  stats?: string[]
 }
 
 export type SearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = SearchResponseBody<TDocument, TAggregations>
@@ -1484,15 +1484,15 @@ export interface SearchMvtRequest extends RequestBase {
   zoom: SearchMvtZoomLevel
   x: SearchMvtCoordinate
   y: SearchMvtCoordinate
+  aggs?: Record<string, AggregationsAggregationContainer>
   exact_bounds?: boolean
   extent?: integer
+  fields?: Fields
   grid_precision?: integer
   grid_type?: SearchMvtGridType
-  size?: integer
-  aggs?: Record<string, AggregationsAggregationContainer>
-  fields?: Fields
   query?: QueryDslQueryContainer
   runtime_mappings?: MappingRuntimeFields
+  size?: integer
   sort?: Sort
   track_total_hits?: SearchTrackHits
 }
@@ -1531,18 +1531,18 @@ export interface SearchTemplateRequest extends RequestBase {
   allow_no_indices?: boolean
   ccs_minimize_roundtrips?: boolean
   expand_wildcards?: ExpandWildcards
-  explain?: boolean
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
   preference?: string
-  profile?: boolean
   routing?: Routing
   scroll?: Time
   search_type?: SearchType
   rest_total_hits_as_int?: boolean
   typed_keys?: boolean
+  explain?: boolean
   id?: Id
   params?: Record<string, any>
+  profile?: boolean
   source?: string
 }
 
@@ -1656,7 +1656,6 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
   routing?: Routing
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
-  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   detect_noop?: boolean
@@ -1664,6 +1663,7 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
   doc_as_upsert?: boolean
   script?: Script
   scripted_upsert?: boolean
+  _source?: SearchSourceConfig
   upsert?: TDocument
 }
 
@@ -1678,14 +1678,12 @@ export interface UpdateByQueryRequest extends RequestBase {
   allow_no_indices?: boolean
   analyzer?: string
   analyze_wildcard?: boolean
-  conflicts?: Conflicts
   default_operator?: QueryDslOperator
   df?: string
   expand_wildcards?: ExpandWildcards
   from?: long
   ignore_unavailable?: boolean
   lenient?: boolean
-  max_docs?: long
   pipeline?: string
   preference?: string
   refresh?: boolean
@@ -1705,9 +1703,11 @@ export interface UpdateByQueryRequest extends RequestBase {
   version_type?: boolean
   wait_for_active_shards?: WaitForActiveShards
   wait_for_completion?: boolean
+  max_docs?: long
   query?: QueryDslQueryContainer
   script?: Script
   slice?: SlicedScroll
+  conflicts?: Conflicts
 }
 
 export interface UpdateByQueryResponse {
@@ -5660,9 +5660,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   ccs_minimize_roundtrips?: boolean
   default_operator?: QueryDslOperator
   df?: string
-  docvalue_fields?: Fields
   expand_wildcards?: ExpandWildcards
-  explain?: boolean
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
   lenient?: boolean
@@ -5674,32 +5672,24 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   routing?: Routing
   scroll?: Time
   search_type?: SearchType
-  stats?: string[]
-  stored_fields?: Fields
   suggest_field?: Field
   suggest_mode?: SuggestMode
   suggest_size?: long
   suggest_text?: string
-  terminate_after?: long
-  timeout?: Time
-  track_total_hits?: SearchTrackHits
-  track_scores?: boolean
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
-  version?: boolean
-  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
-  seq_no_primary_term?: boolean
   q?: string
-  size?: integer
-  from?: integer
-  sort?: string | string[]
   aggregations?: Record<string, AggregationsAggregationContainer>
   aggs?: Record<string, AggregationsAggregationContainer>
   collapse?: SearchFieldCollapse
+  explain?: boolean
+  from?: integer
   highlight?: SearchHighlight
+  track_total_hits?: SearchTrackHits
   indices_boost?: Record<IndexName, double>[]
+  docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   min_score?: double
   post_filter?: QueryDslQueryContainer
   profile?: boolean
@@ -5707,11 +5697,21 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   rescore?: SearchRescore | SearchRescore[]
   script_fields?: Record<string, ScriptField>
   search_after?: SortResults
+  size?: integer
   slice?: SlicedScroll
+  sort?: Sort
+  _source?: SearchSourceConfig
   fields?: (QueryDslFieldAndFormat | Field)[]
   suggest?: SearchSuggester
+  terminate_after?: long
+  timeout?: string
+  track_scores?: boolean
+  version?: boolean
+  seq_no_primary_term?: boolean
+  stored_fields?: Fields
   pit?: SearchPointInTimeReference
   runtime_mappings?: MappingRuntimeFields
+  stats?: string[]
 }
 
 export type AsyncSearchSubmitResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = AsyncSearchAsyncSearchDocumentResponseBase<TDocument, TAggregations>
@@ -8607,9 +8607,6 @@ export interface EqlSearchRequest extends RequestBase {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
-  keep_alive?: Time
-  keep_on_completion?: boolean
-  wait_for_completion_timeout?: Time
   query: string
   case_sensitive?: boolean
   event_category_field?: Field
@@ -8617,6 +8614,9 @@ export interface EqlSearchRequest extends RequestBase {
   timestamp_field?: Field
   fetch_size?: uint
   filter?: QueryDslQueryContainer | QueryDslQueryContainer[]
+  keep_alive?: Time
+  keep_on_completion?: boolean
+  wait_for_completion_timeout?: Time
   size?: uint
   fields?: QueryDslFieldAndFormat | Field | (QueryDslFieldAndFormat | Field)[]
   result_position?: EqlSearchResultPosition
@@ -8692,9 +8692,7 @@ export interface FleetSearchRequest extends RequestBase {
   ccs_minimize_roundtrips?: boolean
   default_operator?: QueryDslOperator
   df?: string
-  docvalue_fields?: Fields
   expand_wildcards?: ExpandWildcards
-  explain?: boolean
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
   lenient?: boolean
@@ -8706,34 +8704,26 @@ export interface FleetSearchRequest extends RequestBase {
   routing?: Routing
   scroll?: Time
   search_type?: SearchType
-  stats?: string[]
-  stored_fields?: Fields
   suggest_field?: Field
   suggest_mode?: SuggestMode
   suggest_size?: long
   suggest_text?: string
-  terminate_after?: long
-  timeout?: Time
-  track_total_hits?: SearchTrackHits
-  track_scores?: boolean
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
-  version?: boolean
-  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
-  seq_no_primary_term?: boolean
   q?: string
-  size?: integer
-  from?: integer
-  sort?: string | string[]
   wait_for_checkpoints?: FleetCheckpoint[]
   allow_partial_search_results?: boolean
   aggregations?: Record<string, AggregationsAggregationContainer>
   aggs?: Record<string, AggregationsAggregationContainer>
   collapse?: SearchFieldCollapse
+  explain?: boolean
+  from?: integer
   highlight?: SearchHighlight
+  track_total_hits?: SearchTrackHits
   indices_boost?: Record<IndexName, double>[]
+  docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   min_score?: double
   post_filter?: QueryDslQueryContainer
   profile?: boolean
@@ -8741,11 +8731,21 @@ export interface FleetSearchRequest extends RequestBase {
   rescore?: SearchRescore | SearchRescore[]
   script_fields?: Record<string, ScriptField>
   search_after?: SortResults
+  size?: integer
   slice?: SlicedScroll
+  sort?: Sort
+  _source?: SearchSourceConfig
   fields?: (QueryDslFieldAndFormat | Field)[]
   suggest?: SearchSuggester
+  terminate_after?: long
+  timeout?: string
+  track_scores?: boolean
+  version?: boolean
+  seq_no_primary_term?: boolean
+  stored_fields?: Fields
   pit?: SearchPointInTimeReference
   runtime_mappings?: MappingRuntimeFields
+  stats?: string[]
 }
 
 export interface FleetSearchResponse<TDocument = unknown> {
@@ -8969,7 +8969,6 @@ export interface IlmMoveToStepStepKey {
 }
 
 export interface IlmPutLifecycleRequest extends RequestBase {
-  name: Name
   master_timeout?: Time
   timeout?: Time
   policy?: IlmPolicy
@@ -9062,7 +9061,7 @@ export interface IndicesFielddataFrequencyFilter {
   min_segment_size: integer
 }
 
-export type IndicesIndexCheckOnStartup = boolean | 'false' | 'checksum' | 'true'
+export type IndicesIndexCheckOnStartup = boolean | 'true' | 'false' | 'checksum'
 
 export interface IndicesIndexRouting {
   allocation?: IndicesIndexRoutingAllocation
@@ -10025,10 +10024,10 @@ export interface IndicesPutTemplateRequest extends RequestBase {
   flat_settings?: boolean
   master_timeout?: Time
   timeout?: Time
-  order?: integer
   aliases?: Record<IndexName, IndicesAlias>
   index_patterns?: string | string[]
   mappings?: MappingTypeMapping
+  order?: integer
   settings?: Record<string, any>
   version?: VersionNumber
 }
@@ -12560,16 +12559,16 @@ export interface MlForecastResponse {
 export interface MlGetBucketsRequest extends RequestBase {
   job_id: Id
   timestamp?: Timestamp
+  from?: integer
+  size?: integer
   anomaly_score?: double
   desc?: boolean
   end?: DateString
   exclude_interim?: boolean
   expand?: boolean
-  from?: integer
-  size?: integer
+  page?: MlPage
   sort?: Field
   start?: DateString
-  page?: MlPage
 }
 
 export interface MlGetBucketsResponse {
@@ -12776,13 +12775,13 @@ export interface MlGetMemoryStatsResponse {
 export interface MlGetModelSnapshotsRequest extends RequestBase {
   job_id: Id
   snapshot_id?: Id
-  desc?: boolean
-  end?: Time
   from?: integer
   size?: integer
+  desc?: boolean
+  end?: Time
+  page?: MlPage
   sort?: Field
   start?: Time
-  page?: MlPage
 }
 
 export interface MlGetModelSnapshotsResponse {
@@ -12808,15 +12807,15 @@ export interface MlGetOverallBucketsResponse {
 
 export interface MlGetRecordsRequest extends RequestBase {
   job_id: Id
+  from?: integer
+  size?: integer
   desc?: boolean
   end?: DateString
   exclude_interim?: boolean
-  from?: integer
+  page?: MlPage
   record_score?: double
-  size?: integer
   sort?: Field
   start?: DateString
-  page?: MlPage
 }
 
 export interface MlGetRecordsResponse {
@@ -15249,7 +15248,7 @@ export interface SecurityHasPrivilegesIndexPrivilegesCheck {
 export type SecurityHasPrivilegesPrivileges = Record<string, boolean>
 
 export interface SecurityHasPrivilegesRequest extends RequestBase {
-  user?: Name | null
+  user?: Name
   application?: SecurityHasPrivilegesApplicationPrivilegesCheck[]
   cluster?: SecurityClusterPrivilege[]
   index?: SecurityHasPrivilegesIndexPrivilegesCheck[]
@@ -15341,8 +15340,8 @@ export interface SecurityPutRoleMappingResponse {
 }
 
 export interface SecurityPutUserRequest extends RequestBase {
-  username: Username
   refresh?: Refresh
+  username?: Username
   email?: string | null
   full_name?: string | null
   metadata?: Metadata
@@ -15808,7 +15807,6 @@ export interface SnapshotCreateResponse {
 }
 
 export interface SnapshotCreateRepositoryRequest extends RequestBase {
-  name: Name
   master_timeout?: Time
   timeout?: Time
   verify?: boolean

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -913,9 +913,9 @@ export interface ScriptsPainlessExecuteResponse<TResult = unknown> {
 }
 
 export interface ScrollRequest extends RequestBase {
+  scroll_id?: ScrollId
   rest_total_hits_as_int?: boolean
   scroll?: Time
-  scroll_id: ScrollId
 }
 
 export type ScrollResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = SearchResponseBody<TDocument, TAggregations>
@@ -8969,6 +8969,7 @@ export interface IlmMoveToStepStepKey {
 }
 
 export interface IlmPutLifecycleRequest extends RequestBase {
+  name: Name
   master_timeout?: Time
   timeout?: Time
   policy?: IlmPolicy
@@ -15340,8 +15341,8 @@ export interface SecurityPutRoleMappingResponse {
 }
 
 export interface SecurityPutUserRequest extends RequestBase {
+  username: Username
   refresh?: Refresh
-  username?: Username
   email?: string | null
   full_name?: string | null
   metadata?: Metadata
@@ -15807,6 +15808,7 @@ export interface SnapshotCreateResponse {
 }
 
 export interface SnapshotCreateRepositoryRequest extends RequestBase {
+  name: Name
   master_timeout?: Time
   timeout?: Time
   verify?: boolean

--- a/src/api/typesWithBodyKey.ts
+++ b/src/api/typesWithBodyKey.ts
@@ -114,7 +114,6 @@ export interface BulkWriteOperation extends BulkOperationBase {
 }
 
 export interface ClearScrollRequest extends RequestBase {
-  scroll_id?: Ids
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     scroll_id?: Ids
@@ -208,7 +207,6 @@ export interface DeleteByQueryRequest extends RequestBase {
   from?: long
   ignore_unavailable?: boolean
   lenient?: boolean
-  max_docs?: long
   preference?: string
   refresh?: boolean
   request_cache?: boolean
@@ -667,7 +665,6 @@ export interface MtermvectorsOperation {
 
 export interface MtermvectorsRequest extends RequestBase {
   index?: IndexName
-  ids?: Id[]
   fields?: Fields
   field_statistics?: boolean
   offsets?: boolean
@@ -963,8 +960,6 @@ export interface ScriptsPainlessExecuteResponse<TResult = unknown> {
 }
 
 export interface ScrollRequest extends RequestBase {
-  scroll_id?: ScrollId
-  scroll?: Time
   rest_total_hits_as_int?: boolean
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
@@ -985,9 +980,7 @@ export interface SearchRequest extends RequestBase {
   ccs_minimize_roundtrips?: boolean
   default_operator?: QueryDslOperator
   df?: string
-  docvalue_fields?: Fields
   expand_wildcards?: ExpandWildcards
-  explain?: boolean
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
   lenient?: boolean
@@ -999,27 +992,15 @@ export interface SearchRequest extends RequestBase {
   routing?: Routing
   scroll?: Time
   search_type?: SearchType
-  stats?: string[]
-  stored_fields?: Fields
   suggest_field?: Field
   suggest_mode?: SuggestMode
   suggest_size?: long
   suggest_text?: string
-  terminate_after?: long
-  timeout?: Time
-  track_total_hits?: SearchTrackHits
-  track_scores?: boolean
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
-  version?: boolean
-  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
-  seq_no_primary_term?: boolean
   q?: string
-  size?: integer
-  from?: integer
-  sort?: string | string[]
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     aggregations?: Record<string, AggregationsAggregationContainer>
@@ -1556,11 +1537,6 @@ export interface SearchMvtRequest extends RequestBase {
   zoom: SearchMvtZoomLevel
   x: SearchMvtCoordinate
   y: SearchMvtCoordinate
-  exact_bounds?: boolean
-  extent?: integer
-  grid_precision?: integer
-  grid_type?: SearchMvtGridType
-  size?: integer
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     aggs?: Record<string, AggregationsAggregationContainer>
@@ -1611,11 +1587,9 @@ export interface SearchTemplateRequest extends RequestBase {
   allow_no_indices?: boolean
   ccs_minimize_roundtrips?: boolean
   expand_wildcards?: ExpandWildcards
-  explain?: boolean
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
   preference?: string
-  profile?: boolean
   routing?: Routing
   scroll?: Time
   search_type?: SearchType
@@ -1747,7 +1721,6 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
   routing?: Routing
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
-  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
@@ -1773,14 +1746,12 @@ export interface UpdateByQueryRequest extends RequestBase {
   allow_no_indices?: boolean
   analyzer?: string
   analyze_wildcard?: boolean
-  conflicts?: Conflicts
   default_operator?: QueryDslOperator
   df?: string
   expand_wildcards?: ExpandWildcards
   from?: long
   ignore_unavailable?: boolean
   lenient?: boolean
-  max_docs?: long
   pipeline?: string
   preference?: string
   refresh?: boolean
@@ -5760,9 +5731,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   ccs_minimize_roundtrips?: boolean
   default_operator?: QueryDslOperator
   df?: string
-  docvalue_fields?: Fields
   expand_wildcards?: ExpandWildcards
-  explain?: boolean
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
   lenient?: boolean
@@ -5774,27 +5743,15 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   routing?: Routing
   scroll?: Time
   search_type?: SearchType
-  stats?: string[]
-  stored_fields?: Fields
   suggest_field?: Field
   suggest_mode?: SuggestMode
   suggest_size?: long
   suggest_text?: string
-  terminate_after?: long
-  timeout?: Time
-  track_total_hits?: SearchTrackHits
-  track_scores?: boolean
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
-  version?: boolean
-  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
-  seq_no_primary_term?: boolean
   q?: string
-  size?: integer
-  from?: integer
-  sort?: string | string[]
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     aggregations?: Record<string, AggregationsAggregationContainer>
@@ -8752,9 +8709,6 @@ export interface EqlSearchRequest extends RequestBase {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
-  keep_alive?: Time
-  keep_on_completion?: boolean
-  wait_for_completion_timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     query: string
@@ -8844,9 +8798,7 @@ export interface FleetSearchRequest extends RequestBase {
   ccs_minimize_roundtrips?: boolean
   default_operator?: QueryDslOperator
   df?: string
-  docvalue_fields?: Fields
   expand_wildcards?: ExpandWildcards
-  explain?: boolean
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
   lenient?: boolean
@@ -8858,27 +8810,15 @@ export interface FleetSearchRequest extends RequestBase {
   routing?: Routing
   scroll?: Time
   search_type?: SearchType
-  stats?: string[]
-  stored_fields?: Fields
   suggest_field?: Field
   suggest_mode?: SuggestMode
   suggest_size?: long
   suggest_text?: string
-  terminate_after?: long
-  timeout?: Time
-  track_total_hits?: SearchTrackHits
-  track_scores?: boolean
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
-  version?: boolean
-  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
-  seq_no_primary_term?: boolean
   q?: string
-  size?: integer
-  from?: integer
-  sort?: string | string[]
   wait_for_checkpoints?: FleetCheckpoint[]
   allow_partial_search_results?: boolean
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
@@ -9147,7 +9087,6 @@ export interface IlmMoveToStepStepKey {
 }
 
 export interface IlmPutLifecycleRequest extends RequestBase {
-  name: Name
   master_timeout?: Time
   timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
@@ -9243,7 +9182,7 @@ export interface IndicesFielddataFrequencyFilter {
   min_segment_size: integer
 }
 
-export type IndicesIndexCheckOnStartup = boolean | 'false' | 'checksum' | 'true'
+export type IndicesIndexCheckOnStartup = boolean | 'true' | 'false' | 'checksum'
 
 export interface IndicesIndexRouting {
   allocation?: IndicesIndexRoutingAllocation
@@ -10228,7 +10167,6 @@ export interface IndicesPutTemplateRequest extends RequestBase {
   flat_settings?: boolean
   master_timeout?: Time
   timeout?: Time
-  order?: integer
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     aliases?: Record<IndexName, IndicesAlias>
@@ -12547,9 +12485,6 @@ export interface MlZeroShotClassificationInferenceUpdateOptions {
 
 export interface MlCloseJobRequest extends RequestBase {
   job_id: Id
-  allow_no_match?: boolean
-  force?: boolean
-  timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     allow_no_match?: boolean
@@ -12603,8 +12538,6 @@ export type MlDeleteDatafeedResponse = AcknowledgedResponseBase
 
 export interface MlDeleteExpiredDataRequest extends RequestBase {
   job_id?: Id
-  requests_per_second?: float
-  timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     requests_per_second?: float
@@ -12789,11 +12722,6 @@ export interface MlExplainDataFrameAnalyticsResponse {
 
 export interface MlFlushJobRequest extends RequestBase {
   job_id: Id
-  advance_time?: DateString
-  calc_interim?: boolean
-  end?: DateString
-  skip_time?: EpochMillis
-  start?: DateString
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     advance_time?: DateString
@@ -12811,9 +12739,6 @@ export interface MlFlushJobResponse {
 
 export interface MlForecastRequest extends RequestBase {
   job_id: Id
-  duration?: Time
-  expires_in?: Time
-  max_model_memory?: string
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     duration?: Time
@@ -12830,15 +12755,8 @@ export interface MlForecastResponse {
 export interface MlGetBucketsRequest extends RequestBase {
   job_id: Id
   timestamp?: Timestamp
-  anomaly_score?: double
-  desc?: boolean
-  end?: DateString
-  exclude_interim?: boolean
-  expand?: boolean
   from?: integer
   size?: integer
-  sort?: Field
-  start?: DateString
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     anomaly_score?: double
@@ -13065,12 +12983,8 @@ export interface MlGetMemoryStatsResponse {
 export interface MlGetModelSnapshotsRequest extends RequestBase {
   job_id: Id
   snapshot_id?: Id
-  desc?: boolean
-  end?: Time
   from?: integer
   size?: integer
-  sort?: Field
-  start?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     desc?: boolean
@@ -13088,13 +13002,6 @@ export interface MlGetModelSnapshotsResponse {
 
 export interface MlGetOverallBucketsRequest extends RequestBase {
   job_id: Id
-  allow_no_match?: boolean
-  bucket_span?: Time
-  end?: Time
-  exclude_interim?: boolean
-  overall_score?: double | string
-  start?: Time
-  top_n?: integer
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     allow_no_match?: boolean
@@ -13114,14 +13021,8 @@ export interface MlGetOverallBucketsResponse {
 
 export interface MlGetRecordsRequest extends RequestBase {
   job_id: Id
-  desc?: boolean
-  end?: DateString
-  exclude_interim?: boolean
   from?: integer
-  record_score?: double
   size?: integer
-  sort?: Field
-  start?: DateString
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     desc?: boolean
@@ -13227,7 +13128,6 @@ export interface MlInfoResponse {
 
 export interface MlOpenJobRequest extends RequestBase {
   job_id: Id
-  timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     timeout?: Time
@@ -13607,7 +13507,6 @@ export type MlResetJobResponse = AcknowledgedResponseBase
 export interface MlRevertModelSnapshotRequest extends RequestBase {
   job_id: Id
   snapshot_id: Id
-  delete_intervening_results?: boolean
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     delete_intervening_results?: boolean
@@ -13637,9 +13536,6 @@ export interface MlStartDataFrameAnalyticsResponse {
 
 export interface MlStartDatafeedRequest extends RequestBase {
   datafeed_id: Id
-  end?: Time
-  start?: Time
-  timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     end?: Time
@@ -13679,9 +13575,6 @@ export interface MlStopDataFrameAnalyticsResponse {
 
 export interface MlStopDatafeedRequest extends RequestBase {
   datafeed_id: Id
-  allow_no_match?: boolean
-  force?: boolean
-  timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     allow_no_match?: boolean
@@ -15669,7 +15562,7 @@ export interface SecurityHasPrivilegesIndexPrivilegesCheck {
 export type SecurityHasPrivilegesPrivileges = Record<string, boolean>
 
 export interface SecurityHasPrivilegesRequest extends RequestBase {
-  user?: Name | null
+  user?: Name
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     application?: SecurityHasPrivilegesApplicationPrivilegesCheck[]
@@ -15777,7 +15670,6 @@ export interface SecurityPutRoleMappingResponse {
 }
 
 export interface SecurityPutUserRequest extends RequestBase {
-  username: Username
   refresh?: Refresh
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
@@ -16281,7 +16173,6 @@ export interface SnapshotCreateResponse {
 }
 
 export interface SnapshotCreateRepositoryRequest extends RequestBase {
-  name: Name
   master_timeout?: Time
   timeout?: Time
   verify?: boolean

--- a/src/api/typesWithBodyKey.ts
+++ b/src/api/typesWithBodyKey.ts
@@ -114,6 +114,7 @@ export interface BulkWriteOperation extends BulkOperationBase {
 }
 
 export interface ClearScrollRequest extends RequestBase {
+  scroll_id?: Ids
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     scroll_id?: Ids
@@ -960,6 +961,7 @@ export interface ScriptsPainlessExecuteResponse<TResult = unknown> {
 }
 
 export interface ScrollRequest extends RequestBase {
+  scroll_id?: ScrollId
   rest_total_hits_as_int?: boolean
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
@@ -9087,6 +9089,7 @@ export interface IlmMoveToStepStepKey {
 }
 
 export interface IlmPutLifecycleRequest extends RequestBase {
+  name: Name
   master_timeout?: Time
   timeout?: Time
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
@@ -15670,6 +15673,7 @@ export interface SecurityPutRoleMappingResponse {
 }
 
 export interface SecurityPutUserRequest extends RequestBase {
+  username: Username
   refresh?: Refresh
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
@@ -16173,6 +16177,7 @@ export interface SnapshotCreateResponse {
 }
 
 export interface SnapshotCreateRepositoryRequest extends RequestBase {
+  name: Name
   master_timeout?: Time
   timeout?: Time
   verify?: boolean


### PR DESCRIPTION
When the same property can both go in the body and in the query, the code will put that property in the body, but the types where not correctly representing that. This pr address this issue.

Fixes: https://github.com/elastic/elasticsearch-js/issues/1589 https://github.com/elastic/elasticsearch-js/issues/1615