### PR TITLE
Update codegen task to be runnable via CI

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,15 +1,24 @@
 ARG NODE_JS_VERSION=18
 FROM node:${NODE_JS_VERSION}
 
-# Create app directory
-WORKDIR /usr/src/app
+ARG BUILDER_UID=1000
+ARG BUILDER_GID=1000
+ENV BUILDER_USER elastic
+ENV BUILDER_GROUP elastic
 
-RUN apt-get clean -y
-RUN apt-get update -y
-RUN apt-get install -y zip
+# Set user permissions and directory
+RUN groupadd --system -g ${BUILDER_GID} ${BUILDER_GROUP} \
+    && useradd --system --shell /bin/bash -u ${BUILDER_UID} -g ${BUILDER_GROUP} -m elastic 1>/dev/null 2>/dev/null \
+    && mkdir -p /usr/src/elasticsearch-js \
+    && chown -R ${BUILDER_USER}:${BUILDER_GROUP} /usr/src/
+WORKDIR /usr/src/elasticsearch-js
+USER ${BUILDER_USER}:${BUILDER_GROUP}
 
 # Install app dependencies
-COPY package*.json ./
+RUN apt-get clean -y && \
+    apt-get update -y && \
+    apt-get install -y zip
+COPY --chown=$BUILDER_USER:$BUILDER_GROUP package*.json ./
 RUN npm install
 
-COPY . .
+COPY --chown=$BUILDER_USER:$BUILDER_GROUP . .

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -6,6 +6,11 @@ ARG BUILDER_GID=1000
 ENV BUILDER_USER elastic
 ENV BUILDER_GROUP elastic
 
+# install zip util
+RUN apt-get clean -y && \
+    apt-get update -y && \
+    apt-get install -y zip
+
 # Set user permissions and directory
 RUN groupadd --system -g ${BUILDER_GID} ${BUILDER_GROUP} \
     && useradd --system --shell /bin/bash -u ${BUILDER_UID} -g ${BUILDER_GROUP} -m elastic 1>/dev/null 2>/dev/null \
@@ -15,9 +20,6 @@ WORKDIR /usr/src/elasticsearch-js
 USER ${BUILDER_USER}:${BUILDER_GROUP}
 
 # Install app dependencies
-RUN apt-get clean -y && \
-    apt-get update -y && \
-    apt-get install -y zip
 COPY --chown=$BUILDER_USER:$BUILDER_GROUP package*.json ./
 RUN npm install
 

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -155,6 +155,7 @@ docker run \
   $product \
   /bin/bash -c "cd /usr/src && \
     git clone https://$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-js.git && \
+    mkdir -p /usr/src/elastic-client-generator-js/output && \
     cd /usr/src/elasticsearch-js && \
     node .ci/make.mjs --task $TASK ${TASK_ARGS[*]}"
 

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -137,15 +137,17 @@ docker build \
 echo -e "\033[34;1mINFO: running $product container\033[0m"
 
 docker run \
-  --volume "$repo:/usr/src/app" \
-  --volume "$generator:/usr/src/elastic-client-generator-js" \
-  --volume /usr/src/app/node_modules \
+  --volume "$repo:/usr/src/elasticsearch-js" \
+  --volume /usr/src/elasticsearch-js/node_modules \
   -u "$(id -u):$(id -g)" \
   --env "WORKFLOW=$WORKFLOW" \
   --name make-elasticsearch-js \
   --rm \
   $product \
-  node .ci/make.mjs --task $TASK ${TASK_ARGS[*]}
+  /bin/bash -c "cd /usr/src && \
+    git clone https://$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-js.git && \
+    cd /usr/src/elasticsearch-js && \
+    node .ci/make.mjs --task $TASK ${TASK_ARGS[*]}"
 
 # ------------------------------------------------------- #
 # Post Command tasks & checks

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -135,6 +135,8 @@ docker build \
   --file .ci/Dockerfile \
   --tag "$product" \
   --build-arg NODE_JS_VERSION="$NODE_JS_VERSION" \
+  --build-arg "BUILDER_UID=$(id -u)" \
+  --build-arg "BUILDER_GID=$(id -g)" \
   .
 
 # ------------------------------------------------------- #

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -24,7 +24,6 @@
 # ------------------------------------------------------- #
 script_path=$(dirname "$(realpath -s "$0")")
 repo=$(realpath "$script_path/../")
-generator=$(realpath "$script_path/../../elastic-client-generator-js")
 
 # shellcheck disable=SC1090
 CMD=$1

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -67,7 +67,7 @@ case $CMD in
             # fall back to branch name or `main` if no VERSION is set
             branch_name=$(git rev-parse --abbrev-ref HEAD)
             if [[ "$branch_name" =~ ^\d+\.\d+ ]]; then
-              echo -e "\033[36;1mTARGET: codegen -> No VERSION found, using branch name: \`main\`\033[0m"
+              echo -e "\033[36;1mTARGET: codegen -> No VERSION found, using branch name: \`$VERSION\`\033[0m"
               VERSION="$branch_name"
             else
               echo -e "\033[36;1mTARGET: codegen -> No VERSION found, using \`main\`\033[0m"


### PR DESCRIPTION
Updates the `codegen` task so that it can be run by CI. Tested via our manual GitHub action and it successfully created https://github.com/elastic/elasticsearch-js/pull/1943. :tada:
