### PR TITLE
Fix codegen script for 8.8

### DIFF
--- a/.ci/make.mjs
+++ b/.ci/make.mjs
@@ -89,7 +89,7 @@ async function bump (args) {
   const pipeline = await readFile(join(import.meta.url, '..', '.buildkite', 'pipeline.yml'))
   await writeFile(
     join(import.meta.url, '..', '.buildkite', 'pipeline.yml'),
-    pipeline.replace(/STACK_VERSION: [0-9]+[0-9\.]*[0-9](?:\-SNAPSHOT)?/, `STACK_VERSION: - ${cleanVersion}-SNAPSHOT`), // eslint-disable-line
+    pipeline.replace(/STACK_VERSION: [0-9]+[0-9\.]*[0-9](?:\-SNAPSHOT)?/, `STACK_VERSION: ${cleanVersion}-SNAPSHOT`), // eslint-disable-line
     'utf8'
   )
 }
@@ -97,7 +97,7 @@ async function bump (args) {
 // this command can only be executed locally for now
 async function codegen (args) {
   assert(args.length === 1, 'Codegen task expects one parameter')
-  const [version] = args
+  const version = args[0].toString()
 
   const clientGeneratorPath = join(import.meta.url, '..', '..', 'elastic-client-generator-js')
   const isGeneratorCloned = await $`[[ -d ${clientGeneratorPath} ]]`.exitCode === 0


### PR DESCRIPTION
This change has been in main for a while but couldn't be cleanly backported to 8.8.
