### PR TITLE
Use correct user-agent header by default

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -20,6 +20,7 @@
 import { ConnectionOptions as TlsConnectionOptions } from 'tls'
 import { URL } from 'url'
 import buffer from 'buffer'
+import os from 'os'
 import {
   Transport,
   UndiciConnection,
@@ -173,7 +174,9 @@ export default class Client extends API {
       tls: null,
       caFingerprint: null,
       agent: null,
-      headers: {},
+      headers: {
+        'user-agent': `elasticsearch-js/${clientVersion} Node.js ${nodeVersion}; Transport ${transportVersion}; (${os.platform()} ${os.release()} ${os.arch()})`
+      },
       nodeFilter: null,
       generateRequestId: null,
       name: 'elasticsearch-js',

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -432,3 +432,12 @@ test('caFingerprint can\'t be configured over http / 2', t => {
   )
   t.end()
 })
+
+test('user agent is in the correct format', t => {
+  const client = new Client({ node: 'http://localhost:9200' })
+  const agentRaw = client.transport[symbols.kHeaders]['user-agent'] || ''
+  const agentSplit = agentRaw.split(/\s+/)
+  t.equal(agentSplit[0].split('/')[0], 'elasticsearch-js')
+  t.ok(/^\d+\.\d+\.\d+/.test(agentSplit[0].split('/')[1]))
+  t.end()
+})


### PR DESCRIPTION
Sets an `elasticsearch-js/8.9.0 ...` user-agent header by default instead of using the default `elastic-transport-js/8.3.1 ...` format set by the transport.

Fixes https://github.com/elastic/elasticsearch-js/issues/1737
