### PR TITLE
Update changelog.asciidoc

### DIFF
--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -4,7 +4,8 @@
 [discrete]
 === 8.8.1
 
-===== Support for Elasticsearch `v8.8.1`
+[discrete]
+=== Support for Elasticsearch `v8.8.1`
 
 You can find all the API changes
 https://www.elastic.co/guide/en/elasticsearch/reference/8.8/release-notes-8.8.1.html[here].


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-js/pull/1918, but targeting 8.8.