### PR TITLE
Add test to verify bulk helper index drift fix

### DIFF
--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -1070,6 +1070,7 @@ test('bulk delete', t => {
     const [{ port }, server] = await buildServer(handler)
     const client = new Client({ node: `http://localhost:${port}` })
     let id = 0
+
     const result = await client.helpers.bulk({
       datasource: dataset.slice(),
       flushBytes: 1,
@@ -1090,6 +1091,70 @@ test('bulk delete', t => {
           operation: { delete: { _index: 'test', _id: 1 } },
           document: null,
           retried: false
+        })
+      }
+    })
+
+    t.type(result.time, 'number')
+    t.type(result.bytes, 'number')
+    t.match(result, {
+      total: 3,
+      successful: 2,
+      retry: 0,
+      failed: 1,
+      aborted: false
+    })
+    server.stop()
+  })
+
+  t.test('Should call onDrop on the correct document when doing a mix of operations that includes deletes', async t => {
+    // checks to ensure onDrop doesn't provide the wrong document when some operations are deletes
+    // see https://github.com/elastic/elasticsearch-js/issues/1751
+    async function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({
+        took: 0,
+        errors: true,
+        items: [
+          { delete: { status: 200 } },
+          { index: { status: 429 } },
+          { index: { status: 200 } }
+        ]
+      }))
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const client = new Client({ node: `http://localhost:${port}` })
+    let counter = 0
+    const result = await client.helpers.bulk({
+      datasource: dataset.slice(),
+      concurrency: 1,
+      wait: 10,
+      retries: 0,
+      onDocument (doc) {
+        counter++
+        if (counter === 1) {
+          return {
+            delete: {
+              _index: 'test',
+              _id: String(counter)
+            }
+          }
+        } else {
+          return {
+            index: {
+              _index: 'test',
+            }
+          }
+        }
+      },
+      onDrop (doc) {
+        t.same(doc, {
+          status: 429,
+          error: null,
+          operation: { index: { _index: 'test' } },
+          document: { user: "arya", age: 18 },
+          retried: false,
         })
       }
     })


### PR DESCRIPTION
Thanks again to @karlriis for the fix in https://github.com/elastic/elasticsearch-js/pull/1759. Just adding a test to verify that this does indeed solve the problem. Running the test on commit 5d37ca6489dd9ed70f4ac4ff14bad49f69a5a74a failed in a way described in https://github.com/elastic/elasticsearch-js/issues/1751, and passes on all commits after de17dc050c38bb8dd47c0c0b341e1a273e63559e.
