### PR TITLE
Typo: missing ',' in code example

### DIFF
--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -11,7 +11,7 @@ const { Client } = require('@elastic/elasticsearch')
 
 const client = new Client({
   cloud: { id: '<cloud-id>' },
-  auth: { apiKey: 'base64EncodedKey' }
+  auth: { apiKey: 'base64EncodedKey' },
   maxRetries: 5,
   requestTimeout: 60000,
   sniffOnStart: true


### PR DESCRIPTION
Missing ',' in code example