### PR TITLE
Bump to 8.9.1

### DIFF
--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -2,6 +2,17 @@
 == Release notes
 
 [discrete]
+=== 8.9.1
+
+[discrete]
+==== Fixes
+
+[discrete]
+===== Upgrade Transport https://github.com/elastic/elasticsearch-js/pull/1968[#1968]
+
+Upgrades `@elastic/transport` to the latest patch release to fix https://github.com/elastic/elastic-transport-js/pull/69[a bug] that could cause the process to exit when handling malformed `HEAD` requests.
+
+[discrete]
 === 8.9.0
 
 [discrete]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/elasticsearch",
-  "version": "8.9.0",
-  "versionCanary": "8.9.0-canary.2",
+  "version": "8.9.1",
+  "versionCanary": "8.9.1-canary.1",
   "description": "The official Elasticsearch client for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Bumping patch to publish a fix from https://github.com/elastic/elasticsearch-js/pull/1968.

Canary has already been published.
