### PR TITLE
Set module type to commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "The official Elasticsearch client for Node.js",
   "main": "index.js",
   "types": "index.d.ts",
+  "type": "commonjs",
   "scripts": {
     "test": "npm run build && npm run lint && tap test/unit/{*,**/*}.test.ts",
     "test:unit": "npm run build && tap test/unit/{*,**/*}.test.ts",


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch-js/issues/1281.

There may be value in switching to an ES module at some point, but it's currently CommonJS so we may as well be explicit about it.
