### PR TITLE
Updated project metadata to use group name

### DIFF
--- a/docs/examples/proxy/package.json
+++ b/docs/examples/proxy/package.json
@@ -8,7 +8,7 @@
     "test": "standard"
   },
   "keywords": [],
-  "author": "Tomas Della Vedova",
+  "author": "Elastic Client Library Maintainers",
   "license": "Apache-2.0",
   "dependencies": {
     "@elastic/elasticsearch": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -32,11 +32,7 @@
   ],
   "contributors": [
     {
-      "name": "Tomas Della Vedova",
-      "company": "Elastic BV"
-    },
-    {
-      "name": "Josh Mock",
+      "name": "Elastic Client Library Maintainers",
       "company": "Elastic BV"
     }
   ],


### PR DESCRIPTION
This PR replaces the names of individuals with a group name in project metadata.