### PR TITLE
Bump @elastic/transport to 8.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "zx": "^6.1.0"
   },
   "dependencies": {
-    "@elastic/transport": "^8.2.0",
+    "@elastic/transport": "^8.3.1",
     "tslib": "^2.4.0"
   },
   "tap": {


### PR DESCRIPTION
Bumps elastic-transport-js to include the fix for https://github.com/elastic/elastic-transport-js/issues/56