### PR TITLE
Update user agent format

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -175,7 +175,7 @@ export default class Client extends API {
       caFingerprint: null,
       agent: null,
       headers: {
-        'user-agent': `elasticsearch-js/${clientVersion} Node.js ${nodeVersion}; Transport ${transportVersion}; (${os.platform()} ${os.release()} ${os.arch()})`
+        'user-agent': `elasticsearch-js/${clientVersion} (${os.platform()} ${os.release()}-${os.arch()}; Node.js ${nodeVersion}; Transport ${transportVersion})`
       },
       nodeFilter: null,
       generateRequestId: null,


### PR DESCRIPTION
I fixed the user-agent to not be `elastic-transport-js` in https://github.com/elastic/elasticsearch-js/pull/1865, but the format was slightly inconsistent with other clients and the transport user-agent itself. Nothing drastic that will break client usage telemetry, just keeping things consistent.
