### PR TITLE
Fix: Implements generic aggregations for multisearch

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -702,13 +702,13 @@ export interface MgetResponse<TDocument = unknown> {
 
 export type MgetResponseItem<TDocument = unknown> = GetGetResult<TDocument> | MgetMultiGetError
 
-export interface MsearchMultiSearchItem<TDocument = unknown> extends SearchResponseBody<TDocument> {
+export interface MsearchMultiSearchItem<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> extends SearchResponseBody<TDocument, TAggregations> {
   status?: integer
 }
 
-export interface MsearchMultiSearchResult<TDocument = unknown> {
+export interface MsearchMultiSearchResult<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> {
   took: long
-  responses: MsearchResponseItem<TDocument>[]
+  responses: MsearchResponseItem<TDocument, TAggregations>[]
 }
 
 export interface MsearchMultisearchBody {
@@ -779,9 +779,9 @@ export interface MsearchRequest extends RequestBase {
 
 export type MsearchRequestItem = MsearchMultisearchHeader | MsearchMultisearchBody
 
-export type MsearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = MsearchMultiSearchResult<TDocument>
+export type MsearchResponse<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = MsearchMultiSearchResult<TDocument, TAggregations>
 
-export type MsearchResponseItem<TDocument = unknown> = MsearchMultiSearchItem<TDocument> | ErrorResponseBase
+export type MsearchResponseItem<TDocument = unknown, TAggregations = Record<AggregateName, AggregationsAggregate>> = MsearchMultiSearchItem<TDocument, TAggregations> | ErrorResponseBase
 
 export interface MsearchTemplateRequest extends RequestBase {
   index?: Indices


### PR DESCRIPTION
This PR fixes the following bug (#1937)
```js
import { Client } from "@elastic/elasticsearch";
import { AggregationsTermsAggregateBase } from "@elastic/elasticsearch/lib/api/types";

const client = new Client({ node: "http://localhost:9200" });

const reproduce = async () => {
  interface Doc {
    foo: string;
  }

  interface Aggregations {
    unique: AggregationsTermsAggregateBase<{ key: string }>;
  }

  const response = await client.msearch<Doc, Aggregations>({
    index: "foo",
    searches: [
      {},
      {
        query: { match_all: {} },
        aggregations: { unique: { terms: { field: "foo" } } }
      }
    ]
  });

  response.responses.map((e) => {
    if ("error" in r) return
    return e.aggregations?.unique.buckets;
    //                            ^^^^^^^
    // Property 'buckets' does not exist on type 'AggregationsAggregate'.
    // Property 'buckets' does not exist on type 'AggregationsCardinalityAggregate'.
  });
};
```
The error will go way with this commit

Similar PR: #1596