### PR TITLE
[Backport 8.10] Pin untrusted Github Action to a commit hash (#1986)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,6 +11,6 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: tibdex/backport@v2
+        uses: tibdex/backport@7005ef85c4562bc23b0e9b4a9940d5922f439750
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Backport of f72d146b0ab0f50278d0a110b29a901eab5516a5 from #1986