### PR TITLE
Fix estypesWithBody definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,6 @@ import SniffingTransport from './lib/sniffingTransport'
 
 export * from '@elastic/transport'
 export * as estypes from './lib/api/types'
-export * as estypesWithBody from './lib/api/types'
+export * as estypesWithBody from './lib/api/typesWithBodyKey'
 export { Client, SniffingTransport }
 export type { ClientOptions, NodeOptions } from './lib/client'


### PR DESCRIPTION
Fix `estypesWithBody` definition.

`estypesWithBody` should actually export the legacy types with the body key, located in `src/api/typesWithBodyKey.ts`.
