### PR TITLE
Added type: '_doc' parameter in API calls

### DIFF
--- a/docs/examples/update.asciidoc
+++ b/docs/examples/update.asciidoc
@@ -19,6 +19,7 @@ async function run () {
   await client.index({
     index: 'game-of-thrones',
     id: '1',
+    type: '_doc'
     document: {
       character: 'Ned Stark',
       quote: 'Winter is coming.',
@@ -29,6 +30,7 @@ async function run () {
   await client.update({
     index: 'game-of-thrones',
     id: '1',
+    type: '_doc'
     script: {
       lang: 'painless',
       source: 'ctx._source.times++'
@@ -41,6 +43,7 @@ async function run () {
   const document = await client.get({
     index: 'game-of-thrones',
     id: '1'
+    type: '_doc'
   })
 
   console.log(document)
@@ -66,6 +69,7 @@ async function run () {
   await client.index({
     index: 'game-of-thrones',
     id: '1',
+    type: '_doc'
     document: {
       character: 'Ned Stark',
       quote: 'Winter is coming.',
@@ -76,6 +80,7 @@ async function run () {
   await client.update({
     index: 'game-of-thrones',
     id: '1',
+    type: '_doc'
     doc: {
       isAlive: false
     }
@@ -84,6 +89,7 @@ async function run () {
   const document = await client.get({
     index: 'game-of-thrones',
     id: '1'
+    type: '_doc'
   })
 
   console.log(document)


### PR DESCRIPTION
<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->
