### PR TITLE
add link to elasticsearch-specification github repository in typescript documentation

### DIFF
--- a/docs/typescript.asciidoc
+++ b/docs/typescript.asciidoc
@@ -6,6 +6,7 @@ of type definitions of Elasticsearch's API surface.
 
 The types are not 100% complete yet. Some APIs are missing (the newest ones, e.g. EQL),
 and others may contain some errors, but we are continuously pushing fixes & improvements.
+Contribute type fixes and improvements to https://github.com/elastic/elasticsearch-specification[elasticsearch-specification github repository].
 
 NOTE: The client is developed against the https://www.npmjs.com/package/typescript?activeTab=versions[latest]
 version of TypeScript. Furthermore, unless you have set `skipLibCheck` to `true`,


### PR DESCRIPTION
Elasticsearch has a lot of repositories on github. It is not obvious where the elasticsearch typescript definitions are defined. This PR updates the elasticsearch-js typescript documentation with a link to  elasticsearch-specification github repository to point users to the correct location for making typescript contributions.