### PR TITLE
Stop supporting Node v14 and v16

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,6 @@ steps:
           - "free"
           - "platinum"
         nodejs:
-          - "16"
           - "18"
           - "20"
     command: ./.buildkite/run-tests.sh

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ of the getting started documentation.
 
 ### Node.js support
 
-NOTE: The minimum supported version of Node.js is `v14`.
+NOTE: The minimum supported version of Node.js is `v18`.
 
 The client versioning follows the Elastic Stack versioning, this means that
 major, minor, and patch releases are done following a precise schedule that
@@ -53,6 +53,7 @@ of `^7.10.0`).
 | `10.x`          | `April 2021`     | `7.12` (mid 2021)      |
 | `12.x`          | `April 2022`     | `8.2` (early 2022)     |
 | `14.x`          | `April 2023`     | `8.8` (early 2023)     |
+| `16.x`          | `September 2023` | `8.11` (late 2023)     |
 
 ### Compatibility
 

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -24,7 +24,7 @@ To learn more about the supported major versions, please refer to the
 [[nodejs-support]]
 === Node.js support
 
-NOTE: The minimum supported version of Node.js is `v14`.
+NOTE: The minimum supported version of Node.js is `v18`.
 
 The client versioning follows the {stack} versioning, this means that
 major, minor, and patch releases are done following a precise schedule that
@@ -64,6 +64,10 @@ of `^7.10.0`).
 |`14.x`
 |April 2023
 |`8.8` (early 2023)
+
+|`16.x`
+|September 2023
+|`8.11` (late 2023)
 |===
 
 [discrete]

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "github:sinonjs/fake-timers#0bfffc1",


### PR DESCRIPTION
Dropping official support for Node.js v14 and v18 as they are both [EOL](https://endoflife.date/nodejs). This mostly just means not testing code against those versions, and updating the supported version in the package.json. But future versions may take advantage of JavaScript or Node.js features that are only available in v18+.

This will be released in client v8.11 in the next week or two.

Fixes https://github.com/elastic/elasticsearch-js/issues/1855.