### PR TITLE
Fix docs URLs to use '8.0' instead of 'master'

### DIFF
--- a/docs/observability.asciidoc
+++ b/docs/observability.asciidoc
@@ -377,9 +377,9 @@ child.search({
 To improve observability, the client offers an easy way to configure the 
 `X-Opaque-Id` header. If you set the `X-Opaque-Id` in a specific request, this 
 allows you to discover this identifier in the 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/logging.html#deprecation-logging[deprecation logs], 
-helps you with https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-slowlog.html#_identifying_search_slow_log_origin[identifying search slow log origin] 
-as well as https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks[identifying running tasks].
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/logging.html#deprecation-logging[deprecation logs], 
+helps you with https://www.elastic.co/guide/en/elasticsearch/reference/8.0/index-modules-slowlog.html#_identifying_search_slow_log_origin[identifying search slow log origin] 
+as well as https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html#_identifying_running_tasks[identifying running tasks].
 
 The `X-Opaque-Id` should be configured in each request, for doing that you can 
 use the `opaqueId` option, as you can see in the following example. The 

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -29,7 +29,7 @@
 === bulk
 Allows to perform multiple index/update/delete operations in a single request.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-bulk.html[Endpoint documentation]
 [source,ts]
 ----
 client.bulk(...)
@@ -39,7 +39,7 @@ client.bulk(...)
 === clear_scroll
 Explicitly clears the search context for a scroll.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-scroll-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/clear-scroll-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.clearScroll(...)
@@ -49,7 +49,7 @@ client.clearScroll(...)
 === close_point_in_time
 Close a point in time
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/point-in-time-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.closePointInTime(...)
@@ -59,7 +59,7 @@ client.closePointInTime(...)
 === count
 Returns number of documents matching a query.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-count.html[Endpoint documentation]
 [source,ts]
 ----
 client.count(...)
@@ -71,7 +71,7 @@ Creates a new document in the index.
 
 Returns a 409 response when a document with a same ID already exists in the index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-index_.html[Endpoint documentation]
 [source,ts]
 ----
 client.create(...)
@@ -81,7 +81,7 @@ client.create(...)
 === delete
 Removes a document from the index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-delete.html[Endpoint documentation]
 [source,ts]
 ----
 client.delete(...)
@@ -91,7 +91,7 @@ client.delete(...)
 === delete_by_query
 Deletes documents matching the provided query.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-delete-by-query.html[Endpoint documentation]
 [source,ts]
 ----
 client.deleteByQuery(...)
@@ -111,7 +111,7 @@ client.deleteByQueryRethrottle(...)
 === delete_script
 Deletes a script.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-scripting.html[Endpoint documentation]
 [source,ts]
 ----
 client.deleteScript(...)
@@ -121,7 +121,7 @@ client.deleteScript(...)
 === exists
 Returns information about whether a document exists in an index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html[Endpoint documentation]
 [source,ts]
 ----
 client.exists(...)
@@ -131,7 +131,7 @@ client.exists(...)
 === exists_source
 Returns information about whether a document source exists in an index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html[Endpoint documentation]
 [source,ts]
 ----
 client.existsSource(...)
@@ -141,7 +141,7 @@ client.existsSource(...)
 === explain
 Returns information about why a specific matches (or doesn't match) a query.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-explain.html[Endpoint documentation]
 [source,ts]
 ----
 client.explain(...)
@@ -151,7 +151,7 @@ client.explain(...)
 === field_caps
 Returns the information about the capabilities of fields among multiple indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-field-caps.html[Endpoint documentation]
 [source,ts]
 ----
 client.fieldCaps(...)
@@ -161,7 +161,7 @@ client.fieldCaps(...)
 === get
 Returns a document.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html[Endpoint documentation]
 [source,ts]
 ----
 client.get(...)
@@ -171,7 +171,7 @@ client.get(...)
 === get_script
 Returns a script.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-scripting.html[Endpoint documentation]
 [source,ts]
 ----
 client.getScript(...)
@@ -191,7 +191,7 @@ client.getScriptContext(...)
 === get_script_languages
 Returns available script types, languages and contexts
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-scripting.html[Endpoint documentation]
 [source,ts]
 ----
 client.getScriptLanguages(...)
@@ -201,7 +201,7 @@ client.getScriptLanguages(...)
 === get_source
 Returns the source of a document.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html[Endpoint documentation]
 [source,ts]
 ----
 client.getSource(...)
@@ -211,7 +211,7 @@ client.getSource(...)
 === index
 Creates or updates a document in an index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-index_.html[Endpoint documentation]
 [source,ts]
 ----
 client.index(...)
@@ -231,7 +231,7 @@ client.info(...)
 === knn_search
 Performs a kNN search.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.knnSearch(...)
@@ -241,7 +241,7 @@ client.knnSearch(...)
 === mget
 Allows to get multiple documents in one request.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-multi-get.html[Endpoint documentation]
 [source,ts]
 ----
 client.mget(...)
@@ -251,7 +251,7 @@ client.mget(...)
 === msearch
 Allows to execute several search operations in one request.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-multi-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.msearch(...)
@@ -271,7 +271,7 @@ client.msearchTemplate(...)
 === mtermvectors
 Returns multiple termvectors in one request.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-multi-termvectors.html[Endpoint documentation]
 [source,ts]
 ----
 client.mtermvectors(...)
@@ -281,7 +281,7 @@ client.mtermvectors(...)
 === open_point_in_time
 Open a point in time that can be used in subsequent searches
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/point-in-time-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.openPointInTime(...)
@@ -301,7 +301,7 @@ client.ping(...)
 === put_script
 Creates or updates a script.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-scripting.html[Endpoint documentation]
 [source,ts]
 ----
 client.putScript(...)
@@ -311,7 +311,7 @@ client.putScript(...)
 === rank_eval
 Allows to evaluate the quality of ranked search results over a set of typical search queries
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-rank-eval.html[Endpoint documentation]
 [source,ts]
 ----
 client.rankEval(...)
@@ -323,7 +323,7 @@ Allows to copy documents from one index to another, optionally filtering the sou
 documents by a query, changing the destination index settings, or fetching the
 documents from a remote cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-reindex.html[Endpoint documentation]
 [source,ts]
 ----
 client.reindex(...)
@@ -333,7 +333,7 @@ client.reindex(...)
 === reindex_rethrottle
 Changes the number of requests per second for a particular Reindex operation.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-reindex.html[Endpoint documentation]
 [source,ts]
 ----
 client.reindexRethrottle(...)
@@ -363,7 +363,7 @@ client.scriptsPainlessExecute(...)
 === scroll
 Allows to retrieve a large numbers of results from a single search request.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-request-body.html#request-body-search-scroll[Endpoint documentation]
 [source,ts]
 ----
 client.scroll(...)
@@ -373,7 +373,7 @@ client.scroll(...)
 === search
 Returns results matching a query.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.search(...)
@@ -383,7 +383,7 @@ client.search(...)
 === search_mvt
 Searches a vector tile for geospatial values. Returns results as a binary Mapbox vector tile.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-vector-tile-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.searchMvt(...)
@@ -393,7 +393,7 @@ client.searchMvt(...)
 === search_shards
 Returns information about the indices and shards that a search request would be executed against.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-shards.html[Endpoint documentation]
 [source,ts]
 ----
 client.searchShards(...)
@@ -423,7 +423,7 @@ client.termsEnum(...)
 === termvectors
 Returns information and statistics about terms in the fields of a particular document.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-termvectors.html[Endpoint documentation]
 [source,ts]
 ----
 client.termvectors(...)
@@ -433,7 +433,7 @@ client.termvectors(...)
 === update
 Updates a document with a script or partial document.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-update.html[Endpoint documentation]
 [source,ts]
 ----
 client.update(...)
@@ -444,7 +444,7 @@ client.update(...)
 Performs an update on every document in the index without changing the source,
 for example to pick up a mapping change.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-update-by-query.html[Endpoint documentation]
 [source,ts]
 ----
 client.updateByQuery(...)
@@ -466,7 +466,7 @@ client.updateByQueryRethrottle(...)
 ==== delete
 Deletes an async search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/async-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.asyncSearch.delete(...)
@@ -476,7 +476,7 @@ client.asyncSearch.delete(...)
 ==== get
 Retrieves the results of a previously submitted async search request given its ID.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/async-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.asyncSearch.get(...)
@@ -486,7 +486,7 @@ client.asyncSearch.get(...)
 ==== status
 Retrieves the status of a previously submitted async search request given its ID.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/async-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.asyncSearch.status(...)
@@ -496,7 +496,7 @@ client.asyncSearch.status(...)
 ==== submit
 Executes a search request asynchronously.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/async-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.asyncSearch.submit(...)
@@ -508,7 +508,7 @@ client.asyncSearch.submit(...)
 ==== aliases
 Shows information about currently configured aliases to indices including filter and routing infos.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-alias.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.aliases(...)
@@ -518,7 +518,7 @@ client.cat.aliases(...)
 ==== allocation
 Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-allocation.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.allocation(...)
@@ -528,7 +528,7 @@ client.cat.allocation(...)
 ==== count
 Provides quick access to the document count of the entire cluster, or individual indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-count.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.count(...)
@@ -538,7 +538,7 @@ client.cat.count(...)
 ==== fielddata
 Shows how much heap memory is currently being used by fielddata on every data node in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-fielddata.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.fielddata(...)
@@ -548,7 +548,7 @@ client.cat.fielddata(...)
 ==== health
 Returns a concise representation of the cluster health.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-health.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.health(...)
@@ -558,7 +558,7 @@ client.cat.health(...)
 ==== help
 Returns help for the Cat APIs.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.help(...)
@@ -568,7 +568,7 @@ client.cat.help(...)
 ==== indices
 Returns information about indices: number of primaries and replicas, document counts, disk size, ...
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-indices.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.indices(...)
@@ -578,7 +578,7 @@ client.cat.indices(...)
 ==== master
 Returns information about the master node.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-master.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.master(...)
@@ -588,7 +588,7 @@ client.cat.master(...)
 ==== ml_data_frame_analytics
 Gets configuration and usage information about data frame analytics jobs.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-dfanalytics.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-dfanalytics.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.mlDataFrameAnalytics(...)
@@ -598,7 +598,7 @@ client.cat.mlDataFrameAnalytics(...)
 ==== ml_datafeeds
 Gets configuration and usage information about datafeeds.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-datafeeds.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-datafeeds.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.mlDatafeeds(...)
@@ -608,7 +608,7 @@ client.cat.mlDatafeeds(...)
 ==== ml_jobs
 Gets configuration and usage information about anomaly detection jobs.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-anomaly-detectors.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-anomaly-detectors.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.mlJobs(...)
@@ -618,7 +618,7 @@ client.cat.mlJobs(...)
 ==== ml_trained_models
 Gets configuration and usage information about inference trained models.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-trained-model.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-trained-model.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.mlTrainedModels(...)
@@ -628,7 +628,7 @@ client.cat.mlTrainedModels(...)
 ==== nodeattrs
 Returns information about custom node attributes.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-nodeattrs.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.nodeattrs(...)
@@ -638,7 +638,7 @@ client.cat.nodeattrs(...)
 ==== nodes
 Returns basic statistics about performance of cluster nodes.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-nodes.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.nodes(...)
@@ -648,7 +648,7 @@ client.cat.nodes(...)
 ==== pending_tasks
 Returns a concise representation of the cluster pending tasks.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-pending-tasks.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.pendingTasks(...)
@@ -658,7 +658,7 @@ client.cat.pendingTasks(...)
 ==== plugins
 Returns information about installed plugins across nodes node.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-plugins.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.plugins(...)
@@ -668,7 +668,7 @@ client.cat.plugins(...)
 ==== recovery
 Returns information about index shard recoveries, both on-going completed.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-recovery.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.recovery(...)
@@ -678,7 +678,7 @@ client.cat.recovery(...)
 ==== repositories
 Returns information about snapshot repositories registered in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-repositories.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.repositories(...)
@@ -688,7 +688,7 @@ client.cat.repositories(...)
 ==== segments
 Provides low-level information about the segments in the shards of an index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-segments.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.segments(...)
@@ -698,7 +698,7 @@ client.cat.segments(...)
 ==== shards
 Provides a detailed view of shard allocation on nodes.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-shards.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.shards(...)
@@ -708,7 +708,7 @@ client.cat.shards(...)
 ==== snapshots
 Returns all snapshots in a specific repository.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.snapshots(...)
@@ -718,7 +718,7 @@ client.cat.snapshots(...)
 ==== tasks
 Returns information about the tasks currently executing on one or more nodes in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.tasks(...)
@@ -728,7 +728,7 @@ client.cat.tasks(...)
 ==== templates
 Returns information about existing templates.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.templates(...)
@@ -739,7 +739,7 @@ client.cat.templates(...)
 Returns cluster-wide thread pool statistics per node.
 By default the active, queue and rejected statistics are returned for all thread pools.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-thread-pool.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.threadPool(...)
@@ -749,7 +749,7 @@ client.cat.threadPool(...)
 ==== transforms
 Gets configuration and usage information about transforms.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-transforms.html[Endpoint documentation]
 [source,ts]
 ----
 client.cat.transforms(...)
@@ -761,7 +761,7 @@ client.cat.transforms(...)
 ==== delete_auto_follow_pattern
 Deletes auto-follow patterns.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-delete-auto-follow-pattern.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-delete-auto-follow-pattern.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.deleteAutoFollowPattern(...)
@@ -771,7 +771,7 @@ client.ccr.deleteAutoFollowPattern(...)
 ==== follow
 Creates a new follower index configured to follow the referenced leader index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-follow.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-put-follow.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.follow(...)
@@ -781,7 +781,7 @@ client.ccr.follow(...)
 ==== follow_info
 Retrieves information about all follower indices, including parameters and status for each follower index
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-info.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-follow-info.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.followInfo(...)
@@ -791,7 +791,7 @@ client.ccr.followInfo(...)
 ==== follow_stats
 Retrieves follower stats. return shard-level stats about the following tasks associated with each shard for the specified indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-follow-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-follow-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.followStats(...)
@@ -801,7 +801,7 @@ client.ccr.followStats(...)
 ==== forget_follower
 Removes the follower retention leases from the leader.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-forget-follower.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-forget-follower.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.forgetFollower(...)
@@ -811,7 +811,7 @@ client.ccr.forgetFollower(...)
 ==== get_auto_follow_pattern
 Gets configured auto-follow patterns. Returns the specified auto-follow pattern collection.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-auto-follow-pattern.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-auto-follow-pattern.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.getAutoFollowPattern(...)
@@ -821,7 +821,7 @@ client.ccr.getAutoFollowPattern(...)
 ==== pause_auto_follow_pattern
 Pauses an auto-follow pattern
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-pause-auto-follow-pattern.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-pause-auto-follow-pattern.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.pauseAutoFollowPattern(...)
@@ -831,7 +831,7 @@ client.ccr.pauseAutoFollowPattern(...)
 ==== pause_follow
 Pauses a follower index. The follower index will not fetch any additional operations from the leader index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-pause-follow.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-pause-follow.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.pauseFollow(...)
@@ -841,7 +841,7 @@ client.ccr.pauseFollow(...)
 ==== put_auto_follow_pattern
 Creates a new named collection of auto-follow patterns against a specified remote cluster. Newly created indices on the remote cluster matching any of the specified patterns will be automatically configured as follower indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-put-auto-follow-pattern.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-put-auto-follow-pattern.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.putAutoFollowPattern(...)
@@ -851,7 +851,7 @@ client.ccr.putAutoFollowPattern(...)
 ==== resume_auto_follow_pattern
 Resumes an auto-follow pattern that has been paused
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-resume-auto-follow-pattern.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-resume-auto-follow-pattern.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.resumeAutoFollowPattern(...)
@@ -861,7 +861,7 @@ client.ccr.resumeAutoFollowPattern(...)
 ==== resume_follow
 Resumes a follower index that has been paused
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-resume-follow.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-resume-follow.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.resumeFollow(...)
@@ -871,7 +871,7 @@ client.ccr.resumeFollow(...)
 ==== stats
 Gets all stats related to cross-cluster replication.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-get-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.stats(...)
@@ -881,7 +881,7 @@ client.ccr.stats(...)
 ==== unfollow
 Stops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-post-unfollow.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-unfollow.html[Endpoint documentation]
 [source,ts]
 ----
 client.ccr.unfollow(...)
@@ -893,7 +893,7 @@ client.ccr.unfollow(...)
 ==== allocation_explain
 Provides explanations for shard allocations in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-allocation-explain.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.allocationExplain(...)
@@ -903,7 +903,7 @@ client.cluster.allocationExplain(...)
 ==== delete_component_template
 Deletes a component template
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.deleteComponentTemplate(...)
@@ -913,7 +913,7 @@ client.cluster.deleteComponentTemplate(...)
 ==== delete_voting_config_exclusions
 Clears cluster voting config exclusions.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/voting-config-exclusions.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.deleteVotingConfigExclusions(...)
@@ -923,7 +923,7 @@ client.cluster.deleteVotingConfigExclusions(...)
 ==== exists_component_template
 Returns information about whether a particular component template exist
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.existsComponentTemplate(...)
@@ -933,7 +933,7 @@ client.cluster.existsComponentTemplate(...)
 ==== get_component_template
 Returns one or more component templates
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.getComponentTemplate(...)
@@ -943,7 +943,7 @@ client.cluster.getComponentTemplate(...)
 ==== get_settings
 Returns cluster settings.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-get-settings.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.getSettings(...)
@@ -953,7 +953,7 @@ client.cluster.getSettings(...)
 ==== health
 Returns basic information about the health of the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-health.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.health(...)
@@ -964,7 +964,7 @@ client.cluster.health(...)
 Returns a list of any cluster-level changes (e.g. create index, update mapping,
 allocate or fail shard) which have not yet been executed.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-pending.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.pendingTasks(...)
@@ -974,7 +974,7 @@ client.cluster.pendingTasks(...)
 ==== post_voting_config_exclusions
 Updates the cluster voting config exclusions by node ids or node names.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/voting-config-exclusions.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.postVotingConfigExclusions(...)
@@ -984,7 +984,7 @@ client.cluster.postVotingConfigExclusions(...)
 ==== put_component_template
 Creates or updates a component template
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.putComponentTemplate(...)
@@ -994,7 +994,7 @@ client.cluster.putComponentTemplate(...)
 ==== put_settings
 Updates the cluster settings.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-update-settings.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.putSettings(...)
@@ -1004,7 +1004,7 @@ client.cluster.putSettings(...)
 ==== remote_info
 Returns the information about configured remote clusters.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-remote-info.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.remoteInfo(...)
@@ -1014,7 +1014,7 @@ client.cluster.remoteInfo(...)
 ==== reroute
 Allows to manually change the allocation of individual shards in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-reroute.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.reroute(...)
@@ -1024,7 +1024,7 @@ client.cluster.reroute(...)
 ==== state
 Returns a comprehensive information about the state of the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-state.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.state(...)
@@ -1034,7 +1034,7 @@ client.cluster.state(...)
 ==== stats
 Returns high-level overview of cluster statistics.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.cluster.stats(...)
@@ -1046,7 +1046,7 @@ client.cluster.stats(...)
 ==== delete_dangling_index
 Deletes the specified dangling index
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-gateway-dangling-indices.html[Endpoint documentation]
 [source,ts]
 ----
 client.danglingIndices.deleteDanglingIndex(...)
@@ -1056,7 +1056,7 @@ client.danglingIndices.deleteDanglingIndex(...)
 ==== import_dangling_index
 Imports the specified dangling index
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-gateway-dangling-indices.html[Endpoint documentation]
 [source,ts]
 ----
 client.danglingIndices.importDanglingIndex(...)
@@ -1066,7 +1066,7 @@ client.danglingIndices.importDanglingIndex(...)
 ==== list_dangling_indices
 Returns all dangling indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-gateway-dangling-indices.html[Endpoint documentation]
 [source,ts]
 ----
 client.danglingIndices.listDanglingIndices(...)
@@ -1172,7 +1172,7 @@ client.eql.search(...)
 ==== get_features
 Gets a list of features which can be included in snapshots using the feature_states field when creating a snapshot
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-features-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.features.getFeatures(...)
@@ -1182,7 +1182,7 @@ client.features.getFeatures(...)
 ==== reset_features
 Resets the internal state of features, usually by deleting system indices
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.features.resetFeatures(...)
@@ -1346,7 +1346,7 @@ client.ilm.stop(...)
 ==== add_block
 Adds a block to an index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/index-modules-blocks.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.addBlock(...)
@@ -1356,7 +1356,7 @@ client.indices.addBlock(...)
 ==== analyze
 Performs the analysis process on a text and return the tokens breakdown of the text.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-analyze.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.analyze(...)
@@ -1366,7 +1366,7 @@ client.indices.analyze(...)
 ==== clear_cache
 Clears all or specific caches for one or more indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-clearcache.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.clearCache(...)
@@ -1376,7 +1376,7 @@ client.indices.clearCache(...)
 ==== clone
 Clones an index
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-clone-index.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.clone(...)
@@ -1386,7 +1386,7 @@ client.indices.clone(...)
 ==== close
 Closes an index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-open-close.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.close(...)
@@ -1396,7 +1396,7 @@ client.indices.close(...)
 ==== create
 Creates an index with optional settings and mappings.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-create-index.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.create(...)
@@ -1406,7 +1406,7 @@ client.indices.create(...)
 ==== create_data_stream
 Creates a data stream
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/data-streams.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.createDataStream(...)
@@ -1416,7 +1416,7 @@ client.indices.createDataStream(...)
 ==== data_streams_stats
 Provides statistics on operations happening in a data stream.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/data-streams.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.dataStreamsStats(...)
@@ -1426,7 +1426,7 @@ client.indices.dataStreamsStats(...)
 ==== delete
 Deletes an index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-delete-index.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.delete(...)
@@ -1436,7 +1436,7 @@ client.indices.delete(...)
 ==== delete_alias
 Deletes an alias.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.deleteAlias(...)
@@ -1446,7 +1446,7 @@ client.indices.deleteAlias(...)
 ==== delete_data_stream
 Deletes a data stream.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/data-streams.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.deleteDataStream(...)
@@ -1456,7 +1456,7 @@ client.indices.deleteDataStream(...)
 ==== delete_index_template
 Deletes an index template.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.deleteIndexTemplate(...)
@@ -1466,7 +1466,7 @@ client.indices.deleteIndexTemplate(...)
 ==== delete_template
 Deletes an index template.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.deleteTemplate(...)
@@ -1476,7 +1476,7 @@ client.indices.deleteTemplate(...)
 ==== disk_usage
 Analyzes the disk usage of each field of an index or data stream
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-disk-usage.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-disk-usage.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.diskUsage(...)
@@ -1486,7 +1486,7 @@ client.indices.diskUsage(...)
 ==== exists
 Returns information about whether a particular index exists.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-exists.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.exists(...)
@@ -1496,7 +1496,7 @@ client.indices.exists(...)
 ==== exists_alias
 Returns information about whether a particular alias exists.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.existsAlias(...)
@@ -1506,7 +1506,7 @@ client.indices.existsAlias(...)
 ==== exists_index_template
 Returns information about whether a particular index template exists.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.existsIndexTemplate(...)
@@ -1516,7 +1516,7 @@ client.indices.existsIndexTemplate(...)
 ==== exists_template
 Returns information about whether a particular index template exists.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.existsTemplate(...)
@@ -1526,7 +1526,7 @@ client.indices.existsTemplate(...)
 ==== field_usage_stats
 Returns the field usage stats for each field of an index
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/field-usage-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/field-usage-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.fieldUsageStats(...)
@@ -1536,7 +1536,7 @@ client.indices.fieldUsageStats(...)
 ==== flush
 Performs the flush operation on one or more indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-flush.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.flush(...)
@@ -1546,7 +1546,7 @@ client.indices.flush(...)
 ==== forcemerge
 Performs the force merge operation on one or more indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-forcemerge.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.forcemerge(...)
@@ -1556,7 +1556,7 @@ client.indices.forcemerge(...)
 ==== get
 Returns information about one or more indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-index.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.get(...)
@@ -1566,7 +1566,7 @@ client.indices.get(...)
 ==== get_alias
 Returns an alias.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.getAlias(...)
@@ -1576,7 +1576,7 @@ client.indices.getAlias(...)
 ==== get_data_stream
 Returns data streams.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/data-streams.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.getDataStream(...)
@@ -1586,7 +1586,7 @@ client.indices.getDataStream(...)
 ==== get_field_mapping
 Returns mapping for one or more fields.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-field-mapping.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.getFieldMapping(...)
@@ -1596,7 +1596,7 @@ client.indices.getFieldMapping(...)
 ==== get_index_template
 Returns an index template.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.getIndexTemplate(...)
@@ -1606,7 +1606,7 @@ client.indices.getIndexTemplate(...)
 ==== get_mapping
 Returns mappings for one or more indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-mapping.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.getMapping(...)
@@ -1616,7 +1616,7 @@ client.indices.getMapping(...)
 ==== get_settings
 Returns settings for one or more indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-settings.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.getSettings(...)
@@ -1626,7 +1626,7 @@ client.indices.getSettings(...)
 ==== get_template
 Returns an index template.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.getTemplate(...)
@@ -1636,7 +1636,7 @@ client.indices.getTemplate(...)
 ==== migrate_to_data_stream
 Migrates an alias to a data stream
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/data-streams.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.migrateToDataStream(...)
@@ -1646,7 +1646,7 @@ client.indices.migrateToDataStream(...)
 ==== modify_data_stream
 Modifies a data stream
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/data-streams.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.modifyDataStream(...)
@@ -1656,7 +1656,7 @@ client.indices.modifyDataStream(...)
 ==== open
 Opens an index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-open-close.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.open(...)
@@ -1666,7 +1666,7 @@ client.indices.open(...)
 ==== promote_data_stream
 Promotes a data stream from a replicated data stream managed by CCR to a regular data stream
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/data-streams.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.promoteDataStream(...)
@@ -1676,7 +1676,7 @@ client.indices.promoteDataStream(...)
 ==== put_alias
 Creates or updates an alias.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.putAlias(...)
@@ -1686,7 +1686,7 @@ client.indices.putAlias(...)
 ==== put_index_template
 Creates or updates an index template.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.putIndexTemplate(...)
@@ -1696,7 +1696,7 @@ client.indices.putIndexTemplate(...)
 ==== put_mapping
 Updates the index mappings.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-put-mapping.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.putMapping(...)
@@ -1706,7 +1706,7 @@ client.indices.putMapping(...)
 ==== put_settings
 Updates the index settings.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-update-settings.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.putSettings(...)
@@ -1716,7 +1716,7 @@ client.indices.putSettings(...)
 ==== put_template
 Creates or updates an index template.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.putTemplate(...)
@@ -1726,7 +1726,7 @@ client.indices.putTemplate(...)
 ==== recovery
 Returns information about ongoing index shard recoveries.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-recovery.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.recovery(...)
@@ -1736,7 +1736,7 @@ client.indices.recovery(...)
 ==== refresh
 Performs the refresh operation in one or more indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-refresh.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.refresh(...)
@@ -1746,7 +1746,7 @@ client.indices.refresh(...)
 ==== reload_search_analyzers
 Reloads an index's search analyzers and their resources.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-reload-analyzers.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.reloadSearchAnalyzers(...)
@@ -1756,7 +1756,7 @@ client.indices.reloadSearchAnalyzers(...)
 ==== resolve_index
 Returns information about any matching indices, aliases, and data streams
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-resolve-index-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.resolveIndex(...)
@@ -1767,7 +1767,7 @@ client.indices.resolveIndex(...)
 Updates an alias to point to a new index when the existing index
 is considered to be too large or too old.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-rollover-index.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.rollover(...)
@@ -1777,7 +1777,7 @@ client.indices.rollover(...)
 ==== segments
 Provides low-level information about segments in a Lucene index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-segments.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.segments(...)
@@ -1787,7 +1787,7 @@ client.indices.segments(...)
 ==== shard_stores
 Provides store information for shard copies of indices.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-shards-stores.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.shardStores(...)
@@ -1797,7 +1797,7 @@ client.indices.shardStores(...)
 ==== shrink
 Allow to shrink an existing index into a new index with fewer primary shards.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-shrink-index.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.shrink(...)
@@ -1807,7 +1807,7 @@ client.indices.shrink(...)
 ==== simulate_index_template
 Simulate matching the given index name against the index templates in the system
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.simulateIndexTemplate(...)
@@ -1817,7 +1817,7 @@ client.indices.simulateIndexTemplate(...)
 ==== simulate_template
 Simulate resolving the given template name or body
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.simulateTemplate(...)
@@ -1827,7 +1827,7 @@ client.indices.simulateTemplate(...)
 ==== split
 Allows you to split an existing index into a new index with more primary shards.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-split-index.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.split(...)
@@ -1837,7 +1837,7 @@ client.indices.split(...)
 ==== stats
 Provides statistics on operations happening in an index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.stats(...)
@@ -1857,7 +1857,7 @@ client.indices.unfreeze(...)
 ==== update_aliases
 Updates index aliases.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.updateAliases(...)
@@ -1867,7 +1867,7 @@ client.indices.updateAliases(...)
 ==== validate_query
 Allows a user to validate a potentially expensive query without executing it.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-validate.html[Endpoint documentation]
 [source,ts]
 ----
 client.indices.validateQuery(...)
@@ -1879,7 +1879,7 @@ client.indices.validateQuery(...)
 ==== delete_pipeline
 Deletes a pipeline.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-pipeline-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.ingest.deletePipeline(...)
@@ -1889,7 +1889,7 @@ client.ingest.deletePipeline(...)
 ==== geo_ip_stats
 Returns statistical information about geoip databases
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-stats-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/geoip-stats-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.ingest.geoIpStats(...)
@@ -1899,7 +1899,7 @@ client.ingest.geoIpStats(...)
 ==== get_pipeline
 Returns a pipeline.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-pipeline-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.ingest.getPipeline(...)
@@ -1909,7 +1909,7 @@ client.ingest.getPipeline(...)
 ==== processor_grok
 Returns a list of the built-in patterns.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/grok-processor.html#grok-processor-rest-get[Endpoint documentation]
 [source,ts]
 ----
 client.ingest.processorGrok(...)
@@ -1919,7 +1919,7 @@ client.ingest.processorGrok(...)
 ==== put_pipeline
 Creates or updates a pipeline.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/put-pipeline-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.ingest.putPipeline(...)
@@ -1929,7 +1929,7 @@ client.ingest.putPipeline(...)
 ==== simulate
 Allows to simulate a pipeline with example documents.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/simulate-pipeline-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.ingest.simulate(...)
@@ -1941,7 +1941,7 @@ client.ingest.simulate(...)
 ==== delete
 Deletes licensing information for the cluster
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-license.html[Endpoint documentation]
 [source,ts]
 ----
 client.license.delete(...)
@@ -1951,7 +1951,7 @@ client.license.delete(...)
 ==== get
 Retrieves licensing information for the cluster
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-license.html[Endpoint documentation]
 [source,ts]
 ----
 client.license.get(...)
@@ -1961,7 +1961,7 @@ client.license.get(...)
 ==== get_basic_status
 Retrieves information about the status of the basic license.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-basic-status.html[Endpoint documentation]
 [source,ts]
 ----
 client.license.getBasicStatus(...)
@@ -1971,7 +1971,7 @@ client.license.getBasicStatus(...)
 ==== get_trial_status
 Retrieves information about the status of the trial license.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-trial-status.html[Endpoint documentation]
 [source,ts]
 ----
 client.license.getTrialStatus(...)
@@ -1981,7 +1981,7 @@ client.license.getTrialStatus(...)
 ==== post
 Updates the license for the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/update-license.html[Endpoint documentation]
 [source,ts]
 ----
 client.license.post(...)
@@ -1991,7 +1991,7 @@ client.license.post(...)
 ==== post_start_basic
 Starts an indefinite basic license.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/start-basic.html[Endpoint documentation]
 [source,ts]
 ----
 client.license.postStartBasic(...)
@@ -2001,7 +2001,7 @@ client.license.postStartBasic(...)
 ==== post_start_trial
 starts a limited time trial license.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/start-trial.html[Endpoint documentation]
 [source,ts]
 ----
 client.license.postStartTrial(...)
@@ -2077,7 +2077,7 @@ client.migration.postFeatureUpgrade(...)
 ==== close_job
 Closes one or more anomaly detection jobs. A job can be opened and closed multiple times throughout its lifecycle.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-close-job.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-close-job.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.closeJob(...)
@@ -2087,7 +2087,7 @@ client.ml.closeJob(...)
 ==== delete_calendar
 Deletes a calendar.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-calendar.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.deleteCalendar(...)
@@ -2097,7 +2097,7 @@ client.ml.deleteCalendar(...)
 ==== delete_calendar_event
 Deletes scheduled events from a calendar.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-event.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-calendar-event.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.deleteCalendarEvent(...)
@@ -2107,7 +2107,7 @@ client.ml.deleteCalendarEvent(...)
 ==== delete_calendar_job
 Deletes anomaly detection jobs from a calendar.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-calendar-job.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-calendar-job.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.deleteCalendarJob(...)
@@ -2117,7 +2117,7 @@ client.ml.deleteCalendarJob(...)
 ==== delete_data_frame_analytics
 Deletes an existing data frame analytics job.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-dfanalytics.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-dfanalytics.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.deleteDataFrameAnalytics(...)
@@ -2127,7 +2127,7 @@ client.ml.deleteDataFrameAnalytics(...)
 ==== delete_datafeed
 Deletes an existing datafeed.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-delete-datafeed.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-datafeed.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.deleteDatafeed(...)
@@ -2445,7 +2445,7 @@ client.ml.getTrainedModelsStats(...)
 ==== infer_trained_model_deployment
 Evaluate a trained model.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model-deployment.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/infer-trained-model-deployment.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.inferTrainedModelDeployment(...)
@@ -2535,7 +2535,7 @@ client.ml.putCalendarJob(...)
 ==== put_data_frame_analytics
 Instantiates a data frame analytics job.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/put-dfanalytics.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.putDataFrameAnalytics(...)
@@ -2665,7 +2665,7 @@ client.ml.startDatafeed(...)
 ==== start_trained_model_deployment
 Start a trained model deployment.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/start-trained-model-deployment.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.startTrainedModelDeployment(...)
@@ -2695,7 +2695,7 @@ client.ml.stopDatafeed(...)
 ==== stop_trained_model_deployment
 Stop a trained model deployment.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/stop-trained-model-deployment.html[Endpoint documentation]
 [source,ts]
 ----
 client.ml.stopTrainedModelDeployment(...)
@@ -2787,7 +2787,7 @@ client.nodes.getRepositoriesMeteringInfo(...)
 ==== hot_threads
 Returns information about hot threads on each node in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-hot-threads.html[Endpoint documentation]
 [source,ts]
 ----
 client.nodes.hotThreads(...)
@@ -2797,7 +2797,7 @@ client.nodes.hotThreads(...)
 ==== info
 Returns information about nodes in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-info.html[Endpoint documentation]
 [source,ts]
 ----
 client.nodes.info(...)
@@ -2807,7 +2807,7 @@ client.nodes.info(...)
 ==== reload_secure_settings
 Reloads secure settings.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/secure-settings.html#reloadable-secure-settings[Endpoint documentation]
 [source,ts]
 ----
 client.nodes.reloadSecureSettings(...)
@@ -2817,7 +2817,7 @@ client.nodes.reloadSecureSettings(...)
 ==== stats
 Returns statistical information about nodes in the cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.nodes.stats(...)
@@ -2827,7 +2827,7 @@ client.nodes.stats(...)
 ==== usage
 Returns low-level information about REST actions usage on nodes.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-usage.html[Endpoint documentation]
 [source,ts]
 ----
 client.nodes.usage(...)
@@ -2839,7 +2839,7 @@ client.nodes.usage(...)
 ==== delete_job
 Deletes an existing rollup job.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-delete-job.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/rollup-delete-job.html[Endpoint documentation]
 [source,ts]
 ----
 client.rollup.deleteJob(...)
@@ -2849,7 +2849,7 @@ client.rollup.deleteJob(...)
 ==== get_jobs
 Retrieves the configuration, stats, and status of rollup jobs.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-job.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/rollup-get-job.html[Endpoint documentation]
 [source,ts]
 ----
 client.rollup.getJobs(...)
@@ -2859,7 +2859,7 @@ client.rollup.getJobs(...)
 ==== get_rollup_caps
 Returns the capabilities of any rollup jobs that have been configured for a specific index or index pattern.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/rollup-get-rollup-caps.html[Endpoint documentation]
 [source,ts]
 ----
 client.rollup.getRollupCaps(...)
@@ -2869,7 +2869,7 @@ client.rollup.getRollupCaps(...)
 ==== get_rollup_index_caps
 Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the index where rollup data is stored).
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/rollup-get-rollup-index-caps.html[Endpoint documentation]
 [source,ts]
 ----
 client.rollup.getRollupIndexCaps(...)
@@ -2879,7 +2879,7 @@ client.rollup.getRollupIndexCaps(...)
 ==== put_job
 Creates a rollup job.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-put-job.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/rollup-put-job.html[Endpoint documentation]
 [source,ts]
 ----
 client.rollup.putJob(...)
@@ -2899,7 +2899,7 @@ client.rollup.rollup(...)
 ==== rollup_search
 Enables searching rolled-up data using the standard query DSL.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-search.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/rollup-search.html[Endpoint documentation]
 [source,ts]
 ----
 client.rollup.rollupSearch(...)
@@ -2909,7 +2909,7 @@ client.rollup.rollupSearch(...)
 ==== start_job
 Starts an existing, stopped rollup job.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-start-job.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/rollup-start-job.html[Endpoint documentation]
 [source,ts]
 ----
 client.rollup.startJob(...)
@@ -2919,7 +2919,7 @@ client.rollup.startJob(...)
 ==== stop_job
 Stops an existing, started rollup job.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-stop-job.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/rollup-stop-job.html[Endpoint documentation]
 [source,ts]
 ----
 client.rollup.stopJob(...)
@@ -2931,7 +2931,7 @@ client.rollup.stopJob(...)
 ==== cache_stats
 Retrieve node-level cache statistics about searchable snapshots.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/searchable-snapshots-apis.html[Endpoint documentation]
 [source,ts]
 ----
 client.searchableSnapshots.cacheStats(...)
@@ -2941,7 +2941,7 @@ client.searchableSnapshots.cacheStats(...)
 ==== clear_cache
 Clear the cache of searchable snapshots.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/searchable-snapshots-apis.html[Endpoint documentation]
 [source,ts]
 ----
 client.searchableSnapshots.clearCache(...)
@@ -2951,7 +2951,7 @@ client.searchableSnapshots.clearCache(...)
 ==== mount
 Mount a snapshot as a searchable index.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-mount-snapshot.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/searchable-snapshots-api-mount-snapshot.html[Endpoint documentation]
 [source,ts]
 ----
 client.searchableSnapshots.mount(...)
@@ -2961,7 +2961,7 @@ client.searchableSnapshots.mount(...)
 ==== stats
 Retrieve shard-level statistics about searchable snapshots.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/searchable-snapshots-apis.html[Endpoint documentation]
 [source,ts]
 ----
 client.searchableSnapshots.stats(...)
@@ -3141,7 +3141,7 @@ client.security.enableUser(...)
 ==== enroll_kibana
 Allows a kibana instance to configure itself to communicate with a secured elasticsearch cluster.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-kibana-enrollment.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-kibana-enrollment.html[Endpoint documentation]
 [source,ts]
 ----
 client.security.enrollKibana(...)
@@ -3151,7 +3151,7 @@ client.security.enrollKibana(...)
 ==== enroll_node
 Allows a new node to enroll to an existing cluster with security enabled.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-node-enrollment.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-node-enrollment.html[Endpoint documentation]
 [source,ts]
 ----
 client.security.enrollNode(...)
@@ -3499,7 +3499,7 @@ client.slm.getLifecycle(...)
 ==== get_stats
 Returns global and policy-level statistics about actions taken by snapshot lifecycle management.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-get-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.slm.getStats(...)
@@ -3551,7 +3551,7 @@ client.slm.stop(...)
 ==== cleanup_repository
 Removes stale data from repository.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/clean-up-snapshot-repo-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.cleanupRepository(...)
@@ -3561,7 +3561,7 @@ client.snapshot.cleanupRepository(...)
 ==== clone
 Clones indices from one snapshot into another snapshot in the same repository.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.clone(...)
@@ -3571,7 +3571,7 @@ client.snapshot.clone(...)
 ==== create
 Creates a snapshot in a repository.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.create(...)
@@ -3581,7 +3581,7 @@ client.snapshot.create(...)
 ==== create_repository
 Creates a repository.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.createRepository(...)
@@ -3591,7 +3591,7 @@ client.snapshot.createRepository(...)
 ==== delete
 Deletes one or more snapshots.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.delete(...)
@@ -3601,7 +3601,7 @@ client.snapshot.delete(...)
 ==== delete_repository
 Deletes a repository.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.deleteRepository(...)
@@ -3611,7 +3611,7 @@ client.snapshot.deleteRepository(...)
 ==== get
 Returns information about a snapshot.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.get(...)
@@ -3621,7 +3621,7 @@ client.snapshot.get(...)
 ==== get_repository
 Returns information about a repository.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.getRepository(...)
@@ -3631,7 +3631,7 @@ client.snapshot.getRepository(...)
 ==== repository_analyze
 Analyzes a repository for correctness and performance
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.repositoryAnalyze(...)
@@ -3641,7 +3641,7 @@ client.snapshot.repositoryAnalyze(...)
 ==== restore
 Restores a snapshot.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.restore(...)
@@ -3651,7 +3651,7 @@ client.snapshot.restore(...)
 ==== status
 Returns information about the status of a snapshot.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.status(...)
@@ -3661,7 +3661,7 @@ client.snapshot.status(...)
 ==== verify_repository
 Verifies a repository.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html[Endpoint documentation]
 [source,ts]
 ----
 client.snapshot.verifyRepository(...)
@@ -3683,7 +3683,7 @@ client.sql.clearCursor(...)
 ==== delete_async
 Deletes an async SQL search or a stored synchronous SQL search. If the search is still running, the API cancels it.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-async-sql-search-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-async-sql-search-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.sql.deleteAsync(...)
@@ -3693,7 +3693,7 @@ client.sql.deleteAsync(...)
 ==== get_async
 Returns the current status and available results for an async SQL search or stored synchronous SQL search
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-async-sql-search-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.sql.getAsync(...)
@@ -3703,7 +3703,7 @@ client.sql.getAsync(...)
 ==== get_async_status
 Returns the current status of an async SQL search or a stored synchronous SQL search
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-status-api.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-async-sql-search-status-api.html[Endpoint documentation]
 [source,ts]
 ----
 client.sql.getAsyncStatus(...)
@@ -3747,7 +3747,7 @@ client.ssl.certificates(...)
 ==== cancel
 Cancels a task, if it can be cancelled through an API.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html[Endpoint documentation]
 [source,ts]
 ----
 client.tasks.cancel(...)
@@ -3757,7 +3757,7 @@ client.tasks.cancel(...)
 ==== get
 Returns information about a task.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html[Endpoint documentation]
 [source,ts]
 ----
 client.tasks.get(...)
@@ -3767,7 +3767,7 @@ client.tasks.get(...)
 ==== list
 Returns a list of tasks.
 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html[Endpoint documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html[Endpoint documentation]
 [source,ts]
 ----
 client.tasks.list(...)


### PR DESCRIPTION
<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->
