### PR TITLE
Fix docs URLs to use 'current' instead of 'master'

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -29,7 +29,7 @@
 === bulk
 Allows to perform multiple index/update/delete operations in a single request.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html[Endpoint documentation]
 [source,ts]
 ----
 client.bulk(...)
@@ -39,7 +39,7 @@ client.bulk(...)
 === clear_scroll
 Explicitly clears the search context for a scroll.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-scroll-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.clearScroll(...)
@@ -49,7 +49,7 @@ client.clearScroll(...)
 === close_point_in_time
 Close a point in time
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.closePointInTime(...)
@@ -281,7 +281,7 @@ client.mtermvectors(...)
 === open_point_in_time
 Open a point in time that can be used in subsequent searches
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.openPointInTime(...)
@@ -466,7 +466,7 @@ client.updateByQueryRethrottle(...)
 ==== delete
 Deletes an async search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.asyncSearch.delete(...)
@@ -476,7 +476,7 @@ client.asyncSearch.delete(...)
 ==== get
 Retrieves the results of a previously submitted async search request given its ID.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.asyncSearch.get(...)
@@ -486,7 +486,7 @@ client.asyncSearch.get(...)
 ==== status
 Retrieves the status of a previously submitted async search request given its ID.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.asyncSearch.status(...)
@@ -496,7 +496,7 @@ client.asyncSearch.status(...)
 ==== submit
 Executes a search request asynchronously.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.asyncSearch.submit(...)
@@ -508,7 +508,7 @@ client.asyncSearch.submit(...)
 ==== aliases
 Shows information about currently configured aliases to indices including filter and routing infos.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-alias.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.aliases(...)
@@ -518,7 +518,7 @@ client.cat.aliases(...)
 ==== allocation
 Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.allocation(...)
@@ -536,7 +536,7 @@ client.cat.componentTemplates(...)
 ==== count
 Provides quick access to the document count of the entire cluster, or individual indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-count.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.count(...)
@@ -546,7 +546,7 @@ client.cat.count(...)
 ==== fielddata
 Shows how much heap memory is currently being used by fielddata on every data node in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-fielddata.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.fielddata(...)
@@ -556,7 +556,7 @@ client.cat.fielddata(...)
 ==== health
 Returns a concise representation of the cluster health.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-health.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.health(...)
@@ -566,7 +566,7 @@ client.cat.health(...)
 ==== help
 Returns help for the Cat APIs.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.help(...)
@@ -576,7 +576,7 @@ client.cat.help(...)
 ==== indices
 Returns information about indices: number of primaries and replicas, document counts, disk size, ...
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.indices(...)
@@ -586,7 +586,7 @@ client.cat.indices(...)
 ==== master
 Returns information about the master node.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-master.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.master(...)
@@ -596,7 +596,7 @@ client.cat.master(...)
 ==== ml_data_frame_analytics
 Gets configuration and usage information about data frame analytics jobs.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-dfanalytics.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.mlDataFrameAnalytics(...)
@@ -606,7 +606,7 @@ client.cat.mlDataFrameAnalytics(...)
 ==== ml_datafeeds
 Gets configuration and usage information about datafeeds.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-datafeeds.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.mlDatafeeds(...)
@@ -616,7 +616,7 @@ client.cat.mlDatafeeds(...)
 ==== ml_jobs
 Gets configuration and usage information about anomaly detection jobs.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-anomaly-detectors.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.mlJobs(...)
@@ -626,7 +626,7 @@ client.cat.mlJobs(...)
 ==== ml_trained_models
 Gets configuration and usage information about inference trained models.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-trained-model.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.mlTrainedModels(...)
@@ -636,7 +636,7 @@ client.cat.mlTrainedModels(...)
 ==== nodeattrs
 Returns information about custom node attributes.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-nodeattrs.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.nodeattrs(...)
@@ -646,7 +646,7 @@ client.cat.nodeattrs(...)
 ==== nodes
 Returns basic statistics about performance of cluster nodes.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-nodes.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.nodes(...)
@@ -656,7 +656,7 @@ client.cat.nodes(...)
 ==== pending_tasks
 Returns a concise representation of the cluster pending tasks.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-pending-tasks.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.pendingTasks(...)
@@ -666,7 +666,7 @@ client.cat.pendingTasks(...)
 ==== plugins
 Returns information about installed plugins across nodes node.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-plugins.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.plugins(...)
@@ -676,7 +676,7 @@ client.cat.plugins(...)
 ==== recovery
 Returns information about index shard recoveries, both on-going completed.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-recovery.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.recovery(...)
@@ -686,7 +686,7 @@ client.cat.recovery(...)
 ==== repositories
 Returns information about snapshot repositories registered in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-repositories.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.repositories(...)
@@ -696,7 +696,7 @@ client.cat.repositories(...)
 ==== segments
 Provides low-level information about the segments in the shards of an index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-segments.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.segments(...)
@@ -706,7 +706,7 @@ client.cat.segments(...)
 ==== shards
 Provides a detailed view of shard allocation on nodes.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-shards.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.shards(...)
@@ -716,7 +716,7 @@ client.cat.shards(...)
 ==== snapshots
 Returns all snapshots in a specific repository.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.snapshots(...)
@@ -726,7 +726,7 @@ client.cat.snapshots(...)
 ==== tasks
 Returns information about the tasks currently executing on one or more nodes in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.tasks(...)
@@ -736,7 +736,7 @@ client.cat.tasks(...)
 ==== templates
 Returns information about existing templates.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.templates(...)
@@ -747,7 +747,7 @@ client.cat.templates(...)
 Returns cluster-wide thread pool statistics per node.
 By default the active, queue and rejected statistics are returned for all thread pools.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-thread-pool.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.threadPool(...)
@@ -757,7 +757,7 @@ client.cat.threadPool(...)
 ==== transforms
 Gets configuration and usage information about transforms.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.transforms(...)
@@ -769,7 +769,7 @@ client.cat.transforms(...)
 ==== delete_auto_follow_pattern
 Deletes auto-follow patterns.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-delete-auto-follow-pattern.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.deleteAutoFollowPattern(...)
@@ -779,7 +779,7 @@ client.ccr.deleteAutoFollowPattern(...)
 ==== follow
 Creates a new follower index configured to follow the referenced leader index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-follow.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.follow(...)
@@ -789,7 +789,7 @@ client.ccr.follow(...)
 ==== follow_info
 Retrieves information about all follower indices, including parameters and status for each follower index
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-info.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-info.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.followInfo(...)
@@ -799,7 +799,7 @@ client.ccr.followInfo(...)
 ==== follow_stats
 Retrieves follower stats. return shard-level stats about the following tasks associated with each shard for the specified indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.followStats(...)
@@ -809,7 +809,7 @@ client.ccr.followStats(...)
 ==== forget_follower
 Removes the follower retention leases from the leader.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-forget-follower.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-forget-follower.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.forgetFollower(...)
@@ -819,7 +819,7 @@ client.ccr.forgetFollower(...)
 ==== get_auto_follow_pattern
 Gets configured auto-follow patterns. Returns the specified auto-follow pattern collection.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-auto-follow-pattern.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.getAutoFollowPattern(...)
@@ -829,7 +829,7 @@ client.ccr.getAutoFollowPattern(...)
 ==== pause_auto_follow_pattern
 Pauses an auto-follow pattern
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-pause-auto-follow-pattern.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-pause-auto-follow-pattern.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.pauseAutoFollowPattern(...)
@@ -839,7 +839,7 @@ client.ccr.pauseAutoFollowPattern(...)
 ==== pause_follow
 Pauses a follower index. The follower index will not fetch any additional operations from the leader index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-pause-follow.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.pauseFollow(...)
@@ -849,7 +849,7 @@ client.ccr.pauseFollow(...)
 ==== put_auto_follow_pattern
 Creates a new named collection of auto-follow patterns against a specified remote cluster. Newly created indices on the remote cluster matching any of the specified patterns will be automatically configured as follower indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-auto-follow-pattern.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.putAutoFollowPattern(...)
@@ -859,7 +859,7 @@ client.ccr.putAutoFollowPattern(...)
 ==== resume_auto_follow_pattern
 Resumes an auto-follow pattern that has been paused
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-resume-auto-follow-pattern.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-resume-auto-follow-pattern.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.resumeAutoFollowPattern(...)
@@ -869,7 +869,7 @@ client.ccr.resumeAutoFollowPattern(...)
 ==== resume_follow
 Resumes a follower index that has been paused
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-resume-follow.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.resumeFollow(...)
@@ -879,7 +879,7 @@ client.ccr.resumeFollow(...)
 ==== stats
 Gets all stats related to cross-cluster replication.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.stats(...)
@@ -889,7 +889,7 @@ client.ccr.stats(...)
 ==== unfollow
 Stops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-unfollow.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-unfollow.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.unfollow(...)
@@ -901,7 +901,7 @@ client.ccr.unfollow(...)
 ==== allocation_explain
 Provides explanations for shard allocations in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-allocation-explain.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.allocationExplain(...)
@@ -911,7 +911,7 @@ client.cluster.allocationExplain(...)
 ==== delete_component_template
 Deletes a component template
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.deleteComponentTemplate(...)
@@ -921,7 +921,7 @@ client.cluster.deleteComponentTemplate(...)
 ==== delete_voting_config_exclusions
 Clears cluster voting config exclusions.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/voting-config-exclusions.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.deleteVotingConfigExclusions(...)
@@ -931,7 +931,7 @@ client.cluster.deleteVotingConfigExclusions(...)
 ==== exists_component_template
 Returns information about whether a particular component template exist
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.existsComponentTemplate(...)
@@ -941,7 +941,7 @@ client.cluster.existsComponentTemplate(...)
 ==== get_component_template
 Returns one or more component templates
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.getComponentTemplate(...)
@@ -951,7 +951,7 @@ client.cluster.getComponentTemplate(...)
 ==== get_settings
 Returns cluster settings.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-get-settings.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.getSettings(...)
@@ -961,7 +961,7 @@ client.cluster.getSettings(...)
 ==== health
 Returns basic information about the health of the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.health(...)
@@ -972,7 +972,7 @@ client.cluster.health(...)
 Returns a list of any cluster-level changes (e.g. create index, update mapping,
 allocate or fail shard) which have not yet been executed.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-pending.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.pendingTasks(...)
@@ -982,7 +982,7 @@ client.cluster.pendingTasks(...)
 ==== post_voting_config_exclusions
 Updates the cluster voting config exclusions by node ids or node names.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/voting-config-exclusions.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.postVotingConfigExclusions(...)
@@ -992,7 +992,7 @@ client.cluster.postVotingConfigExclusions(...)
 ==== put_component_template
 Creates or updates a component template
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.putComponentTemplate(...)
@@ -1002,7 +1002,7 @@ client.cluster.putComponentTemplate(...)
 ==== put_settings
 Updates the cluster settings.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.putSettings(...)
@@ -1012,7 +1012,7 @@ client.cluster.putSettings(...)
 ==== remote_info
 Returns the information about configured remote clusters.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-remote-info.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.remoteInfo(...)
@@ -1022,7 +1022,7 @@ client.cluster.remoteInfo(...)
 ==== reroute
 Allows to manually change the allocation of individual shards in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-reroute.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.reroute(...)
@@ -1032,7 +1032,7 @@ client.cluster.reroute(...)
 ==== state
 Returns a comprehensive information about the state of the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-state.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.state(...)
@@ -1042,7 +1042,7 @@ client.cluster.state(...)
 ==== stats
 Returns high-level overview of cluster statistics.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.stats(...)
@@ -1488,6 +1488,16 @@ https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-disk-usag
 [source,ts]
 ----
 client.indices.diskUsage(...)
+----
+
+[discrete]
+==== downsample
+Downsample an index
+
+https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-rollup.html[Endpoint documentation]
+[source,ts]
+----
+client.indices.downsample(...)
 ----
 
 [discrete]
@@ -2095,7 +2105,7 @@ client.ml.clearTrainedModelDeploymentCache(...)
 ==== close_job
 Closes one or more anomaly detection jobs. A job can be opened and closed multiple times throughout its lifecycle.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-close-job.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.closeJob(...)
@@ -2105,7 +2115,7 @@ client.ml.closeJob(...)
 ==== delete_calendar
 Deletes a calendar.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.deleteCalendar(...)
@@ -2115,7 +2125,7 @@ client.ml.deleteCalendar(...)
 ==== delete_calendar_event
 Deletes scheduled events from a calendar.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-event.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-event.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.deleteCalendarEvent(...)
@@ -2125,7 +2135,7 @@ client.ml.deleteCalendarEvent(...)
 ==== delete_calendar_job
 Deletes anomaly detection jobs from a calendar.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-job.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-job.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.deleteCalendarJob(...)
@@ -2135,7 +2145,7 @@ client.ml.deleteCalendarJob(...)
 ==== delete_data_frame_analytics
 Deletes an existing data frame analytics job.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-dfanalytics.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.deleteDataFrameAnalytics(...)
@@ -2145,7 +2155,7 @@ client.ml.deleteDataFrameAnalytics(...)
 ==== delete_datafeed
 Deletes an existing datafeed.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-datafeed.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.deleteDatafeed(...)
@@ -2555,7 +2565,7 @@ client.ml.putCalendarJob(...)
 ==== put_data_frame_analytics
 Instantiates a data frame analytics job.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.putDataFrameAnalytics(...)
@@ -2807,7 +2817,7 @@ client.nodes.getRepositoriesMeteringInfo(...)
 ==== hot_threads
 Returns information about hot threads on each node in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-hot-threads.html[Endpoint documentation]
 [source,ts]
 ----
 client.nodes.hotThreads(...)
@@ -2817,7 +2827,7 @@ client.nodes.hotThreads(...)
 ==== info
 Returns information about nodes in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html[Endpoint documentation]
 [source,ts]
 ----
 client.nodes.info(...)
@@ -2837,7 +2847,7 @@ client.nodes.reloadSecureSettings(...)
 ==== stats
 Returns statistical information about nodes in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.nodes.stats(...)
@@ -2847,7 +2857,7 @@ client.nodes.stats(...)
 ==== usage
 Returns low-level information about REST actions usage on nodes.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-usage.html[Endpoint documentation]
 [source,ts]
 ----
 client.nodes.usage(...)
@@ -2903,16 +2913,6 @@ https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-put-job.ht
 [source,ts]
 ----
 client.rollup.putJob(...)
-----
-
-[discrete]
-==== rollup
-Rollup an index
-
-https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-rollup.html[Endpoint documentation]
-[source,ts]
-----
-client.rollup.rollup(...)
 ----
 
 [discrete]
@@ -3460,6 +3460,8 @@ client.security.samlServiceProviderMetadata(...)
 [discrete]
 ==== update_api_key
 Updates attributes of an existing API key.
+
+https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-update-api-key.html[Endpoint documentation]
 [source,ts]
 ----
 client.security.updateApiKey(...)
@@ -3759,7 +3761,7 @@ client.ssl.certificates(...)
 ==== cancel
 Cancels a task, if it can be cancelled through an API.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html[Endpoint documentation]
 [source,ts]
 ----
 client.tasks.cancel(...)
@@ -3769,7 +3771,7 @@ client.tasks.cancel(...)
 ==== get
 Returns information about a task.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html[Endpoint documentation]
 [source,ts]
 ----
 client.tasks.get(...)
@@ -3779,7 +3781,7 @@ client.tasks.get(...)
 ==== list
 Returns a list of tasks.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html[Endpoint documentation]
 [source,ts]
 ----
 client.tasks.list(...)

--- a/src/api/api/async_search.ts
+++ b/src/api/api/async_search.ts
@@ -114,7 +114,7 @@ export default class AsyncSearch {
   async submit<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.AsyncSearchSubmitRequest | TB.AsyncSearchSubmitRequest, options?: TransportRequestOptions): Promise<T.AsyncSearchSubmitResponse<TDocument, TAggregations>>
   async submit<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.AsyncSearchSubmitRequest | TB.AsyncSearchSubmitRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = ['index']
-    const acceptedBody: string[] = ['aggregations', 'aggs', 'collapse', 'explain', 'from', 'highlight', 'track_total_hits', 'indices_boost', 'docvalue_fields', 'knn', 'min_score', 'post_filter', 'profile', 'query', 'rescore', 'script_fields', 'search_after', 'size', 'slice', 'sort', '_source', 'fields', 'suggest', 'terminate_after', 'timeout', 'track_scores', 'version', 'seq_no_primary_term', 'stored_fields', 'pit', 'runtime_mappings', 'stats']
+    const acceptedBody: string[] = ['aggregations', 'aggs', 'collapse', 'explain', 'ext', 'from', 'highlight', 'track_total_hits', 'indices_boost', 'docvalue_fields', 'knn', 'min_score', 'post_filter', 'profile', 'query', 'rescore', 'script_fields', 'search_after', 'size', 'slice', 'sort', '_source', 'fields', 'suggest', 'terminate_after', 'timeout', 'track_scores', 'version', 'seq_no_primary_term', 'stored_fields', 'pit', 'runtime_mappings', 'stats']
     const querystring: Record<string, any> = {}
     // @ts-expect-error
     const userBody: any = params?.body

--- a/src/api/api/fleet.ts
+++ b/src/api/api/fleet.ts
@@ -104,7 +104,7 @@ export default class Fleet {
   async search<TDocument = unknown> (this: That, params: T.FleetSearchRequest | TB.FleetSearchRequest, options?: TransportRequestOptions): Promise<T.FleetSearchResponse<TDocument>>
   async search<TDocument = unknown> (this: That, params: T.FleetSearchRequest | TB.FleetSearchRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = ['index']
-    const acceptedBody: string[] = ['aggregations', 'aggs', 'collapse', 'explain', 'from', 'highlight', 'track_total_hits', 'indices_boost', 'docvalue_fields', 'min_score', 'post_filter', 'profile', 'query', 'rescore', 'script_fields', 'search_after', 'size', 'slice', 'sort', '_source', 'fields', 'suggest', 'terminate_after', 'timeout', 'track_scores', 'version', 'seq_no_primary_term', 'stored_fields', 'pit', 'runtime_mappings', 'stats']
+    const acceptedBody: string[] = ['aggregations', 'aggs', 'collapse', 'explain', 'ext', 'from', 'highlight', 'track_total_hits', 'indices_boost', 'docvalue_fields', 'min_score', 'post_filter', 'profile', 'query', 'rescore', 'script_fields', 'search_after', 'size', 'slice', 'sort', '_source', 'fields', 'suggest', 'terminate_after', 'timeout', 'track_scores', 'version', 'seq_no_primary_term', 'stored_fields', 'pit', 'runtime_mappings', 'stats']
     const querystring: Record<string, any> = {}
     // @ts-expect-error
     const userBody: any = params?.body

--- a/src/api/api/indices.ts
+++ b/src/api/api/indices.ts
@@ -418,6 +418,33 @@ export default class Indices {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
+  async downsample (this: That, params: T.IndicesDownsampleRequest | TB.IndicesDownsampleRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.IndicesDownsampleResponse>
+  async downsample (this: That, params: T.IndicesDownsampleRequest | TB.IndicesDownsampleRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.IndicesDownsampleResponse, unknown>>
+  async downsample (this: That, params: T.IndicesDownsampleRequest | TB.IndicesDownsampleRequest, options?: TransportRequestOptions): Promise<T.IndicesDownsampleResponse>
+  async downsample (this: That, params: T.IndicesDownsampleRequest | TB.IndicesDownsampleRequest, options?: TransportRequestOptions): Promise<any> {
+    const acceptedPath: string[] = ['index', 'target_index']
+    const acceptedBody: string[] = ['config']
+    const querystring: Record<string, any> = {}
+    // @ts-expect-error
+    let body: any = params.body ?? undefined
+
+    for (const key in params) {
+      if (acceptedBody.includes(key)) {
+        // @ts-expect-error
+        body = params[key]
+      } else if (acceptedPath.includes(key)) {
+        continue
+      } else if (key !== 'body') {
+        // @ts-expect-error
+        querystring[key] = params[key]
+      }
+    }
+
+    const method = 'POST'
+    const path = `/${encodeURIComponent(params.index.toString())}/_downsample/${encodeURIComponent(params.target_index.toString())}`
+    return await this.transport.request({ path, method, querystring, body }, options)
+  }
+
   async exists (this: That, params: T.IndicesExistsRequest | TB.IndicesExistsRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.IndicesExistsResponse>
   async exists (this: That, params: T.IndicesExistsRequest | TB.IndicesExistsRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.IndicesExistsResponse, unknown>>
   async exists (this: That, params: T.IndicesExistsRequest | TB.IndicesExistsRequest, options?: TransportRequestOptions): Promise<T.IndicesExistsResponse>

--- a/src/api/api/rollup.ts
+++ b/src/api/api/rollup.ts
@@ -181,33 +181,6 @@ export default class Rollup {
     return await this.transport.request({ path, method, querystring, body }, options)
   }
 
-  async rollup (this: That, params: T.RollupRollupRequest | TB.RollupRollupRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.RollupRollupResponse>
-  async rollup (this: That, params: T.RollupRollupRequest | TB.RollupRollupRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.RollupRollupResponse, unknown>>
-  async rollup (this: That, params: T.RollupRollupRequest | TB.RollupRollupRequest, options?: TransportRequestOptions): Promise<T.RollupRollupResponse>
-  async rollup (this: That, params: T.RollupRollupRequest | TB.RollupRollupRequest, options?: TransportRequestOptions): Promise<any> {
-    const acceptedPath: string[] = ['index', 'rollup_index']
-    const acceptedBody: string[] = ['config']
-    const querystring: Record<string, any> = {}
-    // @ts-expect-error
-    let body: any = params.body ?? undefined
-
-    for (const key in params) {
-      if (acceptedBody.includes(key)) {
-        // @ts-expect-error
-        body = params[key]
-      } else if (acceptedPath.includes(key)) {
-        continue
-      } else if (key !== 'body') {
-        // @ts-expect-error
-        querystring[key] = params[key]
-      }
-    }
-
-    const method = 'POST'
-    const path = `/${encodeURIComponent(params.index.toString())}/_rollup/${encodeURIComponent(params.rollup_index.toString())}`
-    return await this.transport.request({ path, method, querystring, body }, options)
-  }
-
   async rollupSearch<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithOutMeta): Promise<T.RollupRollupSearchResponse<TDocument, TAggregations>>
   async rollupSearch<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptionsWithMeta): Promise<TransportResult<T.RollupRollupSearchResponse<TDocument, TAggregations>, unknown>>
   async rollupSearch<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params: T.RollupRollupSearchRequest | TB.RollupRollupSearchRequest, options?: TransportRequestOptions): Promise<T.RollupRollupSearchResponse<TDocument, TAggregations>>

--- a/src/api/api/search.ts
+++ b/src/api/api/search.ts
@@ -42,7 +42,7 @@ export default async function SearchApi<TDocument = unknown, TAggregations = Rec
 export default async function SearchApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptions): Promise<T.SearchResponse<TDocument, TAggregations>>
 export default async function SearchApi<TDocument = unknown, TAggregations = Record<T.AggregateName, T.AggregationsAggregate>> (this: That, params?: T.SearchRequest | TB.SearchRequest, options?: TransportRequestOptions): Promise<any> {
   const acceptedPath: string[] = ['index']
-  const acceptedBody: string[] = ['aggregations', 'aggs', 'collapse', 'explain', 'from', 'highlight', 'track_total_hits', 'indices_boost', 'docvalue_fields', 'knn', 'min_score', 'post_filter', 'profile', 'query', 'rescore', 'script_fields', 'search_after', 'size', 'slice', 'sort', '_source', 'fields', 'suggest', 'terminate_after', 'timeout', 'track_scores', 'version', 'seq_no_primary_term', 'stored_fields', 'pit', 'runtime_mappings', 'stats']
+  const acceptedBody: string[] = ['aggregations', 'aggs', 'collapse', 'explain', 'ext', 'from', 'highlight', 'track_total_hits', 'indices_boost', 'docvalue_fields', 'knn', 'min_score', 'post_filter', 'profile', 'query', 'rescore', 'script_fields', 'search_after', 'size', 'slice', 'sort', '_source', 'fields', 'suggest', 'terminate_after', 'timeout', 'track_scores', 'version', 'seq_no_primary_term', 'stored_fields', 'pit', 'runtime_mappings', 'stats']
   const querystring: Record<string, any> = {}
   // @ts-expect-error
   const userBody: any = params?.body

--- a/src/api/api/security.ts
+++ b/src/api/api/security.ts
@@ -891,7 +891,7 @@ export default class Security {
   async grantApiKey (this: That, params: T.SecurityGrantApiKeyRequest | TB.SecurityGrantApiKeyRequest, options?: TransportRequestOptions): Promise<T.SecurityGrantApiKeyResponse>
   async grantApiKey (this: That, params: T.SecurityGrantApiKeyRequest | TB.SecurityGrantApiKeyRequest, options?: TransportRequestOptions): Promise<any> {
     const acceptedPath: string[] = []
-    const acceptedBody: string[] = ['api_key', 'grant_type', 'access_token', 'username', 'password']
+    const acceptedBody: string[] = ['api_key', 'grant_type', 'access_token', 'username', 'password', 'run_as']
     const querystring: Record<string, any> = {}
     // @ts-expect-error
     const userBody: any = params?.body

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -433,7 +433,7 @@ export interface GetScriptLanguagesResponse {
   types_allowed: string[]
 }
 
-export interface GetSourceRequest {
+export interface GetSourceRequest extends RequestBase {
   id: Id
   index: IndexName
   preference?: string
@@ -560,6 +560,7 @@ export interface MsearchMultisearchBody {
   collapse?: SearchFieldCollapse
   query?: QueryDslQueryContainer
   explain?: boolean
+  ext?: Record<string, any>
   stored_fields?: Fields
   docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   knn?: KnnQuery
@@ -987,6 +988,7 @@ export interface SearchRequest extends RequestBase {
   aggs?: Record<string, AggregationsAggregationContainer>
   collapse?: SearchFieldCollapse
   explain?: boolean
+  ext?: Record<string, any>
   from?: integer
   highlight?: SearchHighlight
   track_total_hits?: SearchTrackHits
@@ -1876,7 +1878,7 @@ export type EpochTime<Unit = unknown> = Unit
 
 export interface ErrorCauseKeys {
   type: string
-  reason: string
+  reason?: string
   stack_trace?: string
   caused_by?: ErrorCause
   root_cause?: ErrorCause[]
@@ -1918,7 +1920,7 @@ export interface FieldSort {
 
 export type FieldSortNumericType = 'long' | 'double' | 'date' | 'date_nanos'
 
-export type FieldValue = long | double | string | boolean
+export type FieldValue = long | double | string | boolean | any
 
 export interface FielddataStats {
   evictions?: long
@@ -2954,7 +2956,7 @@ export interface AggregationsFormattableMetricAggregation extends AggregationsMe
 export type AggregationsGapPolicy = 'skip' | 'insert_zeros'
 
 export interface AggregationsGeoBoundsAggregate extends AggregationsAggregateBase {
-  bounds: GeoBounds
+  bounds?: GeoBounds
 }
 
 export interface AggregationsGeoBoundsAggregation extends AggregationsMetricAggregationBase {
@@ -3953,17 +3955,18 @@ export type AnalysisIcuCollationStrength = 'primary' | 'secondary' | 'tertiary' 
 
 export interface AnalysisIcuCollationTokenFilter extends AnalysisTokenFilterBase {
   type: 'icu_collation'
-  alternate: AnalysisIcuCollationAlternate
-  caseFirst: AnalysisIcuCollationCaseFirst
-  caseLevel: boolean
-  country: string
-  decomposition: AnalysisIcuCollationDecomposition
-  hiraganaQuaternaryMode: boolean
-  language: string
-  numeric: boolean
-  strength: AnalysisIcuCollationStrength
+  alternate?: AnalysisIcuCollationAlternate
+  caseFirst?: AnalysisIcuCollationCaseFirst
+  caseLevel?: boolean
+  country?: string
+  decomposition?: AnalysisIcuCollationDecomposition
+  hiraganaQuaternaryMode?: boolean
+  language?: string
+  numeric?: boolean
+  rules?: string
+  strength?: AnalysisIcuCollationStrength
   variableTop?: string
-  variant: string
+  variant?: string
 }
 
 export interface AnalysisIcuFoldingTokenFilter extends AnalysisTokenFilterBase {
@@ -3995,7 +3998,7 @@ export type AnalysisIcuTransformDirection = 'forward' | 'reverse'
 
 export interface AnalysisIcuTransformTokenFilter extends AnalysisTokenFilterBase {
   type: 'icu_transform'
-  dir: AnalysisIcuTransformDirection
+  dir?: AnalysisIcuTransformDirection
   id: string
 }
 
@@ -4785,7 +4788,7 @@ export interface MappingRuntimeField {
 
 export type MappingRuntimeFieldType = 'boolean' | 'date' | 'double' | 'geo_point' | 'ip' | 'keyword' | 'long'
 
-export type MappingRuntimeFields = Record<Field, MappingRuntimeField | MappingRuntimeField[]>
+export type MappingRuntimeFields = Record<Field, MappingRuntimeField>
 
 export interface MappingScaledFloatNumberProperty extends MappingNumberPropertyBase {
   type: 'scaled_float'
@@ -5753,6 +5756,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   aggs?: Record<string, AggregationsAggregationContainer>
   collapse?: SearchFieldCollapse
   explain?: boolean
+  ext?: Record<string, any>
   from?: integer
   highlight?: SearchHighlight
   track_total_hits?: SearchTrackHits
@@ -7879,7 +7883,7 @@ export interface ClusterComponentTemplateNode {
 export interface ClusterComponentTemplateSummary {
   _meta?: Metadata
   version?: VersionNumber
-  settings: Record<IndexName, IndicesIndexSettings>
+  settings?: Record<IndexName, IndicesIndexSettings>
   mappings?: MappingTypeMapping
   aliases?: Record<string, IndicesAliasDefinition>
 }
@@ -8812,6 +8816,7 @@ export interface FleetSearchRequest extends RequestBase {
   aggs?: Record<string, AggregationsAggregationContainer>
   collapse?: SearchFieldCollapse
   explain?: boolean
+  ext?: Record<string, any>
   from?: integer
   highlight?: SearchHighlight
   track_total_hits?: SearchTrackHits
@@ -9329,8 +9334,7 @@ export interface IndicesIndexTemplateSummary {
 }
 
 export interface IndicesIndexVersioning {
-  created: VersionString
-  created_string?: VersionString
+  created?: VersionString
 }
 
 export interface IndicesIndexingPressure {
@@ -9565,7 +9569,7 @@ export interface IndicesAnalyzeAnalyzeDetail {
 export interface IndicesAnalyzeAnalyzeToken {
   end_offset: long
   position: long
-  position_length?: long
+  positionLength?: long
   start_offset: long
   token: string
   type: string
@@ -9771,6 +9775,14 @@ export interface IndicesDiskUsageRequest extends RequestBase {
 }
 
 export type IndicesDiskUsageResponse = any
+
+export interface IndicesDownsampleRequest extends RequestBase {
+  index: IndexName
+  target_index: IndexName
+  config?: any
+}
+
+export type IndicesDownsampleResponse = any
 
 export interface IndicesExistsRequest extends RequestBase {
   index: Indices
@@ -14752,14 +14764,6 @@ export interface RollupPutJobRequest extends RequestBase {
 
 export type RollupPutJobResponse = AcknowledgedResponseBase
 
-export interface RollupRollupRequest extends RequestBase {
-  index: IndexName
-  rollup_index: IndexName
-  config?: any
-}
-
-export type RollupRollupResponse = any
-
 export interface RollupRollupSearchRequest extends RequestBase {
   index: Indices
   rest_total_hits_as_int?: boolean
@@ -14875,6 +14879,9 @@ export interface SecurityApiKey {
   realm?: string
   username?: Username
   metadata?: Metadata
+  role_descriptors?: Record<string, SecurityRoleDescriptor>
+  limited_by?: Record<string, SecurityRoleDescriptor>[]
+  _sort?: SortResults
 }
 
 export interface SecurityApplicationGlobalUserPrivileges {
@@ -15001,6 +15008,7 @@ export interface SecurityUser {
   roles: string[]
   username: Username
   enabled: boolean
+  profile_uid?: SecurityUserProfileId
 }
 
 export interface SecurityUserProfile {
@@ -15270,6 +15278,7 @@ export interface SecurityGetApiKeyRequest extends RequestBase {
   owner?: boolean
   realm_name?: Name
   username?: Username
+  with_limited_by?: boolean
 }
 
 export interface SecurityGetApiKeyResponse {
@@ -15381,7 +15390,7 @@ export interface SecurityGetTokenResponse {
   expires_in: long
   scope?: string
   type: string
-  refresh_token: string
+  refresh_token?: string
   kerberos_authentication_response_token?: string
   authentication: SecurityGetTokenAuthenticatedUser
 }
@@ -15393,6 +15402,7 @@ export interface SecurityGetTokenUserRealm {
 
 export interface SecurityGetUserRequest extends RequestBase {
   username?: Username | Username[]
+  with_profile_uid?: boolean
 }
 
 export type SecurityGetUserResponse = Record<string, SecurityUser>
@@ -15411,19 +15421,28 @@ export interface SecurityGetUserPrivilegesResponse {
   run_as: string[]
 }
 
+export interface SecurityGetUserProfileGetUserProfileErrors {
+  count: long
+  details: Record<SecurityUserProfileId, ErrorCause>
+}
+
 export interface SecurityGetUserProfileRequest extends RequestBase {
-  uid: SecurityUserProfileId
+  uid: SecurityUserProfileId | SecurityUserProfileId[]
   data?: string | string[]
 }
 
-export type SecurityGetUserProfileResponse = Record<string, SecurityUserProfileWithMetadata>
+export interface SecurityGetUserProfileResponse {
+  profiles: SecurityUserProfileWithMetadata[]
+  errors?: SecurityGetUserProfileGetUserProfileErrors
+}
 
 export type SecurityGrantApiKeyApiKeyGrantType = 'access_token' | 'password'
 
 export interface SecurityGrantApiKeyGrantApiKey {
   name: Name
-  expiration?: Duration
-  role_descriptors?: Record<string, any>[]
+  expiration?: DurationLarge
+  role_descriptors?: Record<string, SecurityRoleDescriptor> | Record<string, SecurityRoleDescriptor>[]
+  metadata?: Metadata
 }
 
 export interface SecurityGrantApiKeyRequest extends RequestBase {
@@ -15432,6 +15451,7 @@ export interface SecurityGrantApiKeyRequest extends RequestBase {
   access_token?: string
   username?: Username
   password?: Password
+  run_as?: Username
 }
 
 export interface SecurityGrantApiKeyResponse {
@@ -15439,6 +15459,7 @@ export interface SecurityGrantApiKeyResponse {
   id: Id
   name: Name
   expiration?: EpochTime<UnitMillis>
+  encoded: string
 }
 
 export interface SecurityHasPrivilegesApplicationPrivilegesCheck {
@@ -15474,6 +15495,11 @@ export interface SecurityHasPrivilegesResponse {
   username: Username
 }
 
+export interface SecurityHasPrivilegesUserProfileHasPrivilegesUserProfileErrors {
+  count: long
+  details: Record<SecurityUserProfileId, ErrorCause>
+}
+
 export interface SecurityHasPrivilegesUserProfilePrivilegesCheck {
   application?: SecurityHasPrivilegesApplicationPrivilegesCheck[]
   cluster?: SecurityClusterPrivilege[]
@@ -15487,7 +15513,7 @@ export interface SecurityHasPrivilegesUserProfileRequest extends RequestBase {
 
 export interface SecurityHasPrivilegesUserProfileResponse {
   has_privilege_uids: SecurityUserProfileId[]
-  error_uids?: SecurityUserProfileId[]
+  errors?: SecurityHasPrivilegesUserProfileHasPrivilegesUserProfileErrors
 }
 
 export interface SecurityInvalidateApiKeyRequest extends RequestBase {
@@ -15582,6 +15608,7 @@ export interface SecurityPutUserResponse {
 }
 
 export interface SecurityQueryApiKeysRequest extends RequestBase {
+  with_limited_by?: boolean
   query?: QueryDslQueryContainer
   from?: integer
   sort?: Sort
@@ -16309,6 +16336,7 @@ export interface TasksParentTaskInfo extends TasksTaskInfo {
 
 export interface TasksTaskInfo {
   action: string
+  cancelled?: boolean
   cancellable: boolean
   description?: string
   headers: Record<string, string>
@@ -16764,41 +16792,30 @@ export interface WatcherActivationStatus {
 export interface WatcherAlwaysCondition {
 }
 
-export interface WatcherArrayCompareCondition {
-  array_path: string
-  comparison: string
+export interface WatcherArrayCompareConditionKeys {
   path: string
+}
+export type WatcherArrayCompareCondition = WatcherArrayCompareConditionKeys
+& { [property: string]: WatcherArrayCompareOpParams | string }
+
+export interface WatcherArrayCompareOpParams {
   quantifier: WatcherQuantifier
-  value: any
+  value: FieldValue
 }
 
 export interface WatcherChainInput {
-  inputs: WatcherInputContainer[]
-}
-
-export interface WatcherCompareCondition {
-  comparison?: string
-  path?: string
-  value?: any
-  'ctx.payload.match'?: WatcherCompareContextPayloadCondition
-  'ctx.payload.value'?: WatcherCompareContextPayloadCondition
-}
-
-export interface WatcherCompareContextPayloadCondition {
-  eq?: any
-  lt?: any
-  gt?: any
-  lte?: any
-  gte?: any
+  inputs: Partial<Record<string, WatcherInputContainer>>[]
 }
 
 export interface WatcherConditionContainer {
   always?: WatcherAlwaysCondition
-  array_compare?: WatcherArrayCompareCondition
-  compare?: WatcherCompareCondition
+  array_compare?: Partial<Record<string, WatcherArrayCompareCondition>>
+  compare?: Partial<Record<string, Partial<Record<WatcherConditionOp, FieldValue>>>>
   never?: WatcherNeverCondition
   script?: WatcherScriptCondition
 }
+
+export type WatcherConditionOp = 'not_eq' | 'eq' | 'lt' | 'gt' | 'lte' | 'gte'
 
 export type WatcherConditionType = 'always' | 'never' | 'script' | 'compare' | 'array_compare'
 
@@ -16919,7 +16936,6 @@ export interface WatcherHttpEmailAttachment {
 }
 
 export interface WatcherHttpInput {
-  http?: WatcherHttpInput
   extract?: string[]
   request?: WatcherHttpInputRequestDefinition
   response_content_type?: WatcherResponseContentType

--- a/src/api/typesWithBodyKey.ts
+++ b/src/api/typesWithBodyKey.ts
@@ -454,7 +454,7 @@ export interface GetScriptLanguagesResponse {
   types_allowed: string[]
 }
 
-export interface GetSourceRequest {
+export interface GetSourceRequest extends RequestBase {
   id: Id
   index: IndexName
   preference?: string
@@ -588,6 +588,7 @@ export interface MsearchMultisearchBody {
   collapse?: SearchFieldCollapse
   query?: QueryDslQueryContainer
   explain?: boolean
+  ext?: Record<string, any>
   stored_fields?: Fields
   docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   knn?: KnnQuery
@@ -1041,6 +1042,7 @@ export interface SearchRequest extends RequestBase {
     aggs?: Record<string, AggregationsAggregationContainer>
     collapse?: SearchFieldCollapse
     explain?: boolean
+    ext?: Record<string, any>
     from?: integer
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
@@ -1949,7 +1951,7 @@ export type EpochTime<Unit = unknown> = Unit
 
 export interface ErrorCauseKeys {
   type: string
-  reason: string
+  reason?: string
   stack_trace?: string
   caused_by?: ErrorCause
   root_cause?: ErrorCause[]
@@ -1991,7 +1993,7 @@ export interface FieldSort {
 
 export type FieldSortNumericType = 'long' | 'double' | 'date' | 'date_nanos'
 
-export type FieldValue = long | double | string | boolean
+export type FieldValue = long | double | string | boolean | any
 
 export interface FielddataStats {
   evictions?: long
@@ -3027,7 +3029,7 @@ export interface AggregationsFormattableMetricAggregation extends AggregationsMe
 export type AggregationsGapPolicy = 'skip' | 'insert_zeros'
 
 export interface AggregationsGeoBoundsAggregate extends AggregationsAggregateBase {
-  bounds: GeoBounds
+  bounds?: GeoBounds
 }
 
 export interface AggregationsGeoBoundsAggregation extends AggregationsMetricAggregationBase {
@@ -4026,17 +4028,18 @@ export type AnalysisIcuCollationStrength = 'primary' | 'secondary' | 'tertiary' 
 
 export interface AnalysisIcuCollationTokenFilter extends AnalysisTokenFilterBase {
   type: 'icu_collation'
-  alternate: AnalysisIcuCollationAlternate
-  caseFirst: AnalysisIcuCollationCaseFirst
-  caseLevel: boolean
-  country: string
-  decomposition: AnalysisIcuCollationDecomposition
-  hiraganaQuaternaryMode: boolean
-  language: string
-  numeric: boolean
-  strength: AnalysisIcuCollationStrength
+  alternate?: AnalysisIcuCollationAlternate
+  caseFirst?: AnalysisIcuCollationCaseFirst
+  caseLevel?: boolean
+  country?: string
+  decomposition?: AnalysisIcuCollationDecomposition
+  hiraganaQuaternaryMode?: boolean
+  language?: string
+  numeric?: boolean
+  rules?: string
+  strength?: AnalysisIcuCollationStrength
   variableTop?: string
-  variant: string
+  variant?: string
 }
 
 export interface AnalysisIcuFoldingTokenFilter extends AnalysisTokenFilterBase {
@@ -4068,7 +4071,7 @@ export type AnalysisIcuTransformDirection = 'forward' | 'reverse'
 
 export interface AnalysisIcuTransformTokenFilter extends AnalysisTokenFilterBase {
   type: 'icu_transform'
-  dir: AnalysisIcuTransformDirection
+  dir?: AnalysisIcuTransformDirection
   id: string
 }
 
@@ -4858,7 +4861,7 @@ export interface MappingRuntimeField {
 
 export type MappingRuntimeFieldType = 'boolean' | 'date' | 'double' | 'geo_point' | 'ip' | 'keyword' | 'long'
 
-export type MappingRuntimeFields = Record<Field, MappingRuntimeField | MappingRuntimeField[]>
+export type MappingRuntimeFields = Record<Field, MappingRuntimeField>
 
 export interface MappingScaledFloatNumberProperty extends MappingNumberPropertyBase {
   type: 'scaled_float'
@@ -5828,6 +5831,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     aggs?: Record<string, AggregationsAggregationContainer>
     collapse?: SearchFieldCollapse
     explain?: boolean
+    ext?: Record<string, any>
     from?: integer
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
@@ -7968,7 +7972,7 @@ export interface ClusterComponentTemplateNode {
 export interface ClusterComponentTemplateSummary {
   _meta?: Metadata
   version?: VersionNumber
-  settings: Record<IndexName, IndicesIndexSettings>
+  settings?: Record<IndexName, IndicesIndexSettings>
   mappings?: MappingTypeMapping
   aliases?: Record<string, IndicesAliasDefinition>
 }
@@ -8922,6 +8926,7 @@ export interface FleetSearchRequest extends RequestBase {
     aggs?: Record<string, AggregationsAggregationContainer>
     collapse?: SearchFieldCollapse
     explain?: boolean
+    ext?: Record<string, any>
     from?: integer
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
@@ -9452,8 +9457,7 @@ export interface IndicesIndexTemplateSummary {
 }
 
 export interface IndicesIndexVersioning {
-  created: VersionString
-  created_string?: VersionString
+  created?: VersionString
 }
 
 export interface IndicesIndexingPressure {
@@ -9688,7 +9692,7 @@ export interface IndicesAnalyzeAnalyzeDetail {
 export interface IndicesAnalyzeAnalyzeToken {
   end_offset: long
   position: long
-  position_length?: long
+  positionLength?: long
   start_offset: long
   token: string
   type: string
@@ -9903,6 +9907,15 @@ export interface IndicesDiskUsageRequest extends RequestBase {
 }
 
 export type IndicesDiskUsageResponse = any
+
+export interface IndicesDownsampleRequest extends RequestBase {
+  index: IndexName
+  target_index: IndexName
+  /** @deprecated The use of the 'body' key has been deprecated, use 'config' instead. */
+  body?: any
+}
+
+export type IndicesDownsampleResponse = any
 
 export interface IndicesExistsRequest extends RequestBase {
   index: Indices
@@ -15046,15 +15059,6 @@ export interface RollupPutJobRequest extends RequestBase {
 
 export type RollupPutJobResponse = AcknowledgedResponseBase
 
-export interface RollupRollupRequest extends RequestBase {
-  index: IndexName
-  rollup_index: IndexName
-  /** @deprecated The use of the 'body' key has been deprecated, use 'config' instead. */
-  body?: any
-}
-
-export type RollupRollupResponse = any
-
 export interface RollupRollupSearchRequest extends RequestBase {
   index: Indices
   rest_total_hits_as_int?: boolean
@@ -15176,6 +15180,9 @@ export interface SecurityApiKey {
   realm?: string
   username?: Username
   metadata?: Metadata
+  role_descriptors?: Record<string, SecurityRoleDescriptor>
+  limited_by?: Record<string, SecurityRoleDescriptor>[]
+  _sort?: SortResults
 }
 
 export interface SecurityApplicationGlobalUserPrivileges {
@@ -15302,6 +15309,7 @@ export interface SecurityUser {
   roles: string[]
   username: Username
   enabled: boolean
+  profile_uid?: SecurityUserProfileId
 }
 
 export interface SecurityUserProfile {
@@ -15580,6 +15588,7 @@ export interface SecurityGetApiKeyRequest extends RequestBase {
   owner?: boolean
   realm_name?: Name
   username?: Username
+  with_limited_by?: boolean
 }
 
 export interface SecurityGetApiKeyResponse {
@@ -15694,7 +15703,7 @@ export interface SecurityGetTokenResponse {
   expires_in: long
   scope?: string
   type: string
-  refresh_token: string
+  refresh_token?: string
   kerberos_authentication_response_token?: string
   authentication: SecurityGetTokenAuthenticatedUser
 }
@@ -15706,6 +15715,7 @@ export interface SecurityGetTokenUserRealm {
 
 export interface SecurityGetUserRequest extends RequestBase {
   username?: Username | Username[]
+  with_profile_uid?: boolean
 }
 
 export type SecurityGetUserResponse = Record<string, SecurityUser>
@@ -15724,19 +15734,28 @@ export interface SecurityGetUserPrivilegesResponse {
   run_as: string[]
 }
 
+export interface SecurityGetUserProfileGetUserProfileErrors {
+  count: long
+  details: Record<SecurityUserProfileId, ErrorCause>
+}
+
 export interface SecurityGetUserProfileRequest extends RequestBase {
-  uid: SecurityUserProfileId
+  uid: SecurityUserProfileId | SecurityUserProfileId[]
   data?: string | string[]
 }
 
-export type SecurityGetUserProfileResponse = Record<string, SecurityUserProfileWithMetadata>
+export interface SecurityGetUserProfileResponse {
+  profiles: SecurityUserProfileWithMetadata[]
+  errors?: SecurityGetUserProfileGetUserProfileErrors
+}
 
 export type SecurityGrantApiKeyApiKeyGrantType = 'access_token' | 'password'
 
 export interface SecurityGrantApiKeyGrantApiKey {
   name: Name
-  expiration?: Duration
-  role_descriptors?: Record<string, any>[]
+  expiration?: DurationLarge
+  role_descriptors?: Record<string, SecurityRoleDescriptor> | Record<string, SecurityRoleDescriptor>[]
+  metadata?: Metadata
 }
 
 export interface SecurityGrantApiKeyRequest extends RequestBase {
@@ -15747,6 +15766,7 @@ export interface SecurityGrantApiKeyRequest extends RequestBase {
     access_token?: string
     username?: Username
     password?: Password
+    run_as?: Username
   }
 }
 
@@ -15755,6 +15775,7 @@ export interface SecurityGrantApiKeyResponse {
   id: Id
   name: Name
   expiration?: EpochTime<UnitMillis>
+  encoded: string
 }
 
 export interface SecurityHasPrivilegesApplicationPrivilegesCheck {
@@ -15793,6 +15814,11 @@ export interface SecurityHasPrivilegesResponse {
   username: Username
 }
 
+export interface SecurityHasPrivilegesUserProfileHasPrivilegesUserProfileErrors {
+  count: long
+  details: Record<SecurityUserProfileId, ErrorCause>
+}
+
 export interface SecurityHasPrivilegesUserProfilePrivilegesCheck {
   application?: SecurityHasPrivilegesApplicationPrivilegesCheck[]
   cluster?: SecurityClusterPrivilege[]
@@ -15809,7 +15835,7 @@ export interface SecurityHasPrivilegesUserProfileRequest extends RequestBase {
 
 export interface SecurityHasPrivilegesUserProfileResponse {
   has_privilege_uids: SecurityUserProfileId[]
-  error_uids?: SecurityUserProfileId[]
+  errors?: SecurityHasPrivilegesUserProfileHasPrivilegesUserProfileErrors
 }
 
 export interface SecurityInvalidateApiKeyRequest extends RequestBase {
@@ -15921,6 +15947,7 @@ export interface SecurityPutUserResponse {
 }
 
 export interface SecurityQueryApiKeysRequest extends RequestBase {
+  with_limited_by?: boolean
   /** @deprecated The use of the 'body' key has been deprecated, move the nested keys to the top level object. */
   body?: {
     query?: QueryDslQueryContainer
@@ -16702,6 +16729,7 @@ export interface TasksParentTaskInfo extends TasksTaskInfo {
 
 export interface TasksTaskInfo {
   action: string
+  cancelled?: boolean
   cancellable: boolean
   description?: string
   headers: Record<string, string>
@@ -17167,41 +17195,30 @@ export interface WatcherActivationStatus {
 export interface WatcherAlwaysCondition {
 }
 
-export interface WatcherArrayCompareCondition {
-  array_path: string
-  comparison: string
+export interface WatcherArrayCompareConditionKeys {
   path: string
+}
+export type WatcherArrayCompareCondition = WatcherArrayCompareConditionKeys
+& { [property: string]: WatcherArrayCompareOpParams | string }
+
+export interface WatcherArrayCompareOpParams {
   quantifier: WatcherQuantifier
-  value: any
+  value: FieldValue
 }
 
 export interface WatcherChainInput {
-  inputs: WatcherInputContainer[]
-}
-
-export interface WatcherCompareCondition {
-  comparison?: string
-  path?: string
-  value?: any
-  'ctx.payload.match'?: WatcherCompareContextPayloadCondition
-  'ctx.payload.value'?: WatcherCompareContextPayloadCondition
-}
-
-export interface WatcherCompareContextPayloadCondition {
-  eq?: any
-  lt?: any
-  gt?: any
-  lte?: any
-  gte?: any
+  inputs: Partial<Record<string, WatcherInputContainer>>[]
 }
 
 export interface WatcherConditionContainer {
   always?: WatcherAlwaysCondition
-  array_compare?: WatcherArrayCompareCondition
-  compare?: WatcherCompareCondition
+  array_compare?: Partial<Record<string, WatcherArrayCompareCondition>>
+  compare?: Partial<Record<string, Partial<Record<WatcherConditionOp, FieldValue>>>>
   never?: WatcherNeverCondition
   script?: WatcherScriptCondition
 }
+
+export type WatcherConditionOp = 'not_eq' | 'eq' | 'lt' | 'gt' | 'lte' | 'gte'
 
 export type WatcherConditionType = 'always' | 'never' | 'script' | 'compare' | 'array_compare'
 
@@ -17322,7 +17339,6 @@ export interface WatcherHttpEmailAttachment {
 }
 
 export interface WatcherHttpInput {
-  http?: WatcherHttpInput
   extract?: string[]
   request?: WatcherHttpInputRequestDefinition
   response_content_type?: WatcherResponseContentType


### PR DESCRIPTION
Updates the API generator to use `current` instead of `master`.