### PR TITLE
Use GitHub admonition for browser support warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ npm install @elastic/elasticsearch@<major>
 
 #### Browser
 
-WARNING: There is no official support for the browser environment. It exposes your Elasticsearch instance to everyone, which could lead to security issues.
+> [!WARNING]
+> There is no official support for the browser environment. It exposes your Elasticsearch instance to everyone, which could lead to security issues.
 We recommend that you write a lightweight proxy that uses this client instead, you can see a proxy example [here](./docs/examples/proxy).
 
 ## Documentation


### PR DESCRIPTION
Admonitions are a recent addition, and [look like this](https://github.com/pquentin/elasticsearch-js/tree/pquentin-patch-1):

![image](https://github.com/elastic/elasticsearch-js/assets/42327/d94ff9a3-32c1-4726-aa9f-0fe99a0cc6ac)