### PR TITLE
Fix docs URLs to use '7.17' instead of 'master'

### DIFF
--- a/docs/observability.asciidoc
+++ b/docs/observability.asciidoc
@@ -377,9 +377,9 @@ child.search({
 To improve observability, the client offers an easy way to configure the 
 `X-Opaque-Id` header. If you set the `X-Opaque-Id` in a specific request, this 
 allows you to discover this identifier in the 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/logging.html#deprecation-logging[deprecation logs], 
-helps you with https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-slowlog.html#_identifying_search_slow_log_origin[identifying search slow log origin] 
-as well as https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks[identifying running tasks].
+https://www.elastic.co/guide/en/elasticsearch/reference/7.17/logging.html#deprecation-logging[deprecation logs], 
+helps you with https://www.elastic.co/guide/en/elasticsearch/reference/7.17/index-modules-slowlog.html#_identifying_search_slow_log_origin[identifying search slow log origin] 
+as well as https://www.elastic.co/guide/en/elasticsearch/reference/7.17/tasks.html#_identifying_running_tasks[identifying running tasks].
 
 The `X-Opaque-Id` should be configured in each request, for doing that you can 
 use the `opaqueId` option, as you can see in the following example. The 


### PR DESCRIPTION
<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->
