### PR TITLE
[8.4][DOCS] Includes source_branch in docs index

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Elasticsearch JavaScript Client
 
-:branch: master
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]


### PR DESCRIPTION
## Overview

This PR backports the changes of the following commits to the `8.4` branch:
[DOCS] Includes source_branch in docs index #1813