### PR TITLE
Add docs for bulk helper improvement

### DIFF
--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -326,6 +326,33 @@ const result = await client.helpers.bulk({
 console.log(result)
 ----
 
+[discrete]
+==== Modifying a document before operation
+
+~Added~ ~in~ ~`v8.8.2`~
+
+If you need to modify documents in your datasource before it is sent to Elasticsearch, you can return an array in the `onDocument` function rather than an operation object. The first item in the array must be the operation object, and the second item must be the document or partial document object as you'd like it to be sent to Elasticsearch.
+
+[source,js]
+----
+const { Client } = require('@elastic/elasticsearch')
+
+const client = new Client({
+  cloud: { id: '<cloud-id>' },
+  auth: { apiKey: 'base64EncodedKey' }
+})
+const result = await client.helpers.bulk({
+  datasource: [...]
+  onDocument (doc) {
+    return [
+      { index: { _index: 'my-index' } },
+      { ...doc, favorite_color: 'mauve' },
+    ]
+  }
+})
+
+console.log(result)
+----
 
 [discrete]
 [[multi-search-helper]]

--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -281,7 +281,7 @@ helper uses those options in conjunction with the Bulk API call.
 [source,js]
 ----
 const result = await client.helpers.bulk({
-  datasource: [...]
+  datasource: [...],
   onDocument (doc) {
     return {
       index: { _index: 'my-index' }
@@ -342,7 +342,7 @@ const client = new Client({
   auth: { apiKey: 'base64EncodedKey' }
 })
 const result = await client.helpers.bulk({
-  datasource: [...]
+  datasource: [...],
   onDocument (doc) {
     return [
       { index: { _index: 'my-index' } },


### PR DESCRIPTION
Adds a section detailing how to modify documents before sending to the bulk API, using the improvement introduced in https://github.com/elastic/elasticsearch-js/pull/1732. Thanks again, @robdasilva!
