### PR TITLE
Upgrade transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "zx": "^7.2.2"
   },
   "dependencies": {
-    "@elastic/transport": "^8.3.2",
+    "@elastic/transport": "^8.3.3",
     "tslib": "^2.4.0"
   },
   "tap": {


### PR DESCRIPTION
Upgrade transport library to 8.3.3 to take advantage of the fix in https://github.com/elastic/elastic-transport-js/pull/69.

Do not merge until https://github.com/elastic/elastic-transport-js/pull/70 is merged and published to npm. :pray:
