### PR TITLE
Include body parameters in generated API reference docs

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -39,6 +39,7 @@ client.bulk({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string)*: Default index for items which don't provide one
+** *`operations` (Optional, { index, create, update, delete } | { detect_noop, doc, doc_as_upsert, script, scripted_upsert, _source, upsert } | object[])*
 ** *`pipeline` (Optional, string)*: The pipeline id to preprocess incoming documents with
 ** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
 ** *`routing` (Optional, string)*: Specific routing value
@@ -93,6 +94,7 @@ client.count({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string | string[])*: A list of indices to restrict the results
+** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
 ** *`allow_no_indices` (Optional, boolean)*: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
 ** *`analyzer` (Optional, string)*: The analyzer to use for the query string
 ** *`analyze_wildcard` (Optional, boolean)*: Specify whether wildcard and prefix queries should be analyzed (default: false)
@@ -107,7 +109,6 @@ client.count({ ... })
 ** *`routing` (Optional, string)*: A list of specific routing values
 ** *`terminate_after` (Optional, number)*: The maximum count for each shard, upon reaching which the query execution will terminate early
 ** *`q` (Optional, string)*: Query in the Lucene query string syntax
-** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
 
 [discrete]
 === create
@@ -126,6 +127,7 @@ client.create({ id, index })
 * *Request (object):*
 ** *`id` (string)*: Document ID
 ** *`index` (string)*: The name of the index
+** *`document` (Optional, object)*: A document.
 ** *`pipeline` (Optional, string)*: The pipeline id to preprocess incoming documents with
 ** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
 ** *`routing` (Optional, string)*: Specific routing value
@@ -172,6 +174,9 @@ client.deleteByQuery({ index })
 
 * *Request (object):*
 ** *`index` (string | string[])*: A list of index names to search; use `_all` or empty string to perform the operation on all indices
+** *`max_docs` (Optional, number)*
+** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
+** *`slice` (Optional, { field, id, max })*
 ** *`allow_no_indices` (Optional, boolean)*: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
 ** *`analyzer` (Optional, string)*: The analyzer to use for the query string
 ** *`analyze_wildcard` (Optional, boolean)*: Specify whether wildcard and prefix queries should be analyzed (default: false)
@@ -182,7 +187,6 @@ client.deleteByQuery({ index })
 ** *`from` (Optional, number)*: Starting offset (default: 0)
 ** *`ignore_unavailable` (Optional, boolean)*: Whether specified concrete indices should be ignored when unavailable (missing or closed)
 ** *`lenient` (Optional, boolean)*: Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-** *`max_docs` (Optional, number)*: Maximum number of documents to process (default: all documents)
 ** *`preference` (Optional, string)*: Specify the node or shard the operation should be performed on (default: random)
 ** *`refresh` (Optional, boolean)*: Should the affected indexes be refreshed?
 ** *`request_cache` (Optional, boolean)*: Specify if request cache should be used for this request or not, defaults to index level setting
@@ -201,8 +205,6 @@ client.deleteByQuery({ index })
 ** *`version` (Optional, boolean)*: Specify whether to return document version as part of a hit
 ** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 ** *`wait_for_completion` (Optional, boolean)*: Should the request should block until the delete by query is complete.
-** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
-** *`slice` (Optional, { field, id, max })*
 
 [discrete]
 === delete_by_query_rethrottle
@@ -303,6 +305,7 @@ client.explain({ id, index })
 * *Request (object):*
 ** *`id` (string)*: The document ID
 ** *`index` (string)*: The name of the index
+** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
 ** *`analyzer` (Optional, string)*: The analyzer for the query string query
 ** *`analyze_wildcard` (Optional, boolean)*: Specify whether wildcards and prefix queries in the query string query should be analyzed (default: false)
 ** *`default_operator` (Optional, Enum("and" | "or"))*: The default operator for query string query (AND or OR)
@@ -315,7 +318,6 @@ client.explain({ id, index })
 ** *`_source_includes` (Optional, string | string[])*: A list of fields to extract and return from the _source field
 ** *`stored_fields` (Optional, string | string[])*: A list of stored fields to return in the response
 ** *`q` (Optional, string)*: Query in the Lucene query string syntax
-** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
 
 [discrete]
 === field_caps
@@ -331,18 +333,18 @@ client.fieldCaps({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string | string[])*: List of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.
+** *`fields` (Optional, string | string[])*: List of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.
+** *`index_filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*: Allows to filter indices if the provided query rewrites to match_none on every shard.
+** *`runtime_mappings` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*: Defines ad-hoc runtime fields in the request similar to the way it is done in search requests.
+These fields exist only as part of the query and take precedence over fields defined with the same name in the index mappings.
 ** *`allow_no_indices` (Optional, boolean)*: If false, the request returns an error if any wildcard expression, index alias,
 or `_all` value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request
 targeting `foo*,bar*` returns an error if an index starts with foo but no index starts with bar.
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports a list of values, such as `open,hidden`.
-** *`fields` (Optional, string | string[])*: List of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.
 ** *`ignore_unavailable` (Optional, boolean)*: If `true`, missing or closed indices are not included in the response.
 ** *`include_unmapped` (Optional, boolean)*: If true, unmapped fields are included in the response.
 ** *`filters` (Optional, string)*: An optional set of filters: can include +metadata,-metadata,-nested,-multifield,-parent
 ** *`types` (Optional, string[])*: Only return results for fields that have one of the types in the list
-** *`index_filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*: Allows to filter indices if the provided query rewrites to match_none on every shard.
-** *`runtime_mappings` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*: Defines ad-hoc runtime fields in the request similar to the way it is done in search requests.
-These fields exist only as part of the query and take precedence over fields defined with the same name in the index mappings.
 
 [discrete]
 === get
@@ -465,6 +467,7 @@ client.index({ index })
 * *Request (object):*
 ** *`index` (string)*: The name of the index
 ** *`id` (Optional, string)*: Document ID
+** *`document` (Optional, object)*: A document.
 ** *`if_primary_term` (Optional, number)*: only perform the index operation if the last operation that has changed the document has the specified primary term
 ** *`if_seq_no` (Optional, number)*: only perform the index operation if the last operation that has changed the document has the specified sequence number
 ** *`op_type` (Optional, Enum("index" | "create"))*: Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID
@@ -503,7 +506,6 @@ client.knnSearch({ index, knn })
 ** *`index` (string | string[])*: A list of index names to search;
 use `_all` or to perform the operation on all indices
 ** *`knn` ({ field, query_vector, k, num_candidates })*: kNN query to execute
-** *`routing` (Optional, string)*: A list of specific routing values
 ** *`_source` (Optional, boolean | { excludes, includes })*: Indicates which source fields are returned for matching documents. These
 fields are returned in the hits._source property of the search response.
 ** *`docvalue_fields` (Optional, { field, format, include_unmapped }[])*: The request returns doc values for field names matching these patterns
@@ -517,6 +519,7 @@ in the hits.fields property of the response. Accepts wildcard (*) patterns.
 ** *`filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type } | { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type }[])*: Query to filter the documents that can match. The kNN search will return the top
 `k` documents that also match this filter. The value can be a single query or a
 list of queries. If `filter` isn't provided, all documents are allowed to match.
+** *`routing` (Optional, string)*: A list of specific routing values
 
 [discrete]
 === mget
@@ -532,6 +535,8 @@ client.mget({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string)*: Name of the index to retrieve documents from when `ids` are specified, or when a document in the `docs` array does not specify an index.
+** *`docs` (Optional, { _id, _index, routing, _source, stored_fields, version, version_type }[])*: The documents you want to retrieve. Required if no index is specified in the request URI.
+** *`ids` (Optional, string | string[])*: The IDs of the documents you want to retrieve. Allowed when the index is specified in the request URI.
 ** *`preference` (Optional, string)*: Specifies the node or shard the operation should be performed on. Random by default.
 ** *`realtime` (Optional, boolean)*: If `true`, the request is real-time as opposed to near-real-time.
 ** *`refresh` (Optional, boolean)*: If `true`, the request refreshes relevant shards before retrieving documents.
@@ -543,8 +548,6 @@ You can also use this parameter to exclude fields from the subset specified in `
 If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `_source_excludes` query parameter.
 If the `_source` parameter is `false`, this parameter is ignored.
 ** *`stored_fields` (Optional, string | string[])*: If `true`, retrieves the document fields stored in the index rather than the document `_source`.
-** *`docs` (Optional, { _id, _index, routing, _source, stored_fields, version, version_type }[])*: The documents you want to retrieve. Required if no index is specified in the request URI.
-** *`ids` (Optional, string | string[])*: The IDs of the documents you want to retrieve. Allowed when the index is specified in the request URI.
 
 [discrete]
 === msearch
@@ -560,6 +563,7 @@ client.msearch({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string | string[])*: List of data streams, indices, and index aliases to search.
+** *`searches` (Optional, { allow_no_indices, expand_wildcards, ignore_unavailable, index, preference, request_cache, routing, search_type, ccs_minimize_roundtrips, allow_partial_search_results, ignore_throttled } | { aggregations, collapse, query, explain, ext, stored_fields, docvalue_fields, knn, from, highlight, indices_boost, min_score, post_filter, profile, rescore, script_fields, search_after, size, sort, _source, fields, terminate_after, stats, timeout, track_scores, track_total_hits, version, runtime_mappings, seq_no_primary_term, pit, suggest }[])*
 ** *`allow_no_indices` (Optional, boolean)*: If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.
 ** *`ccs_minimize_roundtrips` (Optional, boolean)*: If true, network roundtrips between the coordinating node and remote clusters are minimized for cross-cluster search requests.
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Type of index that wildcard expressions can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
@@ -587,6 +591,7 @@ client.msearchTemplate({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string | string[])*: A list of index names to use as default
+** *`search_templates` (Optional, { allow_no_indices, expand_wildcards, ignore_unavailable, index, preference, request_cache, routing, search_type, ccs_minimize_roundtrips, allow_partial_search_results, ignore_throttled } | { aggregations, collapse, query, explain, ext, stored_fields, docvalue_fields, knn, from, highlight, indices_boost, min_score, post_filter, profile, rescore, script_fields, search_after, size, sort, _source, fields, terminate_after, stats, timeout, track_scores, track_total_hits, version, runtime_mappings, seq_no_primary_term, pit, suggest }[])*
 ** *`ccs_minimize_roundtrips` (Optional, boolean)*: Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
 ** *`max_concurrent_searches` (Optional, number)*: Controls the maximum number of concurrent searches the multi search api will execute
 ** *`search_type` (Optional, Enum("query_then_fetch" | "dfs_query_then_fetch"))*: Search operation type
@@ -607,7 +612,8 @@ client.mtermvectors({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string)*: The index in which the document resides.
-** *`ids` (Optional, string[])*: A list of documents ids. You must define ids as parameter or set "ids" or "docs" in the request body
+** *`docs` (Optional, { _id, _index, routing, _source, stored_fields, version, version_type }[])*
+** *`ids` (Optional, string[])*
 ** *`fields` (Optional, string | string[])*: A list of fields to return. Applies to all returned documents unless otherwise specified in body "params" or "docs".
 ** *`field_statistics` (Optional, boolean)*: Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
 ** *`offsets` (Optional, boolean)*: Specifies if term offsets should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
@@ -619,7 +625,6 @@ client.mtermvectors({ ... })
 ** *`term_statistics` (Optional, boolean)*: Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body "params" or "docs".
 ** *`version` (Optional, number)*: Explicit version number for concurrency control
 ** *`version_type` (Optional, Enum("internal" | "external" | "external_gte" | "force"))*: Specific version type
-** *`docs` (Optional, { _id, _index, routing, _source, stored_fields, version, version_type }[])*
 
 [discrete]
 === open_point_in_time
@@ -686,11 +691,11 @@ client.rankEval({ requests })
 ** *`requests` ({ id, request, ratings, template_id, params }[])*: A set of typical search requests, together with their provided ratings.
 ** *`index` (Optional, string | string[])*: List of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.
 To target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.
+** *`metric` (Optional, { precision, recall, mean_reciprocal_rank, dcg, expected_reciprocal_rank })*: Definition of the evaluation metric to calculate.
 ** *`allow_no_indices` (Optional, boolean)*: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Whether to expand wildcard expression to concrete indices that are open, closed or both.
 ** *`ignore_unavailable` (Optional, boolean)*: If `true`, missing or closed indices are not included in the response.
 ** *`search_type` (Optional, string)*: Search operation type
-** *`metric` (Optional, { precision, recall, mean_reciprocal_rank, dcg, expected_reciprocal_rank })*: Definition of the evaluation metric to calculate.
 
 [discrete]
 === reindex
@@ -709,6 +714,10 @@ client.reindex({ dest, source })
 * *Request (object):*
 ** *`dest` ({ index, op_type, pipeline, routing, version_type })*
 ** *`source` ({ index, query, remote, size, slice, sort, _source, runtime_mappings })*
+** *`conflicts` (Optional, Enum("abort" | "proceed"))*
+** *`max_docs` (Optional, number)*
+** *`script` (Optional, { lang, options, source } | { id })*
+** *`size` (Optional, number)*
 ** *`refresh` (Optional, boolean)*: Should the affected indexes be refreshed?
 ** *`requests_per_second` (Optional, float)*: The throttle to set on this request in sub-requests per second. -1 means no throttle.
 ** *`scroll` (Optional, string | -1 | 0)*: Control how long to keep the search context alive
@@ -717,10 +726,6 @@ client.reindex({ dest, source })
 ** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Sets the number of shard copies that must be active before proceeding with the reindex operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 ** *`wait_for_completion` (Optional, boolean)*: Should the request should block until the reindex is complete.
 ** *`require_alias` (Optional, boolean)*
-** *`conflicts` (Optional, Enum("abort" | "proceed"))*
-** *`max_docs` (Optional, number)*
-** *`script` (Optional, { lang, options, source } | { id })*
-** *`size` (Optional, number)*
 
 [discrete]
 === reindex_rethrottle
@@ -804,6 +809,62 @@ client.search({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string | string[])*: A list of index names to search; use `_all` or empty string to perform the operation on all indices
+** *`aggregations` (Optional, Record<string, { aggregations, meta, adjacency_matrix, auto_date_histogram, avg, avg_bucket, boxplot, bucket_script, bucket_selector, bucket_sort, bucket_count_ks_test, bucket_correlation, cardinality, categorize_text, children, composite, cumulative_cardinality, cumulative_sum, date_histogram, date_range, derivative, diversified_sampler, extended_stats, extended_stats_bucket, frequent_item_sets, filter, filters, geo_bounds, geo_centroid, geo_distance, geohash_grid, geo_line, geotile_grid, geohex_grid, global, histogram, ip_range, ip_prefix, inference, line, matrix_stats, max, max_bucket, median_absolute_deviation, min, min_bucket, missing, moving_avg, moving_percentiles, moving_fn, multi_terms, nested, normalize, parent, percentile_ranks, percentiles, percentiles_bucket, range, rare_terms, rate, reverse_nested, sampler, scripted_metric, serial_diff, significant_terms, significant_text, stats, stats_bucket, string_stats, sum, sum_bucket, terms, top_hits, t_test, top_metrics, value_count, weighted_avg, variable_width_histogram }>)*
+** *`collapse` (Optional, { field, inner_hits, max_concurrent_group_searches, collapse })*
+** *`explain` (Optional, boolean)*: If true, returns detailed information about score computation as part of a hit.
+** *`ext` (Optional, Record<string, User-defined value>)*: Configuration of search extensions defined by Elasticsearch plugins.
+** *`from` (Optional, number)*: Starting document offset. By default, you cannot page through more than 10,000
+hits using the from and size parameters. To page through more hits, use the
+search_after parameter.
+** *`highlight` (Optional, { encoder, fields })*
+** *`track_total_hits` (Optional, boolean | number)*: Number of hits matching the query to count accurately. If true, the exact
+number of hits is returned at the cost of some performance. If false, the
+response does not include the total number of hits matching the query.
+Defaults to 10,000 hits.
+** *`indices_boost` (Optional, Record<string, number>[])*: Boosts the _score of documents from specified indices.
+** *`docvalue_fields` (Optional, { field, format, include_unmapped }[])*: Array of wildcard (*) patterns. The request returns doc values for field
+names matching these patterns in the hits.fields property of the response.
+** *`knn` (Optional, { field, query_vector, query_vector_builder, k, num_candidates, boost, filter } | { field, query_vector, query_vector_builder, k, num_candidates, boost, filter }[])*: Defines the approximate kNN search to run.
+** *`rank` (Optional, { rrf })*: Defines the Reciprocal Rank Fusion (RRF) to use
+** *`min_score` (Optional, number)*: Minimum _score for matching documents. Documents with a lower _score are
+not included in the search results.
+** *`post_filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
+** *`profile` (Optional, boolean)*
+** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*: Defines the search definition using the Query DSL.
+** *`rescore` (Optional, { query, window_size } | { query, window_size }[])*
+** *`script_fields` (Optional, Record<string, { script, ignore_failure }>)*: Retrieve a script evaluation (based on different fields) for each hit.
+** *`search_after` (Optional, number | number | string | boolean | null | User-defined value[])*
+** *`size` (Optional, number)*: The number of hits to return. By default, you cannot page through more
+than 10,000 hits using the from and size parameters. To page through more
+hits, use the search_after parameter.
+** *`slice` (Optional, { field, id, max })*
+** *`sort` (Optional, string | { _score, _doc, _geo_distance, _script } | string | { _score, _doc, _geo_distance, _script }[])*
+** *`_source` (Optional, boolean | { excludes, includes })*: Indicates which source fields are returned for matching documents. These
+fields are returned in the hits._source property of the search response.
+** *`fields` (Optional, { field, format, include_unmapped }[])*: Array of wildcard (*) patterns. The request returns values for field names
+matching these patterns in the hits.fields property of the response.
+** *`suggest` (Optional, { text })*
+** *`terminate_after` (Optional, number)*: Maximum number of documents to collect for each shard. If a query reaches this
+limit, Elasticsearch terminates the query early. Elasticsearch collects documents
+before sorting. Defaults to 0, which does not terminate query execution early.
+** *`timeout` (Optional, string)*: Specifies the period of time to wait for a response from each shard. If no response
+is received before the timeout expires, the request fails and returns an error.
+Defaults to no timeout.
+** *`track_scores` (Optional, boolean)*: If true, calculate and return document scores, even if the scores are not used for sorting.
+** *`version` (Optional, boolean)*: If true, returns document version as part of a hit.
+** *`seq_no_primary_term` (Optional, boolean)*: If true, returns sequence number and primary term of the last modification
+of each hit. See Optimistic concurrency control.
+** *`stored_fields` (Optional, string | string[])*: List of stored fields to return as part of a hit. If no fields are specified,
+no stored fields are included in the response. If this field is specified, the _source
+parameter defaults to false. You can pass _source: true to return both source fields
+and stored fields in the search response.
+** *`pit` (Optional, { id, keep_alive })*: Limits the search to a point in time (PIT). If you provide a PIT, you
+cannot specify an <index> in the request path.
+** *`runtime_mappings` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*: Defines one or more runtime fields in the search request. These fields take
+precedence over mapped fields with the same name.
+** *`stats` (Optional, string[])*: Stats groups to associate with the search. Each group maintains a statistics
+aggregation for its associated searches. You can retrieve these stats using
+the indices stats API.
 ** *`allow_no_indices` (Optional, boolean)*: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
 ** *`allow_partial_search_results` (Optional, boolean)*: Indicate if an error should be returned if there is a partial search failure or timeout
 ** *`analyzer` (Optional, string)*: The analyzer to use for the query string
@@ -812,9 +873,7 @@ client.search({ ... })
 ** *`ccs_minimize_roundtrips` (Optional, boolean)*: Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
 ** *`default_operator` (Optional, Enum("and" | "or"))*: The default operator for query string query (AND or OR)
 ** *`df` (Optional, string)*: The field to use as default where no field prefix is given in the query string
-** *`docvalue_fields` (Optional, string | string[])*: A list of fields to return as the docvalue representation of a field for each hit
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Whether to expand wildcard expression to concrete indices that are open, closed or both.
-** *`explain` (Optional, boolean)*: Specify whether to return detailed information about score computation as part of a hit
 ** *`ignore_throttled` (Optional, boolean)*: Whether specified concrete, expanded or aliased indices should be ignored when throttled
 ** *`ignore_unavailable` (Optional, boolean)*: Whether specified concrete indices should be ignored when unavailable (missing or closed)
 ** *`lenient` (Optional, boolean)*: Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
@@ -826,50 +885,15 @@ client.search({ ... })
 ** *`routing` (Optional, string)*: A list of specific routing values
 ** *`scroll` (Optional, string | -1 | 0)*: Specify how long a consistent view of the index should be maintained for scrolled search
 ** *`search_type` (Optional, Enum("query_then_fetch" | "dfs_query_then_fetch"))*: Search operation type
-** *`stats` (Optional, string[])*: Specific 'tag' of the request for logging and statistical purposes
-** *`stored_fields` (Optional, string | string[])*: A list of stored fields to return as part of a hit
 ** *`suggest_field` (Optional, string)*: Specifies which field to use for suggestions.
 ** *`suggest_mode` (Optional, Enum("missing" | "popular" | "always"))*: Specify suggest mode
 ** *`suggest_size` (Optional, number)*: How many suggestions to return in response
 ** *`suggest_text` (Optional, string)*: The source text for which the suggestions should be returned.
-** *`terminate_after` (Optional, number)*: The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
-** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
-** *`track_total_hits` (Optional, boolean | number)*: Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number.
-** *`track_scores` (Optional, boolean)*: Whether to calculate and return scores even if they are not used for sorting
 ** *`typed_keys` (Optional, boolean)*: Specify whether aggregation and suggester names should be prefixed by their respective types in the response
 ** *`rest_total_hits_as_int` (Optional, boolean)*: Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-** *`version` (Optional, boolean)*: Specify whether to return document version as part of a hit
-** *`_source` (Optional, boolean | string | string[])*: True or false to return the _source field or not, or a list of fields to return
 ** *`_source_excludes` (Optional, string | string[])*: A list of fields to exclude from the returned _source field
 ** *`_source_includes` (Optional, string | string[])*: A list of fields to extract and return from the _source field
-** *`seq_no_primary_term` (Optional, boolean)*: Specify whether to return sequence number and primary term of the last modification of each hit
 ** *`q` (Optional, string)*: Query in the Lucene query string syntax
-** *`size` (Optional, number)*: Number of hits to return (default: 10)
-** *`from` (Optional, number)*: Starting offset (default: 0)
-** *`sort` (Optional, string | string[])*: A list of <field>:<direction> pairs
-** *`aggregations` (Optional, Record<string, { aggregations, meta, adjacency_matrix, auto_date_histogram, avg, avg_bucket, boxplot, bucket_script, bucket_selector, bucket_sort, bucket_count_ks_test, bucket_correlation, cardinality, categorize_text, children, composite, cumulative_cardinality, cumulative_sum, date_histogram, date_range, derivative, diversified_sampler, extended_stats, extended_stats_bucket, frequent_item_sets, filter, filters, geo_bounds, geo_centroid, geo_distance, geohash_grid, geo_line, geotile_grid, geohex_grid, global, histogram, ip_range, ip_prefix, inference, line, matrix_stats, max, max_bucket, median_absolute_deviation, min, min_bucket, missing, moving_avg, moving_percentiles, moving_fn, multi_terms, nested, normalize, parent, percentile_ranks, percentiles, percentiles_bucket, range, rare_terms, rate, reverse_nested, sampler, scripted_metric, serial_diff, significant_terms, significant_text, stats, stats_bucket, string_stats, sum, sum_bucket, terms, top_hits, t_test, top_metrics, value_count, weighted_avg, variable_width_histogram }>)*
-** *`collapse` (Optional, { field, inner_hits, max_concurrent_group_searches, collapse })*
-** *`ext` (Optional, Record<string, User-defined value>)*: Configuration of search extensions defined by Elasticsearch plugins.
-** *`highlight` (Optional, { encoder, fields })*
-** *`indices_boost` (Optional, Record<string, number>[])*: Boosts the _score of documents from specified indices.
-** *`knn` (Optional, { field, query_vector, query_vector_builder, k, num_candidates, boost, filter } | { field, query_vector, query_vector_builder, k, num_candidates, boost, filter }[])*: Defines the approximate kNN search to run.
-** *`rank` (Optional, { rrf })*: Defines the Reciprocal Rank Fusion (RRF) to use
-** *`min_score` (Optional, number)*: Minimum _score for matching documents. Documents with a lower _score are
-not included in the search results.
-** *`post_filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
-** *`profile` (Optional, boolean)*
-** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*: Defines the search definition using the Query DSL.
-** *`rescore` (Optional, { query, window_size } | { query, window_size }[])*
-** *`script_fields` (Optional, Record<string, { script, ignore_failure }>)*: Retrieve a script evaluation (based on different fields) for each hit.
-** *`search_after` (Optional, number | number | string | boolean | null | User-defined value[])*
-** *`slice` (Optional, { field, id, max })*
-** *`fields` (Optional, { field, format, include_unmapped }[])*: Array of wildcard (*) patterns. The request returns values for field names
-matching these patterns in the hits.fields property of the response.
-** *`suggest` (Optional, { text })*
-** *`pit` (Optional, { id, keep_alive })*: Limits the search to a point in time (PIT). If you provide a PIT, you
-cannot specify an <index> in the request path.
-** *`runtime_mappings` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*: Defines one or more runtime fields in the search request. These fields take
-precedence over mapped fields with the same name.
 
 [discrete]
 === search_mvt
@@ -889,24 +913,6 @@ client.searchMvt({ index, field, zoom, x, y })
 ** *`zoom` (number)*: Zoom level for the vector tile to search
 ** *`x` (number)*: X coordinate for the vector tile to search
 ** *`y` (number)*: Y coordinate for the vector tile to search
-** *`exact_bounds` (Optional, boolean)*: If false, the meta layer’s feature is the bounding box of the tile.
-If true, the meta layer’s feature is a bounding box resulting from a
-geo_bounds aggregation. The aggregation runs on <field> values that intersect
-the <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting
-bounding box may be larger than the vector tile.
-** *`extent` (Optional, number)*: Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.
-** *`grid_agg` (Optional, Enum("geotile" | "geohex"))*: Aggregation used to create a grid for `field`.
-** *`grid_precision` (Optional, number)*: Additional zoom levels available through the aggs layer. For example, if <zoom> is 7
-and grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results
-don’t include the aggs layer.
-** *`grid_type` (Optional, Enum("grid" | "point" | "centroid"))*: Determines the geometry type for features in the aggs layer. In the aggs layer,
-each feature represents a geotile_grid cell. If 'grid' each feature is a Polygon
-of the cells bounding box. If 'point' each feature is a Point that is the centroid
-of the cell.
-** *`size` (Optional, number)*: Maximum number of features to return in the hits layer. Accepts 0-10000.
-If 0, results don’t include the hits layer.
-** *`with_labels` (Optional, boolean)*: If `true`, the hits and aggs layers will contain additional point features representing
-suggested label positions for the original features.
 ** *`aggs` (Optional, Record<string, { aggregations, meta, adjacency_matrix, auto_date_histogram, avg, avg_bucket, boxplot, bucket_script, bucket_selector, bucket_sort, bucket_count_ks_test, bucket_correlation, cardinality, categorize_text, children, composite, cumulative_cardinality, cumulative_sum, date_histogram, date_range, derivative, diversified_sampler, extended_stats, extended_stats_bucket, frequent_item_sets, filter, filters, geo_bounds, geo_centroid, geo_distance, geohash_grid, geo_line, geotile_grid, geohex_grid, global, histogram, ip_range, ip_prefix, inference, line, matrix_stats, max, max_bucket, median_absolute_deviation, min, min_bucket, missing, moving_avg, moving_percentiles, moving_fn, multi_terms, nested, normalize, parent, percentile_ranks, percentiles, percentiles_bucket, range, rare_terms, rate, reverse_nested, sampler, scripted_metric, serial_diff, significant_terms, significant_text, stats, stats_bucket, string_stats, sum, sum_bucket, terms, top_hits, t_test, top_metrics, value_count, weighted_avg, variable_width_histogram }>)*: Sub-aggregations for the geotile_grid.
 
 Supports the following aggregation types:
@@ -917,18 +923,36 @@ Supports the following aggregation types:
 - sum
 ** *`buffer` (Optional, number)*: Size, in pixels, of a clipping buffer outside the tile. This allows renderers
 to avoid outline artifacts from geometries that extend past the extent of the tile.
+** *`exact_bounds` (Optional, boolean)*: If false, the meta layer’s feature is the bounding box of the tile.
+If true, the meta layer’s feature is a bounding box resulting from a
+geo_bounds aggregation. The aggregation runs on <field> values that intersect
+the <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting
+bounding box may be larger than the vector tile.
+** *`extent` (Optional, number)*: Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.
 ** *`fields` (Optional, string | string[])*: Fields to return in the `hits` layer. Supports wildcards (`*`).
 This parameter does not support fields with array values. Fields with array
 values may return inconsistent results.
+** *`grid_agg` (Optional, Enum("geotile" | "geohex"))*: Aggregation used to create a grid for the `field`.
+** *`grid_precision` (Optional, number)*: Additional zoom levels available through the aggs layer. For example, if <zoom> is 7
+and grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results
+don’t include the aggs layer.
+** *`grid_type` (Optional, Enum("grid" | "point" | "centroid"))*: Determines the geometry type for features in the aggs layer. In the aggs layer,
+each feature represents a geotile_grid cell. If 'grid' each feature is a Polygon
+of the cells bounding box. If 'point' each feature is a Point that is the centroid
+of the cell.
 ** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*: Query DSL used to filter documents for the search.
 ** *`runtime_mappings` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*: Defines one or more runtime fields in the search request. These fields take
 precedence over mapped fields with the same name.
+** *`size` (Optional, number)*: Maximum number of features to return in the hits layer. Accepts 0-10000.
+If 0, results don’t include the hits layer.
 ** *`sort` (Optional, string | { _score, _doc, _geo_distance, _script } | string | { _score, _doc, _geo_distance, _script }[])*: Sorts features in the hits layer. By default, the API calculates a bounding
 box for each feature. It sorts features based on this box’s diagonal length,
 from longest to shortest.
 ** *`track_total_hits` (Optional, boolean | number)*: Number of hits matching the query to count accurately. If `true`, the exact number
 of hits is returned at the cost of some performance. If `false`, the response does
 not include the total number of hits matching the query.
+** *`with_labels` (Optional, boolean)*: If `true`, the hits and aggs layers will contain additional point features representing
+suggested label positions for the original features.
 
 [discrete]
 === search_shards
@@ -966,26 +990,26 @@ client.searchTemplate({ ... })
 * *Request (object):*
 ** *`index` (Optional, string | string[])*: List of data streams, indices,
 and aliases to search. Supports wildcards (*).
+** *`explain` (Optional, boolean)*
+** *`id` (Optional, string)*: ID of the search template to use. If no source is specified,
+this parameter is required.
+** *`params` (Optional, Record<string, User-defined value>)*
+** *`profile` (Optional, boolean)*
+** *`source` (Optional, string)*: An inline search template. Supports the same parameters as the search API's
+request body. Also supports Mustache variables. If no id is specified, this
+parameter is required.
 ** *`allow_no_indices` (Optional, boolean)*: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
 ** *`ccs_minimize_roundtrips` (Optional, boolean)*: Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Whether to expand wildcard expression to concrete indices that are open, closed or both.
-** *`explain` (Optional, boolean)*: Specify whether to return detailed information about score computation as part of a hit
 ** *`ignore_throttled` (Optional, boolean)*: Whether specified concrete, expanded or aliased indices should be ignored when throttled
 ** *`ignore_unavailable` (Optional, boolean)*: Whether specified concrete indices should be ignored when unavailable (missing or closed)
 ** *`preference` (Optional, string)*: Specify the node or shard the operation should be performed on (default: random)
-** *`profile` (Optional, boolean)*: Specify whether to profile the query execution
 ** *`routing` (Optional, string)*: Custom value used to route operations to a specific shard.
 ** *`scroll` (Optional, string | -1 | 0)*: Specifies how long a consistent view of the index
 should be maintained for scrolled search.
 ** *`search_type` (Optional, Enum("query_then_fetch" | "dfs_query_then_fetch"))*: The type of the search operation.
 ** *`rest_total_hits_as_int` (Optional, boolean)*: If true, hits.total are rendered as an integer in the response.
 ** *`typed_keys` (Optional, boolean)*: Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-** *`id` (Optional, string)*: ID of the search template to use. If no source is specified,
-this parameter is required.
-** *`params` (Optional, Record<string, User-defined value>)*
-** *`source` (Optional, string)*: An inline search template. Supports the same parameters as the search API's
-request body. Also supports Mustache variables. If no id is specified, this
-parameter is required.
 
 [discrete]
 === terms_enum
@@ -1024,6 +1048,9 @@ client.termvectors({ index })
 * *Request (object):*
 ** *`index` (string)*: The index in which the document resides.
 ** *`id` (Optional, string)*: The id of the document, when not specified a doc param should be supplied.
+** *`doc` (Optional, object)*: A document.
+** *`filter` (Optional, { max_doc_freq, max_num_terms, max_term_freq, max_word_length, min_doc_freq, min_term_freq, min_word_length })*
+** *`per_field_analyzer` (Optional, Record<string, string>)*
 ** *`fields` (Optional, string | string[])*: A list of fields to return.
 ** *`field_statistics` (Optional, boolean)*: Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.
 ** *`offsets` (Optional, boolean)*: Specifies if term offsets should be returned.
@@ -1035,9 +1062,6 @@ client.termvectors({ index })
 ** *`term_statistics` (Optional, boolean)*: Specifies if total term frequency and document frequency should be returned.
 ** *`version` (Optional, number)*: Explicit version number for concurrency control
 ** *`version_type` (Optional, Enum("internal" | "external" | "external_gte" | "force"))*: Specific version type
-** *`doc` (Optional, document object)*
-** *`filter` (Optional, { max_doc_freq, max_num_terms, max_term_freq, max_word_length, min_doc_freq, min_term_freq, min_word_length })*
-** *`per_field_analyzer` (Optional, Record<string, string>)*
 
 [discrete]
 === update
@@ -1054,6 +1078,16 @@ client.update({ id, index })
 * *Request (object):*
 ** *`id` (string)*: Document ID
 ** *`index` (string)*: The name of the index
+** *`detect_noop` (Optional, boolean)*: Set to false to disable setting 'result' in the response
+to 'noop' if no change to the document occurred.
+** *`doc` (Optional, object)*: A partial update to an existing document.
+** *`doc_as_upsert` (Optional, boolean)*: Set to true to use the contents of 'doc' as the value of 'upsert'
+** *`script` (Optional, { lang, options, source } | { id })*: Script to execute to update the document.
+** *`scripted_upsert` (Optional, boolean)*: Set to true to execute the script whether or not the document exists.
+** *`_source` (Optional, boolean | { excludes, includes })*: Set to false to disable source retrieval. You can also specify a comma-separated
+list of the fields you want to retrieve.
+** *`upsert` (Optional, object)*: If the document does not already exist, the contents of 'upsert' are inserted as a
+new document. If the document exists, the 'script' is executed.
 ** *`if_primary_term` (Optional, number)*: Only perform the operation if the document has this primary term.
 ** *`if_seq_no` (Optional, number)*: Only perform the operation if the document has this sequence number.
 ** *`lang` (Optional, string)*: The script language.
@@ -1069,18 +1103,8 @@ The actual wait time could be longer, particularly when multiple waits occur.
 ** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: The number of shard copies that must be active before proceeding with the operations.
 Set to 'all' or any positive integer up to the total number of shards in the index
 (number_of_replicas+1). Defaults to 1 meaning the primary shard.
-** *`_source` (Optional, boolean | string | string[])*: Set to false to disable source retrieval. You can also specify a comma-separated
-list of the fields you want to retrieve.
 ** *`_source_excludes` (Optional, string | string[])*: Specify the source fields you want to exclude.
 ** *`_source_includes` (Optional, string | string[])*: Specify the source fields you want to retrieve.
-** *`detect_noop` (Optional, boolean)*: Set to false to disable setting 'result' in the response
-to 'noop' if no change to the document occurred.
-** *`doc` (Optional, partial document object)*: A partial update to an existing document.
-** *`doc_as_upsert` (Optional, boolean)*: Set to true to use the contents of 'doc' as the value of 'upsert'
-** *`script` (Optional, { lang, options, source } | { id })*: Script to execute to update the document.
-** *`scripted_upsert` (Optional, boolean)*: Set to true to execute the script whether or not the document exists.
-** *`upsert` (Optional, document object)*: If the document does not already exist, the contents of 'upsert' are inserted as a
-new document. If the document exists, the 'script' is executed.
 
 [discrete]
 === update_by_query
@@ -1097,17 +1121,20 @@ client.updateByQuery({ index })
 
 * *Request (object):*
 ** *`index` (string | string[])*: A list of index names to search; use `_all` or empty string to perform the operation on all indices
+** *`max_docs` (Optional, number)*
+** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
+** *`script` (Optional, { lang, options, source } | { id })*
+** *`slice` (Optional, { field, id, max })*
+** *`conflicts` (Optional, Enum("abort" | "proceed"))*
 ** *`allow_no_indices` (Optional, boolean)*: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
 ** *`analyzer` (Optional, string)*: The analyzer to use for the query string
 ** *`analyze_wildcard` (Optional, boolean)*: Specify whether wildcard and prefix queries should be analyzed (default: false)
-** *`conflicts` (Optional, Enum("abort" | "proceed"))*: What to do when the update by query hits version conflicts?
 ** *`default_operator` (Optional, Enum("and" | "or"))*: The default operator for query string query (AND or OR)
 ** *`df` (Optional, string)*: The field to use as default where no field prefix is given in the query string
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Whether to expand wildcard expression to concrete indices that are open, closed or both.
 ** *`from` (Optional, number)*: Starting offset (default: 0)
 ** *`ignore_unavailable` (Optional, boolean)*: Whether specified concrete indices should be ignored when unavailable (missing or closed)
 ** *`lenient` (Optional, boolean)*: Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-** *`max_docs` (Optional, number)*: Maximum number of documents to process (default: all documents)
 ** *`pipeline` (Optional, string)*: Ingest pipeline to set on index requests made by this action. (default: none)
 ** *`preference` (Optional, string)*: Specify the node or shard the operation should be performed on (default: random)
 ** *`refresh` (Optional, boolean)*: Should the affected indexes be refreshed?
@@ -1127,9 +1154,6 @@ client.updateByQuery({ index })
 ** *`version_type` (Optional, boolean)*: Should the document increment the version number (internal) on hit or not (reindex)
 ** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 ** *`wait_for_completion` (Optional, boolean)*: Should the request should block until the update by query operation is complete.
-** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
-** *`script` (Optional, { lang, options, source } | { id })*
-** *`slice` (Optional, { field, id, max })*
 
 [discrete]
 === update_by_query_rethrottle
@@ -1221,6 +1245,61 @@ client.asyncSearch.submit({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string | string[])*: A list of index names to search; use `_all` or empty string to perform the operation on all indices
+** *`aggregations` (Optional, Record<string, { aggregations, meta, adjacency_matrix, auto_date_histogram, avg, avg_bucket, boxplot, bucket_script, bucket_selector, bucket_sort, bucket_count_ks_test, bucket_correlation, cardinality, categorize_text, children, composite, cumulative_cardinality, cumulative_sum, date_histogram, date_range, derivative, diversified_sampler, extended_stats, extended_stats_bucket, frequent_item_sets, filter, filters, geo_bounds, geo_centroid, geo_distance, geohash_grid, geo_line, geotile_grid, geohex_grid, global, histogram, ip_range, ip_prefix, inference, line, matrix_stats, max, max_bucket, median_absolute_deviation, min, min_bucket, missing, moving_avg, moving_percentiles, moving_fn, multi_terms, nested, normalize, parent, percentile_ranks, percentiles, percentiles_bucket, range, rare_terms, rate, reverse_nested, sampler, scripted_metric, serial_diff, significant_terms, significant_text, stats, stats_bucket, string_stats, sum, sum_bucket, terms, top_hits, t_test, top_metrics, value_count, weighted_avg, variable_width_histogram }>)*
+** *`collapse` (Optional, { field, inner_hits, max_concurrent_group_searches, collapse })*
+** *`explain` (Optional, boolean)*: If true, returns detailed information about score computation as part of a hit.
+** *`ext` (Optional, Record<string, User-defined value>)*: Configuration of search extensions defined by Elasticsearch plugins.
+** *`from` (Optional, number)*: Starting document offset. By default, you cannot page through more than 10,000
+hits using the from and size parameters. To page through more hits, use the
+search_after parameter.
+** *`highlight` (Optional, { encoder, fields })*
+** *`track_total_hits` (Optional, boolean | number)*: Number of hits matching the query to count accurately. If true, the exact
+number of hits is returned at the cost of some performance. If false, the
+response does not include the total number of hits matching the query.
+Defaults to 10,000 hits.
+** *`indices_boost` (Optional, Record<string, number>[])*: Boosts the _score of documents from specified indices.
+** *`docvalue_fields` (Optional, { field, format, include_unmapped }[])*: Array of wildcard (*) patterns. The request returns doc values for field
+names matching these patterns in the hits.fields property of the response.
+** *`knn` (Optional, { field, query_vector, query_vector_builder, k, num_candidates, boost, filter } | { field, query_vector, query_vector_builder, k, num_candidates, boost, filter }[])*: Defines the approximate kNN search to run.
+** *`min_score` (Optional, number)*: Minimum _score for matching documents. Documents with a lower _score are
+not included in the search results.
+** *`post_filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
+** *`profile` (Optional, boolean)*
+** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*: Defines the search definition using the Query DSL.
+** *`rescore` (Optional, { query, window_size } | { query, window_size }[])*
+** *`script_fields` (Optional, Record<string, { script, ignore_failure }>)*: Retrieve a script evaluation (based on different fields) for each hit.
+** *`search_after` (Optional, number | number | string | boolean | null | User-defined value[])*
+** *`size` (Optional, number)*: The number of hits to return. By default, you cannot page through more
+than 10,000 hits using the from and size parameters. To page through more
+hits, use the search_after parameter.
+** *`slice` (Optional, { field, id, max })*
+** *`sort` (Optional, string | { _score, _doc, _geo_distance, _script } | string | { _score, _doc, _geo_distance, _script }[])*
+** *`_source` (Optional, boolean | { excludes, includes })*: Indicates which source fields are returned for matching documents. These
+fields are returned in the hits._source property of the search response.
+** *`fields` (Optional, { field, format, include_unmapped }[])*: Array of wildcard (*) patterns. The request returns values for field names
+matching these patterns in the hits.fields property of the response.
+** *`suggest` (Optional, { text })*
+** *`terminate_after` (Optional, number)*: Maximum number of documents to collect for each shard. If a query reaches this
+limit, Elasticsearch terminates the query early. Elasticsearch collects documents
+before sorting. Defaults to 0, which does not terminate query execution early.
+** *`timeout` (Optional, string)*: Specifies the period of time to wait for a response from each shard. If no response
+is received before the timeout expires, the request fails and returns an error.
+Defaults to no timeout.
+** *`track_scores` (Optional, boolean)*: If true, calculate and return document scores, even if the scores are not used for sorting.
+** *`version` (Optional, boolean)*: If true, returns document version as part of a hit.
+** *`seq_no_primary_term` (Optional, boolean)*: If true, returns sequence number and primary term of the last modification
+of each hit. See Optimistic concurrency control.
+** *`stored_fields` (Optional, string | string[])*: List of stored fields to return as part of a hit. If no fields are specified,
+no stored fields are included in the response. If this field is specified, the _source
+parameter defaults to false. You can pass _source: true to return both source fields
+and stored fields in the search response.
+** *`pit` (Optional, { id, keep_alive })*: Limits the search to a point in time (PIT). If you provide a PIT, you
+cannot specify an <index> in the request path.
+** *`runtime_mappings` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*: Defines one or more runtime fields in the search request. These fields take
+precedence over mapped fields with the same name.
+** *`stats` (Optional, string[])*: Stats groups to associate with the search. Each group maintains a statistics
+aggregation for its associated searches. You can retrieve these stats using
+the indices stats API.
 ** *`wait_for_completion_timeout` (Optional, string | -1 | 0)*: Blocks and waits until the search is completed up to a certain timeout.
 When the async search completes within the timeout, the response won’t include the ID as the results are not stored in the cluster.
 ** *`keep_on_completion` (Optional, boolean)*: If `true`, results are stored for later retrieval when the search completes within the `wait_for_completion_timeout`.
@@ -1235,9 +1314,7 @@ A partial reduction is performed every time the coordinating node has received a
 ** *`ccs_minimize_roundtrips` (Optional, boolean)*: The default value is the only supported value.
 ** *`default_operator` (Optional, Enum("and" | "or"))*: The default operator for query string query (AND or OR)
 ** *`df` (Optional, string)*: The field to use as default where no field prefix is given in the query string
-** *`docvalue_fields` (Optional, string | string[])*: A list of fields to return as the docvalue representation of a field for each hit
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Whether to expand wildcard expression to concrete indices that are open, closed or both.
-** *`explain` (Optional, boolean)*: Specify whether to return detailed information about score computation as part of a hit
 ** *`ignore_throttled` (Optional, boolean)*: Whether specified concrete, expanded or aliased indices should be ignored when throttled
 ** *`ignore_unavailable` (Optional, boolean)*: Whether specified concrete indices should be ignored when unavailable (missing or closed)
 ** *`lenient` (Optional, boolean)*: Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
@@ -1249,49 +1326,15 @@ A partial reduction is performed every time the coordinating node has received a
 ** *`routing` (Optional, string)*: A list of specific routing values
 ** *`scroll` (Optional, string | -1 | 0)*
 ** *`search_type` (Optional, Enum("query_then_fetch" | "dfs_query_then_fetch"))*: Search operation type
-** *`stats` (Optional, string[])*: Specific 'tag' of the request for logging and statistical purposes
-** *`stored_fields` (Optional, string | string[])*: A list of stored fields to return as part of a hit
 ** *`suggest_field` (Optional, string)*: Specifies which field to use for suggestions.
 ** *`suggest_mode` (Optional, Enum("missing" | "popular" | "always"))*: Specify suggest mode
 ** *`suggest_size` (Optional, number)*: How many suggestions to return in response
 ** *`suggest_text` (Optional, string)*: The source text for which the suggestions should be returned.
-** *`terminate_after` (Optional, number)*: The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
-** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
-** *`track_total_hits` (Optional, boolean | number)*: Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number.
-** *`track_scores` (Optional, boolean)*: Whether to calculate and return scores even if they are not used for sorting
 ** *`typed_keys` (Optional, boolean)*: Specify whether aggregation and suggester names should be prefixed by their respective types in the response
 ** *`rest_total_hits_as_int` (Optional, boolean)*
-** *`version` (Optional, boolean)*: Specify whether to return document version as part of a hit
-** *`_source` (Optional, boolean | string | string[])*: True or false to return the _source field or not, or a list of fields to return
 ** *`_source_excludes` (Optional, string | string[])*: A list of fields to exclude from the returned _source field
 ** *`_source_includes` (Optional, string | string[])*: A list of fields to extract and return from the _source field
-** *`seq_no_primary_term` (Optional, boolean)*: Specify whether to return sequence number and primary term of the last modification of each hit
 ** *`q` (Optional, string)*: Query in the Lucene query string syntax
-** *`size` (Optional, number)*: Number of hits to return (default: 10)
-** *`from` (Optional, number)*: Starting offset (default: 0)
-** *`sort` (Optional, string | string[])*: A list of <field>:<direction> pairs
-** *`aggregations` (Optional, Record<string, { aggregations, meta, adjacency_matrix, auto_date_histogram, avg, avg_bucket, boxplot, bucket_script, bucket_selector, bucket_sort, bucket_count_ks_test, bucket_correlation, cardinality, categorize_text, children, composite, cumulative_cardinality, cumulative_sum, date_histogram, date_range, derivative, diversified_sampler, extended_stats, extended_stats_bucket, frequent_item_sets, filter, filters, geo_bounds, geo_centroid, geo_distance, geohash_grid, geo_line, geotile_grid, geohex_grid, global, histogram, ip_range, ip_prefix, inference, line, matrix_stats, max, max_bucket, median_absolute_deviation, min, min_bucket, missing, moving_avg, moving_percentiles, moving_fn, multi_terms, nested, normalize, parent, percentile_ranks, percentiles, percentiles_bucket, range, rare_terms, rate, reverse_nested, sampler, scripted_metric, serial_diff, significant_terms, significant_text, stats, stats_bucket, string_stats, sum, sum_bucket, terms, top_hits, t_test, top_metrics, value_count, weighted_avg, variable_width_histogram }>)*
-** *`collapse` (Optional, { field, inner_hits, max_concurrent_group_searches, collapse })*
-** *`ext` (Optional, Record<string, User-defined value>)*: Configuration of search extensions defined by Elasticsearch plugins.
-** *`highlight` (Optional, { encoder, fields })*
-** *`indices_boost` (Optional, Record<string, number>[])*: Boosts the _score of documents from specified indices.
-** *`knn` (Optional, { field, query_vector, query_vector_builder, k, num_candidates, boost, filter } | { field, query_vector, query_vector_builder, k, num_candidates, boost, filter }[])*: Defines the approximate kNN search to run.
-** *`min_score` (Optional, number)*: Minimum _score for matching documents. Documents with a lower _score are
-not included in the search results.
-** *`post_filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
-** *`profile` (Optional, boolean)*
-** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*: Defines the search definition using the Query DSL.
-** *`rescore` (Optional, { query, window_size } | { query, window_size }[])*
-** *`script_fields` (Optional, Record<string, { script, ignore_failure }>)*: Retrieve a script evaluation (based on different fields) for each hit.
-** *`search_after` (Optional, number | number | string | boolean | null | User-defined value[])*
-** *`slice` (Optional, { field, id, max })*
-** *`fields` (Optional, { field, format, include_unmapped }[])*: Array of wildcard (*) patterns. The request returns values for field names
-matching these patterns in the hits.fields property of the response.
-** *`suggest` (Optional, { text })*
-** *`pit` (Optional, { id, keep_alive })*: Limits the search to a point in time (PIT). If you provide a PIT, you
-cannot specify an <index> in the request path.
-** *`runtime_mappings` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*: Defines one or more runtime fields in the search request. These fields take
-precedence over mapped fields with the same name.
 
 [discrete]
 === cat
@@ -1798,7 +1841,6 @@ client.ccr.follow({ index })
 
 * *Request (object):*
 ** *`index` (string)*: The name of the follower index
-** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Sets the number of shard copies that must be active before returning. Defaults to 0. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 ** *`leader_index` (Optional, string)*
 ** *`max_outstanding_read_requests` (Optional, number)*
 ** *`max_outstanding_write_requests` (Optional, number)*
@@ -1811,6 +1853,7 @@ client.ccr.follow({ index })
 ** *`max_write_request_size` (Optional, string)*
 ** *`read_poll_timeout` (Optional, string | -1 | 0)*
 ** *`remote_cluster` (Optional, string)*
+** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Sets the number of shard copies that must be active before returning. Defaults to 0. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 
 [discrete]
 ==== follow_info
@@ -2028,12 +2071,12 @@ client.cluster.allocationExplain({ ... })
 ==== Arguments
 
 * *Request (object):*
-** *`include_disk_info` (Optional, boolean)*: If true, returns information about disk usage and shard sizes.
-** *`include_yes_decisions` (Optional, boolean)*: If true, returns YES decisions in explanation.
 ** *`current_node` (Optional, string)*: Specifies the node ID or the name of the node to only explain a shard that is currently located on the specified node.
 ** *`index` (Optional, string)*: Specifies the name of the index that you would like an explanation for.
 ** *`primary` (Optional, boolean)*: If true, returns explanation for the primary shard for the given shard ID.
 ** *`shard` (Optional, number)*: Specifies the ID of the shard that you would like an explanation for.
+** *`include_disk_info` (Optional, boolean)*: If true, returns information about disk usage and shard sizes.
+** *`include_yes_decisions` (Optional, boolean)*: If true, returns YES decisions in explanation.
 
 [discrete]
 ==== delete_component_template
@@ -2248,9 +2291,6 @@ Elastic Agent uses these templates to configure backing indices for its data str
 If you use Elastic Agent and want to overwrite one of these templates, set the `version` for your replacement template higher than the current version.
 If you don’t use Elastic Agent and want to disable all built-in component and index templates, set `stack.templates.enabled` to `false` using the cluster update settings API.
 ** *`template` ({ aliases, mappings, settings, defaults, data_stream, lifecycle })*: The template to be applied which includes mappings, settings, or aliases configuration.
-** *`create` (Optional, boolean)*: If `true`, this request cannot replace or update existing component templates.
-** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node.
-If no response is received before the timeout expires, the request fails and returns an error.
 ** *`allow_auto_create` (Optional, boolean)*: This setting overrides the value of the `action.auto_create_index` cluster setting.
 If set to `true` in a template, then indices can be automatically created using that
 template even if auto-creation of indices is disabled via `actions.auto_create_index`.
@@ -2262,6 +2302,9 @@ To unset a version, replace the template without specifying a version.
 May have any contents. This map is not automatically generated by Elasticsearch.
 This information is stored in the cluster state, so keeping it short is preferable.
 To unset `_meta`, replace the template without specifying this information.
+** *`create` (Optional, boolean)*: If `true`, this request cannot replace or update existing component templates.
+** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node.
+If no response is received before the timeout expires, the request fails and returns an error.
 
 [discrete]
 ==== put_settings
@@ -2277,11 +2320,11 @@ client.cluster.putSettings({ ... })
 ==== Arguments
 
 * *Request (object):*
+** *`persistent` (Optional, Record<string, User-defined value>)*
+** *`transient` (Optional, Record<string, User-defined value>)*
 ** *`flat_settings` (Optional, boolean)*: Return settings in flat format (default: false)
 ** *`master_timeout` (Optional, string | -1 | 0)*: Explicit operation timeout for connection to master node
 ** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
-** *`persistent` (Optional, Record<string, User-defined value>)*
-** *`transient` (Optional, Record<string, User-defined value>)*
 
 [discrete]
 ==== remote_info
@@ -2308,13 +2351,13 @@ client.cluster.reroute({ ... })
 ==== Arguments
 
 * *Request (object):*
+** *`commands` (Optional, { cancel, move, allocate_replica, allocate_stale_primary, allocate_empty_primary }[])*: Defines the commands to perform.
 ** *`dry_run` (Optional, boolean)*: If true, then the request simulates the operation only and returns the resulting state.
 ** *`explain` (Optional, boolean)*: If true, then the response contains an explanation of why the commands can or cannot be executed.
 ** *`metric` (Optional, string | string[])*: Limits the information returned to the specified metrics.
 ** *`retry_failed` (Optional, boolean)*: If true, then retries allocation of shards that are blocked due to too many subsequent allocation failures.
 ** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
 ** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-** *`commands` (Optional, { cancel, move, allocate_replica, allocate_stale_primary, allocate_empty_primary }[])*: Defines the commands to perform.
 
 [discrete]
 ==== state
@@ -2561,22 +2604,22 @@ client.eql.search({ index, query })
 * *Request (object):*
 ** *`index` (string | string[])*: The name of the index to scope the operation
 ** *`query` (string)*: EQL query you wish to run.
-** *`allow_no_indices` (Optional, boolean)*
-** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*
-** *`ignore_unavailable` (Optional, boolean)*: If true, missing or closed indices are not included in the response.
-** *`keep_alive` (Optional, string | -1 | 0)*: Period for which the search and its results are stored on the cluster.
-** *`keep_on_completion` (Optional, boolean)*: If true, the search and its results are stored on the cluster.
-** *`wait_for_completion_timeout` (Optional, string | -1 | 0)*: Timeout duration to wait for the request to finish. Defaults to no timeout, meaning the request waits for complete search results.
 ** *`case_sensitive` (Optional, boolean)*
 ** *`event_category_field` (Optional, string)*: Field containing the event classification, such as process, file, or network.
 ** *`tiebreaker_field` (Optional, string)*: Field used to sort hits with the same timestamp in ascending order
 ** *`timestamp_field` (Optional, string)*: Field containing event timestamp. Default "@timestamp"
 ** *`fetch_size` (Optional, number)*: Maximum number of events to search at a time for sequence queries.
 ** *`filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type } | { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type }[])*: Query, written in Query DSL, used to filter the events on which the EQL query runs.
+** *`keep_alive` (Optional, string | -1 | 0)*
+** *`keep_on_completion` (Optional, boolean)*
+** *`wait_for_completion_timeout` (Optional, string | -1 | 0)*
 ** *`size` (Optional, number)*: For basic queries, the maximum number of matching events to return. Defaults to 10
 ** *`fields` (Optional, { field, format, include_unmapped } | { field, format, include_unmapped }[])*: Array of wildcard (*) patterns. The response returns values for field names matching these patterns in the fields property of each hit.
 ** *`result_position` (Optional, Enum("tail" | "head"))*
 ** *`runtime_mappings` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*
+** *`allow_no_indices` (Optional, boolean)*
+** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*
+** *`ignore_unavailable` (Optional, boolean)*: If true, missing or closed indices are not included in the response.
 
 [discrete]
 === features
@@ -2641,6 +2684,7 @@ client.fleet.msearch({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string | string)*: A single target to search. If the target is an index alias, it must resolve to a single index.
+** *`searches` (Optional, { allow_no_indices, expand_wildcards, ignore_unavailable, index, preference, request_cache, routing, search_type, ccs_minimize_roundtrips, allow_partial_search_results, ignore_throttled } | { aggregations, collapse, query, explain, ext, stored_fields, docvalue_fields, knn, from, highlight, indices_boost, min_score, post_filter, profile, rescore, script_fields, search_after, size, sort, _source, fields, terminate_after, stats, timeout, track_scores, track_total_hits, version, runtime_mappings, seq_no_primary_term, pit, suggest }[])*
 ** *`allow_no_indices` (Optional, boolean)*: If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.
 ** *`ccs_minimize_roundtrips` (Optional, boolean)*: If true, network roundtrips between the coordinating node and remote clusters are minimized for cross-cluster search requests.
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Type of index that wildcard expressions can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
@@ -2672,6 +2716,60 @@ client.fleet.search({ index })
 
 * *Request (object):*
 ** *`index` (string | string)*: A single target to search. If the target is an index alias, it must resolve to a single index.
+** *`aggregations` (Optional, Record<string, { aggregations, meta, adjacency_matrix, auto_date_histogram, avg, avg_bucket, boxplot, bucket_script, bucket_selector, bucket_sort, bucket_count_ks_test, bucket_correlation, cardinality, categorize_text, children, composite, cumulative_cardinality, cumulative_sum, date_histogram, date_range, derivative, diversified_sampler, extended_stats, extended_stats_bucket, frequent_item_sets, filter, filters, geo_bounds, geo_centroid, geo_distance, geohash_grid, geo_line, geotile_grid, geohex_grid, global, histogram, ip_range, ip_prefix, inference, line, matrix_stats, max, max_bucket, median_absolute_deviation, min, min_bucket, missing, moving_avg, moving_percentiles, moving_fn, multi_terms, nested, normalize, parent, percentile_ranks, percentiles, percentiles_bucket, range, rare_terms, rate, reverse_nested, sampler, scripted_metric, serial_diff, significant_terms, significant_text, stats, stats_bucket, string_stats, sum, sum_bucket, terms, top_hits, t_test, top_metrics, value_count, weighted_avg, variable_width_histogram }>)*
+** *`collapse` (Optional, { field, inner_hits, max_concurrent_group_searches, collapse })*
+** *`explain` (Optional, boolean)*: If true, returns detailed information about score computation as part of a hit.
+** *`ext` (Optional, Record<string, User-defined value>)*: Configuration of search extensions defined by Elasticsearch plugins.
+** *`from` (Optional, number)*: Starting document offset. By default, you cannot page through more than 10,000
+hits using the from and size parameters. To page through more hits, use the
+search_after parameter.
+** *`highlight` (Optional, { encoder, fields })*
+** *`track_total_hits` (Optional, boolean | number)*: Number of hits matching the query to count accurately. If true, the exact
+number of hits is returned at the cost of some performance. If false, the
+response does not include the total number of hits matching the query.
+Defaults to 10,000 hits.
+** *`indices_boost` (Optional, Record<string, number>[])*: Boosts the _score of documents from specified indices.
+** *`docvalue_fields` (Optional, { field, format, include_unmapped }[])*: Array of wildcard (*) patterns. The request returns doc values for field
+names matching these patterns in the hits.fields property of the response.
+** *`min_score` (Optional, number)*: Minimum _score for matching documents. Documents with a lower _score are
+not included in the search results.
+** *`post_filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
+** *`profile` (Optional, boolean)*
+** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*: Defines the search definition using the Query DSL.
+** *`rescore` (Optional, { query, window_size } | { query, window_size }[])*
+** *`script_fields` (Optional, Record<string, { script, ignore_failure }>)*: Retrieve a script evaluation (based on different fields) for each hit.
+** *`search_after` (Optional, number | number | string | boolean | null | User-defined value[])*
+** *`size` (Optional, number)*: The number of hits to return. By default, you cannot page through more
+than 10,000 hits using the from and size parameters. To page through more
+hits, use the search_after parameter.
+** *`slice` (Optional, { field, id, max })*
+** *`sort` (Optional, string | { _score, _doc, _geo_distance, _script } | string | { _score, _doc, _geo_distance, _script }[])*
+** *`_source` (Optional, boolean | { excludes, includes })*: Indicates which source fields are returned for matching documents. These
+fields are returned in the hits._source property of the search response.
+** *`fields` (Optional, { field, format, include_unmapped }[])*: Array of wildcard (*) patterns. The request returns values for field names
+matching these patterns in the hits.fields property of the response.
+** *`suggest` (Optional, { text })*
+** *`terminate_after` (Optional, number)*: Maximum number of documents to collect for each shard. If a query reaches this
+limit, Elasticsearch terminates the query early. Elasticsearch collects documents
+before sorting. Defaults to 0, which does not terminate query execution early.
+** *`timeout` (Optional, string)*: Specifies the period of time to wait for a response from each shard. If no response
+is received before the timeout expires, the request fails and returns an error.
+Defaults to no timeout.
+** *`track_scores` (Optional, boolean)*: If true, calculate and return document scores, even if the scores are not used for sorting.
+** *`version` (Optional, boolean)*: If true, returns document version as part of a hit.
+** *`seq_no_primary_term` (Optional, boolean)*: If true, returns sequence number and primary term of the last modification
+of each hit. See Optimistic concurrency control.
+** *`stored_fields` (Optional, string | string[])*: List of stored fields to return as part of a hit. If no fields are specified,
+no stored fields are included in the response. If this field is specified, the _source
+parameter defaults to false. You can pass _source: true to return both source fields
+and stored fields in the search response.
+** *`pit` (Optional, { id, keep_alive })*: Limits the search to a point in time (PIT). If you provide a PIT, you
+cannot specify an <index> in the request path.
+** *`runtime_mappings` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*: Defines one or more runtime fields in the search request. These fields take
+precedence over mapped fields with the same name.
+** *`stats` (Optional, string[])*: Stats groups to associate with the search. Each group maintains a statistics
+aggregation for its associated searches. You can retrieve these stats using
+the indices stats API.
 ** *`allow_no_indices` (Optional, boolean)*
 ** *`analyzer` (Optional, string)*
 ** *`analyze_wildcard` (Optional, boolean)*
@@ -2679,9 +2777,7 @@ client.fleet.search({ index })
 ** *`ccs_minimize_roundtrips` (Optional, boolean)*
 ** *`default_operator` (Optional, Enum("and" | "or"))*
 ** *`df` (Optional, string)*
-** *`docvalue_fields` (Optional, string | string[])*
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*
-** *`explain` (Optional, boolean)*
 ** *`ignore_throttled` (Optional, boolean)*
 ** *`ignore_unavailable` (Optional, boolean)*
 ** *`lenient` (Optional, boolean)*
@@ -2693,54 +2789,21 @@ client.fleet.search({ index })
 ** *`routing` (Optional, string)*
 ** *`scroll` (Optional, string | -1 | 0)*
 ** *`search_type` (Optional, Enum("query_then_fetch" | "dfs_query_then_fetch"))*
-** *`stats` (Optional, string[])*
-** *`stored_fields` (Optional, string | string[])*
 ** *`suggest_field` (Optional, string)*: Specifies which field to use for suggestions.
 ** *`suggest_mode` (Optional, Enum("missing" | "popular" | "always"))*
 ** *`suggest_size` (Optional, number)*
 ** *`suggest_text` (Optional, string)*: The source text for which the suggestions should be returned.
-** *`terminate_after` (Optional, number)*
-** *`timeout` (Optional, string | -1 | 0)*
-** *`track_total_hits` (Optional, boolean | number)*
-** *`track_scores` (Optional, boolean)*
 ** *`typed_keys` (Optional, boolean)*
 ** *`rest_total_hits_as_int` (Optional, boolean)*
-** *`version` (Optional, boolean)*
-** *`_source` (Optional, boolean | string | string[])*
 ** *`_source_excludes` (Optional, string | string[])*
 ** *`_source_includes` (Optional, string | string[])*
-** *`seq_no_primary_term` (Optional, boolean)*
 ** *`q` (Optional, string)*
-** *`size` (Optional, number)*
-** *`from` (Optional, number)*
-** *`sort` (Optional, string | string[])*
 ** *`wait_for_checkpoints` (Optional, number[])*: A comma separated list of checkpoints. When configured, the search API will only be executed on a shard
 after the relevant checkpoint has become visible for search. Defaults to an empty list which will cause
 Elasticsearch to immediately execute the search.
 ** *`allow_partial_search_results` (Optional, boolean)*: If true, returns partial results if there are shard request timeouts or [shard failures](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-replication.html#shard-failures). If false, returns
 an error with no partial results. Defaults to the configured cluster setting `search.default_allow_partial_results`
 which is true by default.
-** *`aggregations` (Optional, Record<string, { aggregations, meta, adjacency_matrix, auto_date_histogram, avg, avg_bucket, boxplot, bucket_script, bucket_selector, bucket_sort, bucket_count_ks_test, bucket_correlation, cardinality, categorize_text, children, composite, cumulative_cardinality, cumulative_sum, date_histogram, date_range, derivative, diversified_sampler, extended_stats, extended_stats_bucket, frequent_item_sets, filter, filters, geo_bounds, geo_centroid, geo_distance, geohash_grid, geo_line, geotile_grid, geohex_grid, global, histogram, ip_range, ip_prefix, inference, line, matrix_stats, max, max_bucket, median_absolute_deviation, min, min_bucket, missing, moving_avg, moving_percentiles, moving_fn, multi_terms, nested, normalize, parent, percentile_ranks, percentiles, percentiles_bucket, range, rare_terms, rate, reverse_nested, sampler, scripted_metric, serial_diff, significant_terms, significant_text, stats, stats_bucket, string_stats, sum, sum_bucket, terms, top_hits, t_test, top_metrics, value_count, weighted_avg, variable_width_histogram }>)*
-** *`collapse` (Optional, { field, inner_hits, max_concurrent_group_searches, collapse })*
-** *`ext` (Optional, Record<string, User-defined value>)*: Configuration of search extensions defined by Elasticsearch plugins.
-** *`highlight` (Optional, { encoder, fields })*
-** *`indices_boost` (Optional, Record<string, number>[])*: Boosts the _score of documents from specified indices.
-** *`min_score` (Optional, number)*: Minimum _score for matching documents. Documents with a lower _score are
-not included in the search results.
-** *`post_filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
-** *`profile` (Optional, boolean)*
-** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*: Defines the search definition using the Query DSL.
-** *`rescore` (Optional, { query, window_size } | { query, window_size }[])*
-** *`script_fields` (Optional, Record<string, { script, ignore_failure }>)*: Retrieve a script evaluation (based on different fields) for each hit.
-** *`search_after` (Optional, number | number | string | boolean | null | User-defined value[])*
-** *`slice` (Optional, { field, id, max })*
-** *`fields` (Optional, { field, format, include_unmapped }[])*: Array of wildcard (*) patterns. The request returns values for field names
-matching these patterns in the hits.fields property of the response.
-** *`suggest` (Optional, { text })*
-** *`pit` (Optional, { id, keep_alive })*: Limits the search to a point in time (PIT). If you provide a PIT, you
-cannot specify an <index> in the request path.
-** *`runtime_mappings` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*: Defines one or more runtime fields in the search request. These fields take
-precedence over mapped fields with the same name.
 
 [discrete]
 === graph
@@ -2759,12 +2822,12 @@ client.graph.explore({ index })
 
 * *Request (object):*
 ** *`index` (string | string[])*: A list of index names to search; use `_all` or empty string to perform the operation on all indices
-** *`routing` (Optional, string)*: Specific routing value
-** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
 ** *`connections` (Optional, { connections, query, vertices })*
 ** *`controls` (Optional, { sample_diversity, sample_size, timeout, use_significance })*
 ** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
 ** *`vertices` (Optional, { exclude, field, include, min_doc_count, shard_min_doc_count, size }[])*
+** *`routing` (Optional, string)*: Specific routing value
+** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
 
 [discrete]
 === ilm
@@ -2850,10 +2913,10 @@ client.ilm.migrateToDataTiers({ ... })
 ==== Arguments
 
 * *Request (object):*
-** *`dry_run` (Optional, boolean)*: If true, simulates the migration from node attributes based allocation filters to data tiers, but does not perform the migration.
-This provides a way to retrieve the indices and ILM policies that need to be migrated.
 ** *`legacy_template_to_delete` (Optional, string)*
 ** *`node_attribute` (Optional, string)*
+** *`dry_run` (Optional, boolean)*: If true, simulates the migration from node attributes based allocation filters to data tiers, but does not perform the migration.
+This provides a way to retrieve the indices and ILM policies that need to be migrated.
 
 [discrete]
 ==== move_to_step
@@ -3045,11 +3108,11 @@ client.indices.clone({ index, target })
 * *Request (object):*
 ** *`index` (string)*: The name of the source index to clone
 ** *`target` (string)*: The name of the target index to clone into
+** *`aliases` (Optional, Record<string, { filter, index_routing, is_hidden, is_write_index, routing, search_routing }>)*
+** *`settings` (Optional, Record<string, User-defined value>)*
 ** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
 ** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
 ** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Set the number of active shards to wait for on the cloned index before the operation returns.
-** *`aliases` (Optional, Record<string, { filter, index_routing, is_hidden, is_write_index, routing, search_routing }>)*
-** *`settings` (Optional, Record<string, User-defined value>)*
 
 [discrete]
 ==== close
@@ -3088,15 +3151,15 @@ client.indices.create({ index })
 
 * *Request (object):*
 ** *`index` (string)*: The name of the index
-** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
-** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
-** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Set the number of active shards to wait for before the operation returns.
 ** *`aliases` (Optional, Record<string, { filter, index_routing, is_hidden, is_write_index, routing, search_routing }>)*
 ** *`mappings` (Optional, { all_field, date_detection, dynamic, dynamic_date_formats, dynamic_templates, _field_names, index_field, _meta, numeric_detection, properties, _routing, _size, _source, runtime, enabled, _data_stream_timestamp })*: Mapping for fields in the index. If specified, this mapping can include:
 - Field names
 - Field data types
 - Mapping parameters
 ** *`settings` (Optional, { index, mode, routing_path, soft_deletes, sort, number_of_shards, number_of_replicas, number_of_routing_shards, check_on_startup, codec, routing_partition_size, load_fixed_bitset_filters_eagerly, hidden, auto_expand_replicas, merge, search, refresh_interval, max_result_window, max_inner_result_window, max_rescore_window, max_docvalue_fields_search, max_script_fields, max_ngram_diff, max_shingle_diff, blocks, max_refresh_listeners, analyze, highlight, max_terms_count, max_regex_length, routing, gc_deletes, default_pipeline, final_pipeline, lifecycle, provided_name, creation_date, creation_date_string, uuid, version, verified_before_close, format, max_slices_per_scroll, translog, query_string, priority, top_metrics_max_size, analysis, settings, time_series, shards, queries, similarity, mapping, indexing.slowlog, indexing_pressure, store })*
+** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
+** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
+** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Set the number of active shards to wait for before the operation returns.
 
 [discrete]
 ==== create_data_stream
@@ -3285,6 +3348,7 @@ client.indices.downsample({ index, target_index })
 * *Request (object):*
 ** *`index` (string)*: The index to downsample
 ** *`target_index` (string)*: The name of the target index to store downsampled data
+** *`config` (Optional, { fixed_interval })*
 
 [discrete]
 ==== exists
@@ -3738,13 +3802,13 @@ client.indices.putAlias({ index, name })
 * *Request (object):*
 ** *`index` (string | string[])*: A list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.
 ** *`name` (string)*: The name of the alias to be created or updated
-** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
-** *`timeout` (Optional, string | -1 | 0)*: Explicit timestamp for the document
 ** *`filter` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
 ** *`index_routing` (Optional, string)*
 ** *`is_write_index` (Optional, boolean)*
 ** *`routing` (Optional, string)*
 ** *`search_routing` (Optional, string)*
+** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
+** *`timeout` (Optional, string | -1 | 0)*: Explicit timestamp for the document
 
 [discrete]
 ==== put_data_lifecycle
@@ -3761,10 +3825,10 @@ client.indices.putDataLifecycle({ name })
 
 * *Request (object):*
 ** *`name` (string | string[])*: A list of data streams whose lifecycle will be updated; use `*` to set the lifecycle to all data streams
+** *`data_retention` (Optional, string | -1 | 0)*
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Whether wildcard expressions should get expanded to open or closed indices (default: open)
 ** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
 ** *`timeout` (Optional, string | -1 | 0)*: Explicit timestamp for the document
-** *`data_retention` (Optional, string | -1 | 0)*
 
 [discrete]
 ==== put_index_template
@@ -3781,7 +3845,6 @@ client.indices.putIndexTemplate({ name })
 
 * *Request (object):*
 ** *`name` (string)*: Index or template name
-** *`create` (Optional, boolean)*: Whether the index template should only be added if new or can also replace an existing one
 ** *`index_patterns` (Optional, string | string[])*
 ** *`composed_of` (Optional, string[])*
 ** *`template` (Optional, { aliases, mappings, settings, lifecycle })*
@@ -3789,6 +3852,7 @@ client.indices.putIndexTemplate({ name })
 ** *`priority` (Optional, number)*
 ** *`version` (Optional, number)*
 ** *`_meta` (Optional, Record<string, User-defined value>)*
+** *`create` (Optional, boolean)*: Whether the index template should only be added if new or can also replace an existing one
 
 [discrete]
 ==== put_mapping
@@ -3805,12 +3869,6 @@ client.indices.putMapping({ index })
 
 * *Request (object):*
 ** *`index` (string | string[])*: A list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.
-** *`allow_no_indices` (Optional, boolean)*: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Whether to expand wildcard expression to concrete indices that are open, closed or both.
-** *`ignore_unavailable` (Optional, boolean)*: Whether specified concrete indices should be ignored when unavailable (missing or closed)
-** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
-** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
-** *`write_index_only` (Optional, boolean)*: When true, applies mappings only to the write index of an alias or data stream
 ** *`date_detection` (Optional, boolean)*: Controls whether dynamic date detection is enabled.
 ** *`dynamic` (Optional, Enum("strict" | "runtime" | true | false))*: Controls whether new fields are added dynamically.
 ** *`dynamic_date_formats` (Optional, string[])*: If date detection is enabled then new string fields are checked
@@ -3830,6 +3888,12 @@ application-specific metadata.
 ** *`_routing` (Optional, { required })*: Enable making a routing value required on indexed documents.
 ** *`_source` (Optional, { compress, compress_threshold, enabled, excludes, includes, mode })*: Control whether the _source field is enabled on the index.
 ** *`runtime` (Optional, Record<string, { fetch_fields, format, input_field, target_field, target_index, script, type }>)*: Mapping of runtime fields for the index.
+** *`allow_no_indices` (Optional, boolean)*: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+** *`ignore_unavailable` (Optional, boolean)*: Whether specified concrete indices should be ignored when unavailable (missing or closed)
+** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
+** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
+** *`write_index_only` (Optional, boolean)*: When true, applies mappings only to the write index of an alias or data stream
 
 [discrete]
 ==== put_settings
@@ -3846,6 +3910,7 @@ client.indices.putSettings({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string | string[])*: A list of index names; use `_all` or empty string to perform the operation on all indices
+** *`settings` (Optional, { index, mode, routing_path, soft_deletes, sort, number_of_shards, number_of_replicas, number_of_routing_shards, check_on_startup, codec, routing_partition_size, load_fixed_bitset_filters_eagerly, hidden, auto_expand_replicas, merge, search, refresh_interval, max_result_window, max_inner_result_window, max_rescore_window, max_docvalue_fields_search, max_script_fields, max_ngram_diff, max_shingle_diff, blocks, max_refresh_listeners, analyze, highlight, max_terms_count, max_regex_length, routing, gc_deletes, default_pipeline, final_pipeline, lifecycle, provided_name, creation_date, creation_date_string, uuid, version, verified_before_close, format, max_slices_per_scroll, translog, query_string, priority, top_metrics_max_size, analysis, settings, time_series, shards, queries, similarity, mapping, indexing.slowlog, indexing_pressure, store })*
 ** *`allow_no_indices` (Optional, boolean)*: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
 ** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Whether to expand wildcard expression to concrete indices that are open, closed or both.
 ** *`flat_settings` (Optional, boolean)*: Return settings in flat format (default: false)
@@ -3869,23 +3934,23 @@ client.indices.putTemplate({ name })
 
 * *Request (object):*
 ** *`name` (string)*: The name of the template
-** *`create` (Optional, boolean)*: If true, this request cannot replace or update existing index templates.
-** *`flat_settings` (Optional, boolean)*
-** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is
-received before the timeout expires, the request fails and returns an error.
-** *`timeout` (Optional, string | -1 | 0)*
+** *`aliases` (Optional, Record<string, { filter, index_routing, is_hidden, is_write_index, routing, search_routing }>)*: Aliases for the index.
+** *`index_patterns` (Optional, string | string[])*: Array of wildcard expressions used to match the names
+of indices during creation.
+** *`mappings` (Optional, { all_field, date_detection, dynamic, dynamic_date_formats, dynamic_templates, _field_names, index_field, _meta, numeric_detection, properties, _routing, _size, _source, runtime, enabled, _data_stream_timestamp })*: Mapping for fields in the index.
 ** *`order` (Optional, number)*: Order in which Elasticsearch applies this template if index
 matches multiple templates.
 
 Templates with lower 'order' values are merged first. Templates with higher
 'order' values are merged later, overriding templates with lower values.
-** *`aliases` (Optional, Record<string, { filter, index_routing, is_hidden, is_write_index, routing, search_routing }>)*: Aliases for the index.
-** *`index_patterns` (Optional, string | string[])*: Array of wildcard expressions used to match the names
-of indices during creation.
-** *`mappings` (Optional, { all_field, date_detection, dynamic, dynamic_date_formats, dynamic_templates, _field_names, index_field, _meta, numeric_detection, properties, _routing, _size, _source, runtime, enabled, _data_stream_timestamp })*: Mapping for fields in the index.
 ** *`settings` (Optional, Record<string, User-defined value>)*: Configuration options for the index.
 ** *`version` (Optional, number)*: Version number used to manage index templates externally. This number
 is not automatically generated by Elasticsearch.
+** *`create` (Optional, boolean)*: If true, this request cannot replace or update existing index templates.
+** *`flat_settings` (Optional, boolean)*
+** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is
+received before the timeout expires, the request fails and returns an error.
+** *`timeout` (Optional, string | -1 | 0)*
 
 [discrete]
 ==== recovery
@@ -3977,14 +4042,14 @@ client.indices.rollover({ alias })
 * *Request (object):*
 ** *`alias` (string)*: The name of the alias to rollover
 ** *`new_index` (Optional, string)*: The name of the rollover index
-** *`dry_run` (Optional, boolean)*: If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false
-** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
-** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
-** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Set the number of active shards to wait for on the newly created rollover index before the operation returns.
 ** *`aliases` (Optional, Record<string, { filter, index_routing, is_hidden, is_write_index, routing, search_routing }>)*
 ** *`conditions` (Optional, { min_age, max_age, max_age_millis, min_docs, max_docs, max_size, max_size_bytes, min_size, min_size_bytes, max_primary_shard_size, max_primary_shard_size_bytes, min_primary_shard_size, min_primary_shard_size_bytes, max_primary_shard_docs, min_primary_shard_docs })*
 ** *`mappings` (Optional, { all_field, date_detection, dynamic, dynamic_date_formats, dynamic_templates, _field_names, index_field, _meta, numeric_detection, properties, _routing, _size, _source, runtime, enabled, _data_stream_timestamp })*
 ** *`settings` (Optional, Record<string, User-defined value>)*
+** *`dry_run` (Optional, boolean)*: If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false
+** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
+** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
+** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Set the number of active shards to wait for on the newly created rollover index before the operation returns.
 
 [discrete]
 ==== segments
@@ -4045,11 +4110,11 @@ client.indices.shrink({ index, target })
 * *Request (object):*
 ** *`index` (string)*: The name of the source index to shrink
 ** *`target` (string)*: The name of the target index to shrink into
+** *`aliases` (Optional, Record<string, { filter, index_routing, is_hidden, is_write_index, routing, search_routing }>)*
+** *`settings` (Optional, Record<string, User-defined value>)*
 ** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
 ** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
 ** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Set the number of active shards to wait for on the shrunken index before the operation returns.
-** *`aliases` (Optional, Record<string, { filter, index_routing, is_hidden, is_write_index, routing, search_routing }>)*
-** *`settings` (Optional, Record<string, User-defined value>)*
 
 [discrete]
 ==== simulate_index_template
@@ -4066,14 +4131,6 @@ client.indices.simulateIndexTemplate({ name })
 
 * *Request (object):*
 ** *`name` (string)*: Index or template name to simulate
-** *`create` (Optional, boolean)*: If `true`, the template passed in the body is only used if no existing
-templates match the same index patterns. If `false`, the simulation uses
-the template with the highest priority. Note that the template is not
-permanently added or updated in either case; it is only used for the
-simulation.
-** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is received
-before the timeout expires, the request fails and returns an error.
-** *`include_defaults` (Optional, boolean)*: If true, returns all relevant default configurations for the index template.
 ** *`allow_auto_create` (Optional, boolean)*
 ** *`index_patterns` (Optional, string | string[])*
 ** *`composed_of` (Optional, string[])*
@@ -4082,6 +4139,14 @@ before the timeout expires, the request fails and returns an error.
 ** *`priority` (Optional, number)*
 ** *`version` (Optional, number)*
 ** *`_meta` (Optional, Record<string, User-defined value>)*
+** *`create` (Optional, boolean)*: If `true`, the template passed in the body is only used if no existing
+templates match the same index patterns. If `false`, the simulation uses
+the template with the highest priority. Note that the template is not
+permanently added or updated in either case; it is only used for the
+simulation.
+** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is received
+before the timeout expires, the request fails and returns an error.
+** *`include_defaults` (Optional, boolean)*: If true, returns all relevant default configurations for the index template.
 
 [discrete]
 ==== simulate_template
@@ -4099,6 +4164,7 @@ client.indices.simulateTemplate({ ... })
 * *Request (object):*
 ** *`name` (Optional, string)*: Name of the index template to simulate. To test a template configuration before you add it to the cluster, omit
 this parameter and specify the template configuration in the request body.
+** *`template` (Optional, { index_patterns, composed_of, template, version, priority, _meta, allow_auto_create, data_stream })*
 ** *`create` (Optional, boolean)*: If true, the template passed in the body is only used if no existing templates match the same index patterns. If false, the simulation uses the template with the highest priority. Note that the template is not permanently added or updated in either case; it is only used for the simulation.
 ** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
 ** *`include_defaults` (Optional, boolean)*: If true, returns all relevant default configurations for the index template.
@@ -4119,11 +4185,11 @@ client.indices.split({ index, target })
 * *Request (object):*
 ** *`index` (string)*: The name of the source index to split
 ** *`target` (string)*: The name of the target index to split into
+** *`aliases` (Optional, Record<string, { filter, index_routing, is_hidden, is_write_index, routing, search_routing }>)*
+** *`settings` (Optional, Record<string, User-defined value>)*
 ** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
 ** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
 ** *`wait_for_active_shards` (Optional, number | Enum("all" | "index-setting"))*: Set the number of active shards to wait for on the shrunken index before the operation returns.
-** *`aliases` (Optional, Record<string, { filter, index_routing, is_hidden, is_write_index, routing, search_routing }>)*
-** *`settings` (Optional, Record<string, User-defined value>)*
 
 [discrete]
 ==== stats
@@ -4189,9 +4255,9 @@ client.indices.updateAliases({ ... })
 ==== Arguments
 
 * *Request (object):*
+** *`actions` (Optional, { add_backing_index, remove_backing_index }[])*
 ** *`master_timeout` (Optional, string | -1 | 0)*: Specify timeout for connection to master
 ** *`timeout` (Optional, string | -1 | 0)*: Request timeout
-** *`actions` (Optional, { add_backing_index, remove_backing_index }[])*
 
 [discrete]
 ==== validate_query
@@ -4208,6 +4274,7 @@ client.indices.validateQuery({ ... })
 
 * *Request (object):*
 ** *`index` (Optional, string | string[])*: A list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices
+** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
 ** *`allow_no_indices` (Optional, boolean)*: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
 ** *`all_shards` (Optional, boolean)*: Execute validation on all shards instead of one random shard per index
 ** *`analyzer` (Optional, string)*: The analyzer to use for the query string
@@ -4220,7 +4287,6 @@ client.indices.validateQuery({ ... })
 ** *`lenient` (Optional, boolean)*: Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
 ** *`rewrite` (Optional, boolean)*: Provide a more detailed explanation showing the actual Lucene query that will be executed.
 ** *`q` (Optional, string)*: Query in the Lucene query string syntax
-** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
 
 [discrete]
 === ingest
@@ -4297,14 +4363,14 @@ client.ingest.putPipeline({ id })
 
 * *Request (object):*
 ** *`id` (string)*: ID of the ingest pipeline to create or update.
-** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
-** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-** *`if_version` (Optional, number)*: Required version for optimistic concurrency control for pipeline updates
 ** *`_meta` (Optional, Record<string, User-defined value>)*: Optional metadata about the ingest pipeline. May have any contents. This map is not automatically generated by Elasticsearch.
 ** *`description` (Optional, string)*: Description of the ingest pipeline.
 ** *`on_failure` (Optional, { attachment, append, csv, convert, date, date_index_name, dot_expander, enrich, fail, foreach, json, user_agent, kv, geoip, grok, gsub, join, lowercase, remove, rename, script, set, sort, split, trim, uppercase, urldecode, bytes, dissect, set_security_user, pipeline, drop, circle, inference }[])*: Processors to run immediately after a processor failure. Each processor supports a processor-level `on_failure` value. If a processor without an `on_failure` value fails, Elasticsearch uses this pipeline-level parameter as a fallback. The processors in this parameter run sequentially in the order specified. Elasticsearch will not attempt to run the pipeline's remaining processors.
 ** *`processors` (Optional, { attachment, append, csv, convert, date, date_index_name, dot_expander, enrich, fail, foreach, json, user_agent, kv, geoip, grok, gsub, join, lowercase, remove, rename, script, set, sort, split, trim, uppercase, urldecode, bytes, dissect, set_security_user, pipeline, drop, circle, inference }[])*: Processors used to perform transformations on documents before indexing. Processors run sequentially in the order specified.
 ** *`version` (Optional, number)*: Version number used by external systems to track ingest pipelines. This parameter is intended for external systems only. Elasticsearch does not use or validate pipeline version numbers.
+** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
+** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+** *`if_version` (Optional, number)*: Required version for optimistic concurrency control for pipeline updates
 
 [discrete]
 ==== simulate
@@ -4321,9 +4387,9 @@ client.ingest.simulate({ ... })
 
 * *Request (object):*
 ** *`id` (Optional, string)*: Pipeline ID
-** *`verbose` (Optional, boolean)*: Verbose mode. Display data output for each processor in executed pipeline
 ** *`docs` (Optional, { _id, _index, _source }[])*
 ** *`pipeline` (Optional, { description, on_failure, processors, version })*
+** *`verbose` (Optional, boolean)*: Verbose mode. Display data output for each processor in executed pipeline
 
 [discrete]
 === license
@@ -4392,9 +4458,9 @@ client.license.post({ ... })
 ==== Arguments
 
 * *Request (object):*
-** *`acknowledge` (Optional, boolean)*: Specifies whether you acknowledge the license changes.
 ** *`license` (Optional, { expiry_date_in_millis, issue_date_in_millis, start_date_in_millis, issued_to, issuer, max_nodes, max_resource_units, signature, type, uid })*
 ** *`licenses` (Optional, { expiry_date_in_millis, issue_date_in_millis, start_date_in_millis, issued_to, issuer, max_nodes, max_resource_units, signature, type, uid }[])*: A sequence of one or more JSON documents containing the license information.
+** *`acknowledge` (Optional, boolean)*: Specifies whether you acknowledge the license changes.
 
 [discrete]
 ==== post_start_basic
@@ -4478,6 +4544,7 @@ client.logstash.putPipeline({ id })
 
 * *Request (object):*
 ** *`id` (string)*: The ID of the Pipeline
+** *`pipeline` (Optional, { description, on_failure, processors, version })*
 
 [discrete]
 === migration
@@ -4552,11 +4619,9 @@ client.ml.closeJob({ job_id })
 
 * *Request (object):*
 ** *`job_id` (string)*: Identifier for the anomaly detection job. It can be a job identifier, a group name, or a wildcard expression. You can close multiple anomaly detection jobs in a single API request by using a group name, a list of jobs, or a wildcard expression. You can close all jobs by using `_all` or by specifying `*` as the job identifier.
-** *`allow_no_match` (Optional, boolean)*: Specifies what to do when the request: contains wildcard expressions and there are no jobs that match; contains the  `_all` string or no identifiers and there are no matches; or contains wildcard expressions and there are only partial matches. By default, it returns an empty jobs array when there are no matches and the subset of results when there are partial matches.
-If `false`, the request returns a 404 status code when there are no matches or only partial matches.
-** *`force` (Optional, boolean)*: Use to close a failed job, or to forcefully close a job which has not responded to its initial close request; the request returns without performing the associated actions such as flushing buffers and persisting the model snapshots.
-If you want the job to be in a consistent state after the close job API returns, do not set to `true`. This parameter should be used only in situations where the job has already failed or where you are not interested in results the job might have recently produced or might produce in the future.
-** *`timeout` (Optional, string | -1 | 0)*: Controls the time to wait until a job has closed.
+** *`allow_no_match` (Optional, boolean)*: Refer to the description for the `allow_no_match` query parameter.
+** *`force` (Optional, boolean)*: Refer to the descriptiion for the `force` query parameter.
+** *`timeout` (Optional, string | -1 | 0)*: Refer to the description for the `timeout` query parameter.
 
 [discrete]
 ==== delete_calendar
@@ -4888,16 +4953,11 @@ client.ml.flushJob({ job_id })
 
 * *Request (object):*
 ** *`job_id` (string)*: Identifier for the anomaly detection job.
-** *`advance_time` (Optional, string | Unit)*: Specifies to advance to a particular time value. Results are generated
-and the model is updated for data from the specified time interval.
-** *`calc_interim` (Optional, boolean)*: If true, calculates the interim results for the most recent bucket or all
-buckets within the latency period.
-** *`end` (Optional, string | Unit)*: When used in conjunction with `calc_interim` and `start`, specifies the
-range of buckets on which to calculate interim results.
-** *`skip_time` (Optional, string | Unit)*: Specifies to skip to a particular time value. Results are not generated
-and the model is not updated for data from the specified time interval.
-** *`start` (Optional, string | Unit)*: When used in conjunction with `calc_interim`, specifies the range of
-buckets on which to calculate interim results.
+** *`advance_time` (Optional, string | Unit)*: Refer to the description for the `advance_time` query parameter.
+** *`calc_interim` (Optional, boolean)*: Refer to the description for the `calc_interim` query parameter.
+** *`end` (Optional, string | Unit)*: Refer to the description for the `end` query parameter.
+** *`skip_time` (Optional, string | Unit)*: Refer to the description for the `skip_time` query parameter.
+** *`start` (Optional, string | Unit)*: Refer to the description for the `start` query parameter.
 
 [discrete]
 ==== forecast
@@ -4915,17 +4975,9 @@ client.ml.forecast({ job_id })
 * *Request (object):*
 ** *`job_id` (string)*: Identifier for the anomaly detection job. The job must be open when you
 create a forecast; otherwise, an error occurs.
-** *`duration` (Optional, string | -1 | 0)*: A period of time that indicates how far into the future to forecast. For
-example, `30d` corresponds to 30 days. The forecast starts at the last
-record that was processed.
-** *`expires_in` (Optional, string | -1 | 0)*: The period of time that forecast results are retained. After a forecast
-expires, the results are deleted. If set to a value of 0, the forecast is
-never automatically deleted.
-** *`max_model_memory` (Optional, string)*: The maximum memory the forecast can use. If the forecast needs to use
-more than the provided amount, it will spool to disk. Default is 20mb,
-maximum is 500mb and minimum is 1mb. If set to 40% or more of the job’s
-configured memory limit, it is automatically reduced to below that
-amount.
+** *`duration` (Optional, string | -1 | 0)*: Refer to the description for the `duration` query parameter.
+** *`expires_in` (Optional, string | -1 | 0)*: Refer to the description for the `expires_in` query parameter.
+** *`max_model_memory` (Optional, string)*: Refer to the description for the `max_model_memory` query parameter.
 
 [discrete]
 ==== get_buckets
@@ -4944,18 +4996,16 @@ client.ml.getBuckets({ job_id })
 ** *`job_id` (string)*: Identifier for the anomaly detection job.
 ** *`timestamp` (Optional, string | Unit)*: The timestamp of a single bucket result. If you do not specify this
 parameter, the API returns information about all buckets.
-** *`anomaly_score` (Optional, number)*: Returns buckets with anomaly scores greater or equal than this value.
-** *`desc` (Optional, boolean)*: If `true`, the buckets are sorted in descending order.
-** *`end` (Optional, string | Unit)*: Returns buckets with timestamps earlier than this time. `-1` means it is
-unset and results are not limited to specific timestamps.
-** *`exclude_interim` (Optional, boolean)*: If `true`, the output excludes interim results.
-** *`expand` (Optional, boolean)*: If true, the output includes anomaly records.
+** *`anomaly_score` (Optional, number)*: Refer to the description for the `anomaly_score` query parameter.
+** *`desc` (Optional, boolean)*: Refer to the description for the `desc` query parameter.
+** *`end` (Optional, string | Unit)*: Refer to the description for the `end` query parameter.
+** *`exclude_interim` (Optional, boolean)*: Refer to the description for the `exclude_interim` query parameter.
+** *`expand` (Optional, boolean)*: Refer to the description for the `expand` query parameter.
+** *`page` (Optional, { from, size })*
+** *`sort` (Optional, string)*: Refer to the desription for the `sort` query parameter.
+** *`start` (Optional, string | Unit)*: Refer to the description for the `start` query parameter.
 ** *`from` (Optional, number)*: Skips the specified number of buckets.
 ** *`size` (Optional, number)*: Specifies the maximum number of buckets to obtain.
-** *`sort` (Optional, string)*: Specifies the sort field for the requested buckets.
-** *`start` (Optional, string | Unit)*: Returns buckets with timestamps after this time. `-1` means it is unset
-and results are not limited to specific timestamps.
-** *`page` (Optional, { from, size })*
 
 [discrete]
 ==== get_calendar_events
@@ -4993,9 +5043,9 @@ client.ml.getCalendars({ ... })
 
 * *Request (object):*
 ** *`calendar_id` (Optional, string)*: A string that uniquely identifies a calendar. You can get information for multiple calendars by using a list of ids or a wildcard expression. You can get information for all calendars by using `_all` or `*` or by omitting the calendar identifier.
+** *`page` (Optional, { from, size })*: This object is supported only when you omit the calendar identifier.
 ** *`from` (Optional, number)*: Skips the specified number of calendars. This parameter is supported only when you omit the calendar identifier.
 ** *`size` (Optional, number)*: Specifies the maximum number of calendars to obtain. This parameter is supported only when you omit the calendar identifier.
-** *`page` (Optional, { from, size })*: This object is supported only when you omit the calendar identifier.
 
 [discrete]
 ==== get_categories
@@ -5017,10 +5067,10 @@ neither the category ID nor the partition_field_value, the API returns
 information about all categories. If you specify only the
 partition_field_value, it returns information about all categories for
 the specified partition.
+** *`page` (Optional, { from, size })*
 ** *`from` (Optional, number)*: Skips the specified number of categories.
 ** *`partition_field_value` (Optional, string)*: Only return categories for the specified partition.
 ** *`size` (Optional, number)*: Specifies the maximum number of categories to obtain.
-** *`page` (Optional, { from, size })*
 
 [discrete]
 ==== get_data_frame_analytics
@@ -5180,6 +5230,7 @@ client.ml.getInfluencers({ job_id })
 
 * *Request (object):*
 ** *`job_id` (string)*: Identifier for the anomaly detection job.
+** *`page` (Optional, { from, size })*
 ** *`desc` (Optional, boolean)*: If true, the results are sorted in descending order.
 ** *`end` (Optional, string | Unit)*: Returns influencers with timestamps earlier than this time.
 The default value means it is unset and results are not limited to
@@ -5194,7 +5245,6 @@ value.
 influencers are sorted by the `influencer_score` value.
 ** *`start` (Optional, string | Unit)*: Returns influencers with timestamps after this time. The default value
 means it is unset and results are not limited to specific timestamps.
-** *`page` (Optional, { from, size })*
 
 [discrete]
 ==== get_job_stats
@@ -5325,14 +5375,13 @@ client.ml.getModelSnapshots({ job_id })
 ** *`snapshot_id` (Optional, string)*: A numerical character string that uniquely identifies the model snapshot. You can get information for multiple
 snapshots by using a list or a wildcard expression. You can get all snapshots by using `_all`,
 by specifying `*` as the snapshot ID, or by omitting the snapshot ID.
-** *`desc` (Optional, boolean)*: If true, the results are sorted in descending order.
-** *`end` (Optional, string | Unit)*: Returns snapshots with timestamps earlier than this time.
+** *`desc` (Optional, boolean)*: Refer to the description for the `desc` query parameter.
+** *`end` (Optional, string | Unit)*: Refer to the description for the `end` query parameter.
+** *`page` (Optional, { from, size })*
+** *`sort` (Optional, string)*: Refer to the description for the `sort` query parameter.
+** *`start` (Optional, string | Unit)*: Refer to the description for the `start` query parameter.
 ** *`from` (Optional, number)*: Skips the specified number of snapshots.
 ** *`size` (Optional, number)*: Specifies the maximum number of snapshots to obtain.
-** *`sort` (Optional, string)*: Specifies the sort field for the requested snapshots. By default, the
-snapshots are sorted by their timestamp.
-** *`start` (Optional, string | Unit)*: Returns snapshots with timestamps after this time.
-** *`page` (Optional, { from, size })*
 
 [discrete]
 ==== get_overall_buckets
@@ -5354,30 +5403,13 @@ expression.
 
 You can summarize the bucket results for all anomaly detection jobs by
 using `_all` or by specifying `*` as the `<job_id>`.
-** *`allow_no_match` (Optional, boolean)*: Specifies what to do when the request:
-
-1. Contains wildcard expressions and there are no jobs that match.
-2. Contains the `_all` string or no identifiers and there are no matches.
-3. Contains wildcard expressions and there are only partial matches.
-
-If `true`, the request returns an empty `jobs` array when there are no
-matches and the subset of results when there are partial matches. If this
-parameter is `false`, the request returns a `404` status code when there
-are no matches or only partial matches.
-** *`bucket_span` (Optional, string | -1 | 0)*: The span of the overall buckets. Must be greater or equal to the largest
-bucket span of the specified anomaly detection jobs, which is the default
-value.
-
-By default, an overall bucket has a span equal to the largest bucket span
-of the specified anomaly detection jobs. To override that behavior, use
-the optional `bucket_span` parameter.
-** *`end` (Optional, string | Unit)*: Returns overall buckets with timestamps earlier than this time.
-** *`exclude_interim` (Optional, boolean)*: If `true`, the output excludes interim results.
-** *`overall_score` (Optional, number | string)*: Returns overall buckets with overall scores greater than or equal to this
-value.
-** *`start` (Optional, string | Unit)*: Returns overall buckets with timestamps after this time.
-** *`top_n` (Optional, number)*: The number of top anomaly detection job bucket scores to be used in the
-`overall_score` calculation.
+** *`allow_no_match` (Optional, boolean)*: Refer to the description for the `allow_no_match` query parameter.
+** *`bucket_span` (Optional, string | -1 | 0)*: Refer to the description for the `bucket_span` query parameter.
+** *`end` (Optional, string | Unit)*: Refer to the description for the `end` query parameter.
+** *`exclude_interim` (Optional, boolean)*: Refer to the description for the `exclude_interim` query parameter.
+** *`overall_score` (Optional, number | string)*: Refer to the description for the `overall_score` query parameter.
+** *`start` (Optional, string | Unit)*: Refer to the description for the `start` query parameter.
+** *`top_n` (Optional, number)*: Refer to the description for the `top_n` query parameter.
 
 [discrete]
 ==== get_records
@@ -5394,17 +5426,15 @@ client.ml.getRecords({ job_id })
 
 * *Request (object):*
 ** *`job_id` (string)*: Identifier for the anomaly detection job.
-** *`desc` (Optional, boolean)*: If true, the results are sorted in descending order.
-** *`end` (Optional, string | Unit)*: Returns records with timestamps earlier than this time. The default value
-means results are not limited to specific timestamps.
-** *`exclude_interim` (Optional, boolean)*: If `true`, the output excludes interim results.
-** *`from` (Optional, number)*: Skips the specified number of records.
-** *`record_score` (Optional, number)*: Returns records with anomaly scores greater or equal than this value.
-** *`size` (Optional, number)*: Specifies the maximum number of records to obtain.
-** *`sort` (Optional, string)*: Specifies the sort field for the requested records.
-** *`start` (Optional, string | Unit)*: Returns records with timestamps after this time. The default value means
-results are not limited to specific timestamps.
+** *`desc` (Optional, boolean)*: Refer to the description for the `desc` query parameter.
+** *`end` (Optional, string | Unit)*: Refer to the description for the `end` query parameter.
+** *`exclude_interim` (Optional, boolean)*: Refer to the description for the `exclude_interim` query parameter.
 ** *`page` (Optional, { from, size })*
+** *`record_score` (Optional, number)*: Refer to the description for the `record_score` query parameter.
+** *`sort` (Optional, string)*: Refer to the description for the `sort` query parameter.
+** *`start` (Optional, string | Unit)*: Refer to the description for the `start` query parameter.
+** *`from` (Optional, number)*: Skips the specified number of records.
+** *`size` (Optional, number)*: Specifies the maximum number of records to obtain.
 
 [discrete]
 ==== get_trained_models
@@ -5487,8 +5517,8 @@ client.ml.inferTrainedModel({ model_id, docs })
 ** *`docs` (Record<string, User-defined value>[])*: An array of objects to pass to the model for inference. The objects should contain a fields matching your
 configured trained model input. Typically, for NLP models, the field name is `text_field`.
 Currently, for NLP models, only a single value is allowed.
-** *`timeout` (Optional, string | -1 | 0)*: Controls the amount of time to wait for inference results.
 ** *`inference_config` (Optional, { regression, classification, text_classification, zero_shot_classification, fill_mask, ner, pass_through, text_embedding, text_expansion, question_answering })*: The inference configuration updates to apply on the API call
+** *`timeout` (Optional, string | -1 | 0)*: Controls the amount of time to wait for inference results.
 
 [discrete]
 ==== info
@@ -5516,7 +5546,7 @@ client.ml.openJob({ job_id })
 
 * *Request (object):*
 ** *`job_id` (string)*: Identifier for the anomaly detection job.
-** *`timeout` (Optional, string | -1 | 0)*: Controls the time to wait until a job has opened.
+** *`timeout` (Optional, string | -1 | 0)*: Refer to the description for the `timeout` query parameter.
 
 [discrete]
 ==== post_calendar_events
@@ -5550,6 +5580,7 @@ client.ml.postData({ job_id })
 
 * *Request (object):*
 ** *`job_id` (string)*: Identifier for the anomaly detection job. The job must have a state of open to receive and process the data.
+** *`data` (Optional, TData[])*
 ** *`reset_end` (Optional, string | Unit)*: Specifies the end of the bucket resetting range.
 ** *`reset_start` (Optional, string | Unit)*: Specifies the start of the bucket resetting range.
 
@@ -5590,13 +5621,13 @@ client.ml.previewDatafeed({ ... })
 alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric
 characters. NOTE: If you use this path parameter, you cannot provide datafeed or anomaly detection job
 configuration details in the request body.
-** *`start` (Optional, string | Unit)*: The start time from where the datafeed preview should begin
-** *`end` (Optional, string | Unit)*: The end time when the datafeed preview should stop
 ** *`datafeed_config` (Optional, { aggregations, chunking_config, datafeed_id, delayed_data_check_config, frequency, indices, indices_options, job_id, max_empty_searches, query, query_delay, runtime_mappings, script_fields, scroll_size })*: The datafeed definition to preview.
 ** *`job_config` (Optional, { allow_lazy_open, analysis_config, analysis_limits, background_persist_interval, custom_settings, daily_model_snapshot_retention_after_days, data_description, datafeed_config, description, groups, job_id, job_type, model_plot_config, model_snapshot_retention_days, renormalization_window_days, results_index_name, results_retention_days })*: The configuration details for the anomaly detection job that is associated with the datafeed. If the
 `datafeed_config` object does not include a `job_id` that references an existing anomaly detection job, you must
 supply this `job_config` object. If you include both a `job_id` and a `job_config`, the latter information is
 used. You cannot specify a `job_config` object unless you also supply a `datafeed_config` object.
+** *`start` (Optional, string | Unit)*: The start time from where the datafeed preview should begin
+** *`end` (Optional, string | Unit)*: The end time when the datafeed preview should stop
 
 [discrete]
 ==== put_calendar
@@ -5721,12 +5752,6 @@ client.ml.putDatafeed({ datafeed_id })
 ** *`datafeed_id` (string)*: A numerical character string that uniquely identifies the datafeed.
 This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
 It must start and end with alphanumeric characters.
-** *`allow_no_indices` (Optional, boolean)*: If true, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the `_all`
-string or when no indices are specified.
-** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines
-whether wildcard expressions match hidden data streams. Supports a list of values.
-** *`ignore_throttled` (Optional, boolean)*: If true, concrete, expanded, or aliased indices are ignored when frozen.
-** *`ignore_unavailable` (Optional, boolean)*: If true, unavailable indices (missing or closed) are ignored.
 ** *`aggregations` (Optional, Record<string, { aggregations, meta, adjacency_matrix, auto_date_histogram, avg, avg_bucket, boxplot, bucket_script, bucket_selector, bucket_sort, bucket_count_ks_test, bucket_correlation, cardinality, categorize_text, children, composite, cumulative_cardinality, cumulative_sum, date_histogram, date_range, derivative, diversified_sampler, extended_stats, extended_stats_bucket, frequent_item_sets, filter, filters, geo_bounds, geo_centroid, geo_distance, geohash_grid, geo_line, geotile_grid, geohex_grid, global, histogram, ip_range, ip_prefix, inference, line, matrix_stats, max, max_bucket, median_absolute_deviation, min, min_bucket, missing, moving_avg, moving_percentiles, moving_fn, multi_terms, nested, normalize, parent, percentile_ranks, percentiles, percentiles_bucket, range, rare_terms, rate, reverse_nested, sampler, scripted_metric, serial_diff, significant_terms, significant_text, stats, stats_bucket, string_stats, sum, sum_bucket, terms, top_hits, t_test, top_metrics, value_count, weighted_avg, variable_width_histogram }>)*: If set, the datafeed performs aggregation searches.
 Support for aggregations is limited and should be used only with low cardinality data.
 ** *`chunking_config` (Optional, { mode, time_span })*: Datafeeds might be required to search over long time periods, for several months or years.
@@ -5764,6 +5789,12 @@ The detector configuration objects in a job can contain functions that use these
 ** *`scroll_size` (Optional, number)*: The size parameter that is used in Elasticsearch searches when the datafeed does not use aggregations.
 The maximum value is the value of `index.max_result_window`, which is 10,000 by default.
 ** *`headers` (Optional, Record<string, string | string[]>)*
+** *`allow_no_indices` (Optional, boolean)*: If true, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the `_all`
+string or when no indices are specified.
+** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines
+whether wildcard expressions match hidden data streams. Supports a list of values.
+** *`ignore_throttled` (Optional, boolean)*: If true, concrete, expanded, or aliased indices are ignored when frozen.
+** *`ignore_unavailable` (Optional, boolean)*: If true, unavailable indices (missing or closed) are ignored.
 
 [discrete]
 ==== put_filter
@@ -5822,7 +5853,7 @@ Creates an inference trained model.
 {ref}/put-trained-models.html[Endpoint documentation]
 [source,ts]
 ----
-client.ml.putTrainedModel({ model_id, inference_config })
+client.ml.putTrainedModel({ model_id })
 ----
 
 [discrete]
@@ -5830,16 +5861,16 @@ client.ml.putTrainedModel({ model_id, inference_config })
 
 * *Request (object):*
 ** *`model_id` (string)*: The unique identifier of the trained model.
-** *`inference_config` ({ regression, classification, text_classification, zero_shot_classification, fill_mask, ner, pass_through, text_embedding, text_expansion, question_answering })*: The default configuration for inference. This can be either a regression
-or classification configuration. It must match the underlying
-definition.trained_model's target_type.
-** *`defer_definition_decompression` (Optional, boolean)*: If set to `true` and a `compressed_definition` is provided, the request defers definition decompression and skips relevant validations.
 ** *`compressed_definition` (Optional, string)*: The compressed (GZipped and Base64 encoded) inference definition of the
 model. If compressed_definition is specified, then definition cannot be
 specified.
 ** *`definition` (Optional, { preprocessors, trained_model })*: The inference definition for the model. If definition is specified, then
 compressed_definition cannot be specified.
 ** *`description` (Optional, string)*: A human-readable description of the inference trained model.
+** *`inference_config` (Optional, { regression, classification, text_classification, zero_shot_classification, fill_mask, ner, pass_through, text_embedding, text_expansion, question_answering })*: The default configuration for inference. This can be either a regression
+or classification configuration. It must match the underlying
+definition.trained_model's target_type. For pre-packaged models such as
+ELSER the config is not required.
 ** *`input` (Optional, { field_names })*: The input field names for the model definition.
 ** *`metadata` (Optional, User-defined value)*: An object map that contains metadata about the model.
 ** *`model_type` (Optional, Enum("tree_ensemble" | "lang_ident" | "pytorch"))*: The model type.
@@ -5847,6 +5878,7 @@ compressed_definition cannot be specified.
 This property is supported only if defer_definition_decompression is true
 or the model definition is not supplied.
 ** *`tags` (Optional, string[])*: An array of tags to organize the model.
+** *`defer_definition_decompression` (Optional, boolean)*: If set to `true` and a `compressed_definition` is provided, the request defers definition decompression and skips relevant validations.
 
 [discrete]
 ==== put_trained_model_alias
@@ -5946,12 +5978,7 @@ client.ml.revertModelSnapshot({ job_id, snapshot_id })
 ** *`snapshot_id` (string)*: You can specify `empty` as the <snapshot_id>. Reverting to the empty
 snapshot means the anomaly detection job starts learning a new model from
 scratch when it is started.
-** *`delete_intervening_results` (Optional, boolean)*: If true, deletes the results in the time period between the latest
-results and the time of the reverted snapshot. It also resets the model
-to accept records for this time period. If you choose not to delete
-intervening results when reverting a snapshot, the job will not accept
-input data that is older than the current time. If you want to resend
-data, then delete the intervening results.
+** *`delete_intervening_results` (Optional, boolean)*: Refer to the description for the `delete_intervening_results` query parameter.
 
 [discrete]
 ==== set_upgrade_mode
@@ -6009,24 +6036,9 @@ client.ml.startDatafeed({ datafeed_id })
 ** *`datafeed_id` (string)*: A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase
 alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric
 characters.
-** *`end` (Optional, string | Unit)*: The time that the datafeed should end, which can be specified by using one of the following formats:
-
-* ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`
-* ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`
-* Milliseconds since the epoch, for example `1485061200000`
-
-Date-time arguments using either of the ISO 8601 formats must have a time zone designator, where `Z` is accepted
-as an abbreviation for UTC time. When a URL is expected (for example, in browsers), the `+` used in time zone
-designators must be encoded as `%2B`.
-The end time value is exclusive. If you do not specify an end time, the datafeed
-runs continuously.
-** *`start` (Optional, string | Unit)*: The time that the datafeed should begin, which can be specified by using the same formats as the `end` parameter.
-This value is inclusive.
-If you do not specify a start time and the datafeed is associated with a new anomaly detection job, the analysis
-starts from the earliest time for which data is available.
-If you restart a stopped datafeed and specify a start value that is earlier than the timestamp of the latest
-processed record, the datafeed continues from 1 millisecond after the timestamp of the latest processed record.
-** *`timeout` (Optional, string | -1 | 0)*: Specifies the amount of time to wait until a datafeed starts.
+** *`end` (Optional, string | Unit)*: Refer to the description for the `end` query parameter.
+** *`start` (Optional, string | Unit)*: Refer to the description for the `start` query parameter.
+** *`timeout` (Optional, string | -1 | 0)*: Refer to the description for the `timeout` query parameter.
 
 [discrete]
 ==== start_trained_model_deployment
@@ -6112,17 +6124,9 @@ client.ml.stopDatafeed({ datafeed_id })
 ** *`datafeed_id` (string)*: Identifier for the datafeed. You can stop multiple datafeeds in a single API request by using a comma-separated
 list of datafeeds or a wildcard expression. You can close all datafeeds by using `_all` or by specifying `*` as
 the identifier.
-** *`allow_no_match` (Optional, boolean)*: Specifies what to do when the request:
-
-* Contains wildcard expressions and there are no datafeeds that match.
-* Contains the `_all` string or no identifiers and there are no matches.
-* Contains wildcard expressions and there are only partial matches.
-
-If `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when
-there are partial matches. If `false`, the API returns a 404 status code when there are no matches or only
-partial matches.
-** *`force` (Optional, boolean)*: If `true`, the datafeed is stopped forcefully.
-** *`timeout` (Optional, string | -1 | 0)*: Specifies the amount of time to wait until a datafeed stops.
+** *`allow_no_match` (Optional, boolean)*: Refer to the description for the `allow_no_match` query parameter.
+** *`force` (Optional, boolean)*: Refer to the description for the `force` query parameter.
+** *`timeout` (Optional, string | -1 | 0)*: Refer to the description for the `timeout` query parameter.
 
 [discrete]
 ==== stop_trained_model_deployment
@@ -6193,18 +6197,6 @@ client.ml.updateDatafeed({ datafeed_id })
 ** *`datafeed_id` (string)*: A numerical character string that uniquely identifies the datafeed.
 This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
 It must start and end with alphanumeric characters.
-** *`allow_no_indices` (Optional, boolean)*: If `true`, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the
-`_all` string or when no indices are specified.
-** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines
-whether wildcard expressions match hidden data streams. Supports a list of values. Valid values are:
-
-* `all`: Match any data stream or index, including hidden ones.
-* `closed`: Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed.
-* `hidden`: Match hidden data streams and hidden indices. Must be combined with `open`, `closed`, or both.
-* `none`: Wildcard patterns are not accepted.
-* `open`: Match open, non-hidden indices. Also matches any non-hidden data stream.
-** *`ignore_throttled` (Optional, boolean)*: If `true`, concrete, expanded or aliased indices are ignored when frozen.
-** *`ignore_unavailable` (Optional, boolean)*: If `true`, unavailable indices (missing or closed) are ignored.
 ** *`aggregations` (Optional, Record<string, { aggregations, meta, adjacency_matrix, auto_date_histogram, avg, avg_bucket, boxplot, bucket_script, bucket_selector, bucket_sort, bucket_count_ks_test, bucket_correlation, cardinality, categorize_text, children, composite, cumulative_cardinality, cumulative_sum, date_histogram, date_range, derivative, diversified_sampler, extended_stats, extended_stats_bucket, frequent_item_sets, filter, filters, geo_bounds, geo_centroid, geo_distance, geohash_grid, geo_line, geotile_grid, geohex_grid, global, histogram, ip_range, ip_prefix, inference, line, matrix_stats, max, max_bucket, median_absolute_deviation, min, min_bucket, missing, moving_avg, moving_percentiles, moving_fn, multi_terms, nested, normalize, parent, percentile_ranks, percentiles, percentiles_bucket, range, rare_terms, rate, reverse_nested, sampler, scripted_metric, serial_diff, significant_terms, significant_text, stats, stats_bucket, string_stats, sum, sum_bucket, terms, top_hits, t_test, top_metrics, value_count, weighted_avg, variable_width_histogram }>)*: If set, the datafeed performs aggregation searches. Support for aggregations is limited and should be used only
 with low cardinality data.
 ** *`chunking_config` (Optional, { mode, time_span })*: Datafeeds might search over long time periods, for several months or years. This search is split into time
@@ -6244,6 +6236,18 @@ when there are multiple jobs running on the same node.
 The detector configuration objects in a job can contain functions that use these script fields.
 ** *`scroll_size` (Optional, number)*: The size parameter that is used in Elasticsearch searches when the datafeed does not use aggregations.
 The maximum value is the value of `index.max_result_window`.
+** *`allow_no_indices` (Optional, boolean)*: If `true`, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the
+`_all` string or when no indices are specified.
+** *`expand_wildcards` (Optional, Enum("all" | "open" | "closed" | "hidden" | "none") | Enum("all" | "open" | "closed" | "hidden" | "none")[])*: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines
+whether wildcard expressions match hidden data streams. Supports a list of values. Valid values are:
+
+* `all`: Match any data stream or index, including hidden ones.
+* `closed`: Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed.
+* `hidden`: Match hidden data streams and hidden indices. Must be combined with `open`, `closed`, or both.
+* `none`: Wildcard patterns are not accepted.
+* `open`: Match open, non-hidden indices. Also matches any non-hidden data stream.
+** *`ignore_throttled` (Optional, boolean)*: If `true`, concrete, expanded or aliased indices are ignored when frozen.
+** *`ignore_unavailable` (Optional, boolean)*: If `true`, unavailable indices (missing or closed) are ignored.
 
 [discrete]
 ==== update_filter
@@ -6481,8 +6485,8 @@ client.nodes.reloadSecureSettings({ ... })
 
 * *Request (object):*
 ** *`node_id` (Optional, string | string[])*: A list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.
-** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
 ** *`secure_settings_password` (Optional, string)*
+** *`timeout` (Optional, string | -1 | 0)*: Explicit operation timeout
 
 [discrete]
 ==== stats
@@ -6652,11 +6656,11 @@ client.rollup.rollupSearch({ index })
 
 * *Request (object):*
 ** *`index` (string | string[])*: The indices or index-pattern(s) (containing rollup or regular data) that should be searched
-** *`rest_total_hits_as_int` (Optional, boolean)*: Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-** *`typed_keys` (Optional, boolean)*: Specify whether aggregation and suggester names should be prefixed by their respective types in the response
 ** *`aggregations` (Optional, Record<string, { aggregations, meta, adjacency_matrix, auto_date_histogram, avg, avg_bucket, boxplot, bucket_script, bucket_selector, bucket_sort, bucket_count_ks_test, bucket_correlation, cardinality, categorize_text, children, composite, cumulative_cardinality, cumulative_sum, date_histogram, date_range, derivative, diversified_sampler, extended_stats, extended_stats_bucket, frequent_item_sets, filter, filters, geo_bounds, geo_centroid, geo_distance, geohash_grid, geo_line, geotile_grid, geohex_grid, global, histogram, ip_range, ip_prefix, inference, line, matrix_stats, max, max_bucket, median_absolute_deviation, min, min_bucket, missing, moving_avg, moving_percentiles, moving_fn, multi_terms, nested, normalize, parent, percentile_ranks, percentiles, percentiles_bucket, range, rare_terms, rate, reverse_nested, sampler, scripted_metric, serial_diff, significant_terms, significant_text, stats, stats_bucket, string_stats, sum, sum_bucket, terms, top_hits, t_test, top_metrics, value_count, weighted_avg, variable_width_histogram }>)*
 ** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*
 ** *`size` (Optional, number)*: Must be zero if set, as rollups work on pre-aggregated data
+** *`rest_total_hits_as_int` (Optional, boolean)*: Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+** *`typed_keys` (Optional, boolean)*: Specify whether aggregation and suggester names should be prefixed by their respective types in the response
 
 [discrete]
 ==== start_job
@@ -6802,6 +6806,7 @@ client.searchApplication.put({ name })
 
 * *Request (object):*
 ** *`name` (string)*: The name of the search application to be created or updated
+** *`search_application` (Optional, { name, indices, updated_at_millis, analytics_collection_name, template })*
 ** *`create` (Optional, boolean)*: If true, requires that a search application with the specified resource_id does not already exist. (default: false)
 
 [discrete]
@@ -6905,12 +6910,12 @@ client.searchableSnapshots.mount({ repository, snapshot, index })
 ** *`repository` (string)*: The name of the repository containing the snapshot of the index to mount
 ** *`snapshot` (string)*: The name of the snapshot of the index to mount
 ** *`index` (string)*
-** *`master_timeout` (Optional, string | -1 | 0)*: Explicit operation timeout for connection to master node
-** *`wait_for_completion` (Optional, boolean)*: Should this request wait until the operation has completed before returning
-** *`storage` (Optional, string)*: Selects the kind of local storage used to accelerate searches. Experimental, and defaults to `full_copy`
 ** *`renamed_index` (Optional, string)*
 ** *`index_settings` (Optional, Record<string, User-defined value>)*
 ** *`ignore_index_settings` (Optional, string[])*
+** *`master_timeout` (Optional, string | -1 | 0)*: Explicit operation timeout for connection to master node
+** *`wait_for_completion` (Optional, boolean)*: Should this request wait until the operation has completed before returning
+** *`storage` (Optional, string)*: Selects the kind of local storage used to accelerate searches. Experimental, and defaults to `full_copy`
 
 [discrete]
 ==== stats
@@ -6969,12 +6974,12 @@ client.security.changePassword({ ... })
 * *Request (object):*
 ** *`username` (Optional, string)*: The user whose password you want to change. If you do not specify this
 parameter, the password is changed for the current user.
-** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 ** *`password` (Optional, string)*: The new password value. Passwords must be at least 6 characters long.
 ** *`password_hash` (Optional, string)*: A hash of the new password value. This must be produced using the same
 hashing algorithm as has been configured for password storage. For more details,
 see the explanation of the `xpack.security.authc.password_hashing.algorithm`
 setting.
+** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 
 [discrete]
 ==== clear_api_key_cache
@@ -7073,11 +7078,11 @@ client.security.createApiKey({ ... })
 ==== Arguments
 
 * *Request (object):*
-** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 ** *`expiration` (Optional, string | -1 | 0)*: Expiration time for the API key. By default, API keys never expire.
 ** *`name` (Optional, string)*: Specifies the name for this API key.
 ** *`role_descriptors` (Optional, Record<string, { cluster, indices, global, applications, metadata, run_as, transient_metadata }>)*: An array of role descriptors for this API key. This parameter is optional. When it is not specified or is an empty array, then the API key will have a point in time snapshot of permissions of the authenticated user. If you supply role descriptors then the resultant permissions would be an intersection of API keys permissions and authenticated user’s permissions thereby limiting the access scope for API keys. The structure of role descriptor is the same as the request for create role API. For more details, see create or update roles API.
 ** *`metadata` (Optional, Record<string, User-defined value>)*: Arbitrary metadata that you want to associate with the API key. It supports nested data structure. Within the metadata object, keys beginning with _ are reserved for system usage.
+** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 
 [discrete]
 ==== create_cross_cluster_api_key
@@ -7554,6 +7559,7 @@ client.security.putPrivileges({ ... })
 ==== Arguments
 
 * *Request (object):*
+** *`privileges` (Optional, Record<string, Record<string, User-defined value>>)*
 ** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 
 [discrete]
@@ -7571,7 +7577,6 @@ client.security.putRole({ name })
 
 * *Request (object):*
 ** *`name` (string)*: The name of the role.
-** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 ** *`applications` (Optional, { application, privileges, resources }[])*: A list of application privilege entries.
 ** *`cluster` (Optional, Enum("all" | "cancel_task" | "create_snapshot" | "grant_api_key" | "manage" | "manage_api_key" | "manage_ccr" | "manage_enrich" | "manage_ilm" | "manage_index_templates" | "manage_ingest_pipelines" | "manage_logstash_pipelines" | "manage_ml" | "manage_oidc" | "manage_own_api_key" | "manage_pipeline" | "manage_rollup" | "manage_saml" | "manage_security" | "manage_service_account" | "manage_slm" | "manage_token" | "manage_transform" | "manage_user_profile" | "manage_watcher" | "monitor" | "monitor_ml" | "monitor_rollup" | "monitor_snapshot" | "monitor_text_structure" | "monitor_transform" | "monitor_watcher" | "read_ccr" | "read_ilm" | "read_pipeline" | "read_slm" | "transport_client")[])*: A list of cluster privileges. These privileges define the cluster-level actions for users with this role.
 ** *`global` (Optional, Record<string, User-defined value>)*: An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.
@@ -7579,6 +7584,7 @@ client.security.putRole({ name })
 ** *`metadata` (Optional, Record<string, User-defined value>)*: Optional metadata. Within the metadata object, keys that begin with an underscore (`_`) are reserved for system use.
 ** *`run_as` (Optional, string[])*: A list of users that the owners of this role can impersonate.
 ** *`transient_metadata` (Optional, { enabled })*: Indicates roles that might be incompatible with the current cluster license, specifically roles with document and field level security. When the cluster license doesn’t allow certain features for a given role, this parameter is updated dynamically to list the incompatible features. If `enabled` is `false`, the role is ignored, but is still listed in the response from the authenticate API.
+** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 
 [discrete]
 ==== put_role_mapping
@@ -7595,12 +7601,12 @@ client.security.putRoleMapping({ name })
 
 * *Request (object):*
 ** *`name` (string)*: Role-mapping name
-** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 ** *`enabled` (Optional, boolean)*
 ** *`metadata` (Optional, Record<string, User-defined value>)*
 ** *`roles` (Optional, string[])*
 ** *`rules` (Optional, { any, all, field, except })*
 ** *`run_as` (Optional, string[])*
+** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 
 [discrete]
 ==== put_user
@@ -7617,7 +7623,6 @@ client.security.putUser({ username })
 
 * *Request (object):*
 ** *`username` (string)*: The username of the User
-** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 ** *`email` (Optional, string | null)*
 ** *`full_name` (Optional, string | null)*
 ** *`metadata` (Optional, Record<string, User-defined value>)*
@@ -7625,6 +7630,7 @@ client.security.putUser({ username })
 ** *`password_hash` (Optional, string)*
 ** *`roles` (Optional, string[])*
 ** *`enabled` (Optional, boolean)*
+** *`refresh` (Optional, Enum(true | false | "wait_for"))*: If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
 
 [discrete]
 ==== query_api_keys
@@ -7640,10 +7646,6 @@ client.security.queryApiKeys({ ... })
 ==== Arguments
 
 * *Request (object):*
-** *`with_limited_by` (Optional, boolean)*: Return the snapshot of the owner user's role descriptors
-associated with the API key. An API key's actual
-permission is the intersection of its assigned role
-descriptors and the owner user's role descriptors.
 ** *`query` (Optional, { bool, boosting, common, combined_fields, constant_score, dis_max, distance_feature, exists, function_score, fuzzy, geo_bounding_box, geo_distance, geo_polygon, geo_shape, has_child, has_parent, ids, intervals, match, match_all, match_bool_prefix, match_none, match_phrase, match_phrase_prefix, more_like_this, multi_match, nested, parent_id, percolate, pinned, prefix, query_string, range, rank_feature, regexp, script, script_score, shape, simple_query_string, span_containing, field_masking_span, span_first, span_multi, span_near, span_not, span_or, span_term, span_within, term, terms, terms_set, text_expansion, wildcard, wrapper, type })*: A query to filter which API keys to return.
 The query supports a subset of query types, including match_all, bool, term, terms, ids, prefix, wildcard, and range.
 You can query all public information associated with an API key
@@ -7655,6 +7657,10 @@ search_after parameter.
 than 10,000 hits using the from and size parameters. To page through more
 hits, use the search_after parameter.
 ** *`search_after` (Optional, number | number | string | boolean | null | User-defined value[])*
+** *`with_limited_by` (Optional, boolean)*: Return the snapshot of the owner user's role descriptors
+associated with the API key. An API key's actual
+permission is the intersection of its assigned role
+descriptors and the owner user's role descriptors.
 
 [discrete]
 ==== saml_authenticate
@@ -7898,13 +7904,13 @@ client.slm.putLifecycle({ policy_id })
 
 * *Request (object):*
 ** *`policy_id` (string)*: ID for the snapshot lifecycle policy you want to create or update.
-** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
-** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
 ** *`config` (Optional, { ignore_unavailable, indices, include_global_state, feature_states, metadata, partial })*: Configuration for each snapshot created by the policy.
 ** *`name` (Optional, string)*: Name automatically assigned to each snapshot created by the policy. Date math is supported. To prevent conflicting snapshot names, a UUID is automatically appended to each snapshot name.
 ** *`repository` (Optional, string)*: Repository used to store snapshots created by this policy. This repository must exist prior to the policy’s creation. You can create a repository using the snapshot repository API.
 ** *`retention` (Optional, { expire_after, max_count, min_count })*: Retention rules used to retain and delete snapshots created by the policy.
 ** *`schedule` (Optional, string)*: Periodic or absolute schedule at which the policy creates snapshots. SLM applies schedule changes immediately.
+** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
+** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
 
 [discrete]
 ==== start
@@ -7985,14 +7991,14 @@ client.snapshot.create({ repository, snapshot })
 * *Request (object):*
 ** *`repository` (string)*: Repository for the snapshot.
 ** *`snapshot` (string)*: Name of the snapshot. Must be unique in the repository.
-** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
-** *`wait_for_completion` (Optional, boolean)*: If `true`, the request returns a response when the snapshot is complete. If `false`, the request returns a response when the snapshot initializes.
 ** *`ignore_unavailable` (Optional, boolean)*: If `true`, the request ignores data streams and indices in `indices` that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed.
 ** *`include_global_state` (Optional, boolean)*: If `true`, the current cluster state is included in the snapshot. The cluster state includes persistent cluster settings, composable index templates, legacy index templates, ingest pipelines, and ILM policies. It also includes data stored in system indices, such as Watches and task records (configurable via `feature_states`).
 ** *`indices` (Optional, string | string[])*: Data streams and indices to include in the snapshot. Supports multi-target syntax. Includes all data streams and indices by default.
 ** *`feature_states` (Optional, string[])*: Feature states to include in the snapshot. Each feature state includes one or more system indices containing related data. You can view a list of eligible features using the get features API. If `include_global_state` is `true`, all current feature states are included by default. If `include_global_state` is `false`, no feature states are included by default.
 ** *`metadata` (Optional, Record<string, User-defined value>)*: Optional metadata for the snapshot. May have any contents. Must be less than 1024 bytes. This map is not automatically generated by Elasticsearch.
 ** *`partial` (Optional, boolean)*: If `true`, allows restoring a partial snapshot of indices with unavailable shards. Only shards that were successfully included in the snapshot will be restored. All missing shards will be recreated as empty. If `false`, the entire restore operation will fail if one or more indices included in the snapshot do not have all primary shards available.
+** *`master_timeout` (Optional, string | -1 | 0)*: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
+** *`wait_for_completion` (Optional, boolean)*: If `true`, the request returns a response when the snapshot is complete. If `false`, the request returns a response when the snapshot initializes.
 
 [discrete]
 ==== create_repository
@@ -8128,8 +8134,6 @@ client.snapshot.restore({ repository, snapshot })
 * *Request (object):*
 ** *`repository` (string)*: A repository name
 ** *`snapshot` (string)*: A snapshot name
-** *`master_timeout` (Optional, string | -1 | 0)*: Explicit operation timeout for connection to master node
-** *`wait_for_completion` (Optional, boolean)*: Should this request wait until the operation has completed before returning
 ** *`feature_states` (Optional, string[])*
 ** *`ignore_index_settings` (Optional, string[])*
 ** *`ignore_unavailable` (Optional, boolean)*
@@ -8140,6 +8144,8 @@ client.snapshot.restore({ repository, snapshot })
 ** *`partial` (Optional, boolean)*
 ** *`rename_pattern` (Optional, string)*
 ** *`rename_replacement` (Optional, string)*
+** *`master_timeout` (Optional, string | -1 | 0)*: Explicit operation timeout for connection to master node
+** *`wait_for_completion` (Optional, boolean)*: Should this request wait until the operation has completed before returning
 
 [discrete]
 ==== status
@@ -8265,7 +8271,6 @@ client.sql.query({ ... })
 ==== Arguments
 
 * *Request (object):*
-** *`format` (Optional, string)*: a short version of the Accept header, e.g. json, yaml
 ** *`catalog` (Optional, string)*: Default catalog (cluster) for queries. If unspecified, the queries execute on the data in the local cluster only.
 ** *`columnar` (Optional, boolean)*: If true, the results in a columnar fashion: one row represents all the values of a certain column from the current page of results.
 ** *`cursor` (Optional, string)*
@@ -8283,6 +8288,7 @@ precedence over mapped fields with the same name.
 ** *`keep_alive` (Optional, string | -1 | 0)*: Retention period for an async or saved synchronous search.
 ** *`keep_on_completion` (Optional, boolean)*: If true, Elasticsearch stores synchronous searches if you also specify the wait_for_completion_timeout parameter. If false, Elasticsearch only stores async searches that don’t finish before the wait_for_completion_timeout.
 ** *`index_using_frozen` (Optional, boolean)*: If true, the search can run on frozen indices. Defaults to false.
+** *`format` (Optional, string)*: a short version of the Accept header, e.g. json, yaml
 
 [discrete]
 ==== translate
@@ -8430,6 +8436,7 @@ client.textStructure.findStructure({ ... })
 ==== Arguments
 
 * *Request (object):*
+** *`text_files` (Optional, TJsonDocument[])*
 ** *`charset` (Optional, string)*: The text’s character set. It must be a character set that is supported by the JVM that Elasticsearch uses. For example, UTF-8, UTF-16LE, windows-1252, or EUC-JP. If this parameter is not specified, the structure finder chooses an appropriate character set.
 ** *`column_names` (Optional, string)*: If you have set format to delimited, you can specify the column names in a list. If this parameter is not specified, the structure finder uses the column names from the header row of the text. If the text does not have a header role, columns are named "column1", "column2", "column3", etc.
 ** *`delimiter` (Optional, string)*: If you have set format to delimited, you can specify the character used to delimit the values in each row. Only a single character is supported; the delimiter cannot have multiple characters. By default, the API considers the following possibilities: comma, tab, semi-colon, and pipe (|). In this default scenario, all rows must have the same number of fields for the delimited format to be detected. If you specify a delimiter, up to 10% of the rows can have a different number of columns than the first row.
@@ -8544,8 +8551,6 @@ client.transform.previewTransform({ ... })
 * *Request (object):*
 ** *`transform_id` (Optional, string)*: Identifier for the transform to preview. If you specify this path parameter, you cannot provide transform
 configuration details in the request body.
-** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the
-timeout expires, the request fails and returns an error.
 ** *`dest` (Optional, { index, op_type, pipeline, routing, version_type })*: The destination for the transform.
 ** *`description` (Optional, string)*: Free text description of the transform.
 ** *`frequency` (Optional, string | -1 | 0)*: The interval between checks for changes in the source indices when the
@@ -8562,6 +8567,8 @@ the data.
 criteria is deleted from the destination index.
 ** *`latest` (Optional, { sort, unique_key })*: The latest method transforms the data by finding the latest document for
 each unique key.
+** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the
+timeout expires, the request fails and returns an error.
 
 [discrete]
 ==== put_transform
@@ -8581,12 +8588,6 @@ client.transform.putTransform({ transform_id, dest, source })
 hyphens, and underscores. It has a 64 character limit and must start and end with alphanumeric characters.
 ** *`dest` ({ index, op_type, pipeline, routing, version_type })*: The destination for the transform.
 ** *`source` ({ index, query, remote, size, slice, sort, _source, runtime_mappings })*: The source of the data for the transform.
-** *`defer_validation` (Optional, boolean)*: When the transform is created, a series of validations occur to ensure its success. For example, there is a
-check for the existence of the source indices and a check that the destination index is not part of the source
-index pattern. You can use this parameter to skip the checks, for example when the source index does not exist
-until after the transform is created. The validations are always run when you start the transform, however, with
-the exception of privilege checks.
-** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
 ** *`description` (Optional, string)*: Free text description of the transform.
 ** *`frequency` (Optional, string | -1 | 0)*: The interval between checks for changes in the source indices when the transform is running continuously. Also
 determines the retry interval in the event of transient failures while the transform is searching or indexing.
@@ -8599,6 +8600,12 @@ and the aggregation to reduce the data.
 destination index.
 ** *`settings` (Optional, { align_checkpoints, dates_as_epoch_millis, deduce_mappings, docs_per_second, max_page_search_size, unattended })*: Defines optional transform settings.
 ** *`sync` (Optional, { time })*: Defines the properties transforms require to run continuously.
+** *`defer_validation` (Optional, boolean)*: When the transform is created, a series of validations occur to ensure its success. For example, there is a
+check for the existence of the source indices and a check that the destination index is not part of the source
+index pattern. You can use this parameter to skip the checks, for example when the source index does not exist
+until after the transform is created. The validations are always run when you start the transform, however, with
+the exception of privilege checks.
+** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
 
 [discrete]
 ==== reset_transform
@@ -8702,11 +8709,6 @@ client.transform.updateTransform({ transform_id })
 
 * *Request (object):*
 ** *`transform_id` (string)*: Identifier for the transform.
-** *`defer_validation` (Optional, boolean)*: When true, deferrable validations are not run. This behavior may be
-desired if the source index does not exist until after the transform is
-created.
-** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the
-timeout expires, the request fails and returns an error.
 ** *`dest` (Optional, { index, op_type, pipeline, routing, version_type })*: The destination for the transform.
 ** *`description` (Optional, string)*: Free text description of the transform.
 ** *`frequency` (Optional, string | -1 | 0)*: The interval between checks for changes in the source indices when the
@@ -8719,6 +8721,11 @@ indexing. The minimum value is 1s and the maximum is 1h.
 ** *`sync` (Optional, { time })*: Defines the properties transforms require to run continuously.
 ** *`retention_policy` (Optional, { time } | null)*: Defines a retention policy for the transform. Data that meets the defined
 criteria is deleted from the destination index.
+** *`defer_validation` (Optional, boolean)*: When true, deferrable validations are not run. This behavior may be
+desired if the source index does not exist until after the transform is
+created.
+** *`timeout` (Optional, string | -1 | 0)*: Period to wait for a response. If no response is received before the
+timeout expires, the request fails and returns an error.
 
 [discrete]
 ==== upgrade_transforms
@@ -8820,7 +8827,6 @@ client.watcher.executeWatch({ ... })
 
 * *Request (object):*
 ** *`id` (Optional, string)*: Identifier for the watch.
-** *`debug` (Optional, boolean)*: Defines whether the watch runs in debug mode.
 ** *`action_modes` (Optional, Record<string, Enum("simulate" | "force_simulate" | "execute" | "force_execute" | "skip")>)*: Determines how to handle the watch actions as part of the watch execution.
 ** *`alternative_input` (Optional, Record<string, User-defined value>)*: When present, the watch uses this object as a payload instead of executing its own input.
 ** *`ignore_condition` (Optional, boolean)*: When set to `true`, the watch execution uses the always condition. This can also be specified as an HTTP parameter.
@@ -8828,6 +8834,7 @@ client.watcher.executeWatch({ ... })
 ** *`simulated_actions` (Optional, { actions, all, use_all })*
 ** *`trigger_data` (Optional, { scheduled_time, triggered_time })*: This structure is parsed as the data of the trigger event that will be used during the watch execution
 ** *`watch` (Optional, { actions, condition, input, metadata, status, throttle_period, throttle_period_in_millis, transform, trigger })*: When present, this watch is used instead of the one specified in the request. This watch is not persisted to the index and record_execution cannot be set.
+** *`debug` (Optional, boolean)*: Defines whether the watch runs in debug mode.
 
 [discrete]
 ==== get_settings
@@ -8871,10 +8878,6 @@ client.watcher.putWatch({ id })
 
 * *Request (object):*
 ** *`id` (string)*: Watch ID
-** *`active` (Optional, boolean)*: Specify whether the watch is in/active by default
-** *`if_primary_term` (Optional, number)*: only update the watch if the last operation that has changed the watch has the specified primary term
-** *`if_seq_no` (Optional, number)*: only update the watch if the last operation that has changed the watch has the specified sequence number
-** *`version` (Optional, number)*: Explicit version number for concurrency control
 ** *`actions` (Optional, Record<string, { add_backing_index, remove_backing_index }>)*
 ** *`condition` (Optional, { always, array_compare, compare, never, script })*
 ** *`input` (Optional, { chain, http, search, simple })*
@@ -8882,6 +8885,10 @@ client.watcher.putWatch({ id })
 ** *`throttle_period` (Optional, string)*
 ** *`transform` (Optional, { chain, script, search })*
 ** *`trigger` (Optional, { schedule })*
+** *`active` (Optional, boolean)*: Specify whether the watch is in/active by default
+** *`if_primary_term` (Optional, number)*: only update the watch if the last operation that has changed the watch has the specified primary term
+** *`if_seq_no` (Optional, number)*: only update the watch if the last operation that has changed the watch has the specified sequence number
+** *`version` (Optional, number)*: Explicit version number for concurrency control
 
 [discrete]
 ==== query_watches

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -13891,7 +13891,7 @@ export interface MlPutTrainedModelRequest extends RequestBase {
   compressed_definition?: string
   definition?: MlPutTrainedModelDefinition
   description?: string
-  inference_config: MlInferenceConfigCreateContainer
+  inference_config?: MlInferenceConfigCreateContainer
   input?: MlPutTrainedModelInput
   metadata?: any
   model_type?: MlTrainedModelType

--- a/src/api/typesWithBodyKey.ts
+++ b/src/api/typesWithBodyKey.ts
@@ -14147,7 +14147,7 @@ export interface MlPutTrainedModelRequest extends RequestBase {
     compressed_definition?: string
     definition?: MlPutTrainedModelDefinition
     description?: string
-    inference_config: MlInferenceConfigCreateContainer
+    inference_config?: MlInferenceConfigCreateContainer
     input?: MlPutTrainedModelInput
     metadata?: any
     model_type?: MlTrainedModelType


### PR DESCRIPTION
Noticed that properties in the `body` were not being included in the generated API reference docs when I added argument-level docs.
