### PR TITLE
Fix hang in bulk helper semaphore when server responses are slower than flushInterval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/elasticsearch",
-  "version": "8.9.1",
-  "versionCanary": "8.9.1-canary.1",
+  "version": "8.10.1",
+  "versionCanary": "8.10.1-canary.1",
   "description": "The official Elasticsearch client for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -648,10 +648,11 @@ export default class Helpers {
 
         if (chunkBytes >= flushBytes) {
           stats.bytes += chunkBytes
-          const send = await semaphore()
-          send(bulkBody.slice())
+          const bulkBodyCopy = bulkBody.slice()
           bulkBody.length = 0
           chunkBytes = 0
+          const send = await semaphore()
+          send(bulkBodyCopy)
         }
       }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -616,7 +616,7 @@ export default class Helpers {
       let chunkBytes = 0
       timeoutRef = setTimeout(onFlushTimeout, flushInterval) // eslint-disable-line
 
-      // @ts-expect-error datasoruce is an iterable
+      // @ts-expect-error datasource is an iterable
       for await (const chunk of datasource) {
         if (shouldAbort) break
         timeoutRef.refresh()
@@ -657,7 +657,7 @@ export default class Helpers {
       }
 
       clearTimeout(timeoutRef)
-      // In some cases the previos http call does not have finished,
+      // In some cases the previous http call has not finished,
       // or we didn't reach the flush bytes threshold, so we force one last operation.
       if (!shouldAbort && chunkBytes > 0) {
         const send = await semaphore()
@@ -701,8 +701,8 @@ export default class Helpers {
     // to guarantee that no more than the number of operations
     // allowed to run at the same time are executed.
     // It returns a semaphore function which resolves in the next tick
-    // if we didn't reach the maximim concurrency yet, otherwise it returns
-    // a promise that resolves as soon as one of the running request has finshed.
+    // if we didn't reach the maximum concurrency yet, otherwise it returns
+    // a promise that resolves as soon as one of the running requests has finished.
     // The semaphore function resolves a send function, which will be used
     // to send the actual bulk request.
     // It also returns a finish function, which returns a promise that is resolved


### PR DESCRIPTION
A possible fix for https://github.com/elastic/elasticsearch-js/issues/1562.

The failing state in the above issue is reached when a server's response times are slower than `flushInterval`. What happens in this situation, in this order:

1. The [`flushBytes` block](https://github.com/elastic/elasticsearch-js/blob/65580b0a2d59179ea9d63be315051588d0b25ab1/src/helpers.ts#L649-L655) awaits `semaphore()`
2. While awaiting, `onFlushTimeout` is triggered
3. [`onFlushTimeout` "steals"](https://github.com/elastic/elasticsearch-js/blob/65580b0a2d59179ea9d63be315051588d0b25ab1/src/helpers.ts#L684-L690) the bulk body rows that the `flushBytes` block is waiting to send by emptying `bulkBody` before awaiting a semaphore
4. When the `flushBytes` block's semaphore resolves, it tries to `send(bulkBody)` but `bulkBody` is empty

By having `flushBytes` set its blocks aside before awaiting the semaphore, like `onFlushTimeout` already does, it appears to solve the situation where a Promise sits unresolved indefinitely.

@delvedor I'm particularly interested in your thoughts on this solution, since you wrote the helper and chose the semaphore strategy.
