### PR TITLE
Upgrade transport: skip adding new nodes that aren't ready yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "zx": "^7.2.2"
   },
   "dependencies": {
-    "@elastic/transport": "^8.3.3",
+    "@elastic/transport": "^8.3.4",
     "tslib": "^2.4.0"
   },
   "tap": {


### PR DESCRIPTION
Draft until https://github.com/elastic/elastic-transport-js/pull/72 is merged and released.

A fix for https://github.com/elastic/elasticsearch-js/issues/1230.