### PR TITLE
[DOCS] Change master to current in user profile API links

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -2983,7 +2983,7 @@ client.searchableSnapshots.stats(...)
 ==== activate_user_profile
 Creates or updates the user profile on behalf of another user.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-activate-user-profile.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-activate-user-profile.html[Endpoint documentation]
 [source,ts]
 ----
 client.security.activateUserProfile(...)
@@ -3293,7 +3293,7 @@ client.security.getUserPrivileges(...)
 ==== get_user_profile
 Retrieves user profile for the given unique ID.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-profile.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-user-profile.html[Endpoint documentation]
 [source,ts]
 ----
 client.security.getUserProfile(...)
@@ -3493,7 +3493,7 @@ client.security.suggestUserProfiles(...)
 ==== update_user_profile_data
 Update application specific data for the user profile of the given unique ID.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-update-user-profile-data.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-user-profile-data.html[Endpoint documentation]
 [source,ts]
 ----
 client.security.updateUserProfileData(...)


### PR DESCRIPTION
This is intended to fix a number of broken links to pages related to the new User Profile API, which are currently behind a feature flag. I think changing the target from `current` to `master` should do the trick. I'm not sure about the labeling but from the errors below we need to fix `8.2`, `8.2`, `current` and `master`.

```
INFO:build_docs:Bad cross-document links:
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/8.2/api-reference.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-activate-user-profile.html
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-get-user-profile.html
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-update-user-profile-data.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/8.3/api-reference.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-activate-user-profile.html
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-get-user-profile.html
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-update-user-profile-data.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/current/api-reference.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-activate-user-profile.html
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-get-user-profile.html
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-update-user-profile-data.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/master/api-reference.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-activate-user-profile.html
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-get-user-profile.html
INFO:build_docs:   - en/elasticsearch/reference/current/security-api-update-user-profile-data.html
```