### PR TITLE
[DOCS] Includes source_branch in docs index

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Elasticsearch JavaScript Client
 
-:branch: master
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/clients-team/issues/532.
This PR includes `source_branch` in the docs index file and removes `:branch: master` from the same file. The `jsclient` attribute will point to the respective branch instead of `master` this way.

### Notes

The changes of this PR need to be backported to:
* 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 
* 7.17, 7.16,
* 6.x.