### PR TITLE
add position to MappingTimeSeriesMetricType

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -5138,7 +5138,7 @@ export interface MappingTextProperty extends MappingCorePropertyBase {
   type: 'text'
 }
 
-export type MappingTimeSeriesMetricType = 'gauge' | 'counter' | 'summary' | 'histogram'
+export type MappingTimeSeriesMetricType = 'gauge' | 'counter' | 'summary' | 'histogram' | 'position'
 
 export interface MappingTokenCountProperty extends MappingDocValuesPropertyBase {
   analyzer?: string

--- a/src/api/typesWithBodyKey.ts
+++ b/src/api/typesWithBodyKey.ts
@@ -5211,7 +5211,7 @@ export interface MappingTextProperty extends MappingCorePropertyBase {
   type: 'text'
 }
 
-export type MappingTimeSeriesMetricType = 'gauge' | 'counter' | 'summary' | 'histogram'
+export type MappingTimeSeriesMetricType = 'gauge' | 'counter' | 'summary' | 'histogram' | 'position'
 
 export interface MappingTokenCountProperty extends MappingDocValuesPropertyBase {
   analyzer?: string


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/93946 added `position` time series metric. This PR updates `MappingTimeSeriesMetricType` to include `position`.