### PR TITLE
[Backport 8.9] Upgrade transport: skip adding new nodes that aren't ready yet (#1995)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "zx": "^7.2.2"
   },
   "dependencies": {
-    "@elastic/transport": "^8.3.3",
+    "@elastic/transport": "^8.3.4",
     "tslib": "^2.4.0"
   },
   "tap": {


### PR DESCRIPTION
Backport of 57e84a911432db195f7f3a93b36f6f921b5d2553 from #1995