### PR TITLE
Stop running integration tests on PRs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,6 @@ steps:
           - "free"
           - "platinum"
         nodejs:
-          - "14"
           - "16"
           - "18"
           - "20"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -33,6 +33,8 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      provider_settings:
+        build_pull_requests: false
       cancel_intermediate_builds: true
       cancel_intermediate_builds_branch_filter: '!main'
       schedules:
@@ -44,10 +46,4 @@ spec:
           cronline: '0 */12 * * *'
         8_7_daily:
           branch: '8.7'
-          cronline: '@daily'
-        8_6_daily:
-          branch: '8.6'
-          cronline: '@daily'
-        7_17_daily:
-          branch: '7.17'
           cronline: '@daily'


### PR DESCRIPTION
No longer run integration tests on PRs and older branches. Also stops running those tests on Node 14.x.

The team has discussed the value of these, so I'm quieting them down a bit while we decide.
