### PR TITLE
[8.8] [DOCS] Fix `welcome-to-elastic` link (#2007)

### DIFF
--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -159,7 +159,7 @@
       </a>
     </div>
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-observability.html">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[DOCS] Fix &#x60;welcome-to-elastic&#x60; link (#2007)](https://github.com/elastic/elasticsearch-js/pull/2007)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)