### PR TITLE
fix: types.ts SnapshotGetRequest

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -16739,10 +16739,10 @@ export interface SnapshotGetRequest extends RequestBase {
   index_names?: boolean
   include_repository?: boolean
   sort?: SnapshotSnapshotSort
-  size?: integer
+  size?: number
   order?: SortOrder
   after?: string
-  offset?: integer
+  offset?: number
   from_sort_value?: string
   slm_policy_filter?: Name
 }


### PR DESCRIPTION
Changing the type that is causing error on NestJS build
