### PR TITLE
Fix branch name checker for automatic codegen script

### DIFF
--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -65,11 +65,11 @@ case $CMD in
         if [ -v "$VERSION" ] || [[ -z "$VERSION" ]]; then
             # fall back to branch name or `main` if no VERSION is set
             branch_name=$(git rev-parse --abbrev-ref HEAD)
-            if [[ "$branch_name" =~ ^\d+\.\d+ ]]; then
-              echo -e "\033[36;1mTARGET: codegen -> No VERSION found, using branch name: \`$VERSION\`\033[0m"
+            if [[ "$branch_name" =~ ^[0-9]+\.[0-9]+ ]]; then
+              echo -e "\033[36;1mTARGET: codegen -> No VERSION argument found, using branch name: \`$branch_name\`\033[0m"
               VERSION="$branch_name"
             else
-              echo -e "\033[36;1mTARGET: codegen -> No VERSION found, using \`main\`\033[0m"
+              echo -e "\033[36;1mTARGET: codegen -> No VERSION argument found, using \`main\`\033[0m"
               VERSION="main"
             fi
         fi


### PR DESCRIPTION
TIL Bash doesn't support `\d` for digits in regexes. Right now, daily automated codegen for 8.8 and 8.9 branches is running as though it is on `main` instead.
