### PR TITLE
Improve unit test path filtering rules

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,32 +1,35 @@
 ---
 name: Node CI
 
-on:
-  push:
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.asciidoc'
-      - '**/*.txt'
-      - 'docs/**'
-      - '.ci/**'
-      - '.buildkite/**'
-      - 'scripts/**'
-      - 'catalog-info.yaml'
-  pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.asciidoc'
-      - '**/*.txt'
-      - 'docs/**'
-      - '.ci/**'
-      - '.buildkite/**'
-      - 'scripts/**'
-      - 'catalog-info.yaml'
+on: [push, pull_request]
 
 jobs:
+  paths-filter:
+    name: Detect files changed
+    runs-on: ubuntu-latest
+    outputs:
+      skip: '${{ steps.changes.outputs.skip }}'
+    steps:
+      - uses: dorny/paths-filter/@v2.11.1
+        id: changes
+        with:
+          filters: |
+            skip:
+              - '**/*.md'
+              - '**/*.asciidoc'
+              - '**/*.txt'
+              - 'docs/**'
+              - '.ci/**'
+              - '.buildkite/**'
+              - 'scripts/**'
+              - 'catalog-info.yaml'
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    needs: paths-filter
+    # only run if files not in `skip` filter were changed
+    if: needs.paths-filter.outputs.skip != 'true'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
[See docs](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution) about how jobs that are skipped still report success. When using `paths-ignore` the action does not run at all, so branch-protection rules are violated to merge a PR. Using the `paths-filter` action ensures the action does run, just skips tests and reports success.
