### PR TITLE
[6.x][DOCS] Includes source_branch in docs index

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Elasticsearch Node.js client
 
-:branch: 6.7
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]

--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -4163,7 +4163,7 @@ client.scriptsPainlessExecute({
   body: object
 })
 ----
-link:https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html[Reference]
+link:https://www.elastic.co/guide/en/elasticsearch/painless/6.7/painless-execute-api.html[Reference]
 [cols=2*]
 |===
 |`body`


### PR DESCRIPTION
## Overview

This PR backports the changes of the following commits to the `6.x` branch:
[DOCS] Includes source_branch in docs index #1813