### PR TITLE
Skip adding new nodes that aren't ready yet

### DIFF
--- a/lib/pool/BaseConnectionPool.js
+++ b/lib/pool/BaseConnectionPool.js
@@ -206,6 +206,10 @@ class BaseConnectionPool {
 
     for (let i = 0, len = ids.length; i < len; i++) {
       const node = nodes[ids[i]]
+
+      // newly-added nodes do not have http assigned yet, so skip
+      if (node.http === undefined) continue
+
       // If there is no protocol in
       // the `publish_address` new URL will throw
       // the publish_address can have two forms:

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "./*": "./*.js"
   },
   "homepage": "http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html",
-  "version": "7.17.12",
-  "versionCanary": "7.17.12-canary.1",
+  "version": "7.17.13",
+  "versionCanary": "7.17.13-canary.1",
   "keywords": [
     "elasticsearch",
     "elastic",

--- a/test/unit/base-connection-pool.test.js
+++ b/test/unit/base-connection-pool.test.js
@@ -313,6 +313,36 @@ test('API', t => {
       t.end()
     })
 
+    t.test('Should skip nodes that do not have an http property yet', t => {
+      const pool = new BaseConnectionPool({ Connection })
+      const nodes = {
+        a1: {
+          http: {
+            publish_address: '127.0.0.1:9200'
+          },
+          roles: ['master', 'data', 'ingest']
+        },
+        a2: {
+          roles: ['master', 'data', 'ingest']
+        }
+      }
+
+      t.same(pool.nodesToHost(nodes, 'http:'), [{
+        url: new URL('http://127.0.0.1:9200'),
+        id: 'a1',
+        roles: {
+          master: true,
+          data: true,
+          ingest: true,
+          ml: false
+        }
+      }])
+
+      t.equal(pool.nodesToHost(nodes, 'http:').length, 1)
+      t.equal(pool.nodesToHost(nodes, 'http:')[0].url.host, '127.0.0.1:9200')
+      t.end()
+    })
+
     t.end()
   })
 


### PR DESCRIPTION
A fix for https://github.com/elastic/elasticsearch-js/issues/1230.
