### PR TITLE
fix: add types to exports (v7.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "import": "./index.mjs"
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
     },
     "./": "./"
   },


### PR DESCRIPTION
<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->
Hi,

Enabling ESM mode with TypeScript seems to cause this error to appear: `Cannot find module '@elastic/elasticsearch' or its corresponding type declarations.(2307)`

We're not ready yet to upgrade to v8.x which is why I'm patching v7.x, but it seems this error is also present in this version, and I'm not sure how to fix it yet, maybe it's as simple as declaring `"type": "commonjs"` in the package.json?