### PR TITLE
[Backport 7.17] fix: add types to exports (v7.x) (#1930)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "import": "./index.mjs"
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
     },
     "./*": "./*.js"
   },


### PR DESCRIPTION
Backport of e20ddc7e from #1930