### PR TITLE
Fix stuck clients-ci job removal

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,81 @@
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: clients-ci
+
+##### JOB DEFAULTS
+
+- job:
+    project-type: matrix
+    logrotate:
+      daysToKeep: 30
+      numToKeep: 100
+    parameters:
+    - string:
+        name: branch_specifier
+        default: refs/heads/main
+        description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+          &lt;commitId&gt;, etc.)
+    properties:
+    - github:
+        url: https://github.com/elastic/elasticsearch-js/
+    - inject:
+        properties-content: HOME=$JENKINS_HOME
+    concurrent: true
+    node: flyweight
+    scm:
+    - git:
+        name: origin
+        credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        reference-repo: /var/lib/jenkins/.git-references/elasticsearch-js.git
+        branches:
+        - ${branch_specifier}
+        url: https://github.com/elastic/elasticsearch-js.git
+        basedir: ''
+        wipe-workspace: 'True'
+    triggers:
+    - github
+    vault:
+      # vault read auth/approle/role/clients-ci/role-id
+      role_id: ddbd0d44-0e51-105b-177a-c8fdfd445126
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - linux
+    - axis:
+        type: yaml
+        filename: .ci/test-matrix.yml
+        name: STACK_VERSION
+    - axis:
+        type: yaml
+        filename: .ci/test-matrix.yml
+        name: NODE_JS_VERSION
+    - axis:
+        type: yaml
+        filename: .ci/test-matrix.yml
+        name: TEST_SUITE
+    yaml-strategy:
+      exclude-key: exclude
+      filename: .ci/test-matrix.yml
+    wrappers:
+      - ansicolor
+      - timeout:
+          type: absolute
+          timeout: 120
+          fail: true
+      - timestamps
+      - workspace-cleanup
+    builders:
+      - shell: |-
+          #!/usr/local/bin/runbld
+          .ci/run-tests
+    publishers:
+      - email:
+          recipients: build-lang-clients@elastic.co
+      - junit:
+          results: "**/*-junit.xml"
+          allow-empty-results: true


### PR DESCRIPTION
JJBB, which generates jobs in clients-ci, needs a default.yml file even if there are no job definitions. Otherwise it cannot delete old job definitions.
