### PR TITLE
Add missing optional `status` key to `HealthReportResponse` type

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -560,6 +560,7 @@ export interface HealthReportRequest extends RequestBase {
 
 export interface HealthReportResponse {
   cluster_name: string
+  status?: HealthReportIndicatorHealthStatus
   indicators: HealthReportIndicators
 }
 


### PR DESCRIPTION
<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->

Closes elastic/elasticsearch-specification#2227 by adding the missing optional `status` key to `HealthReportResponse` type.