### PR TITLE
Upgrade transport to 8.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "zx": "^7.2.2"
   },
   "dependencies": {
-    "@elastic/transport": "^8.3.1",
+    "@elastic/transport": "^8.3.2",
     "tslib": "^2.4.0"
   },
   "tap": {


### PR DESCRIPTION
Upgrades the transport to fix a memory leak caused by an outdated version of Undici.

See https://github.com/elastic/elastic-transport-js/issues/63, fixed by https://github.com/elastic/elastic-transport-js/pull/66.
