### PR TITLE
Fix 8.10 codegen

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     env:
       NODE_VERSION: "{{ matrix.nodejs }}"
       TEST_SUITE: "{{ matrix.suite }}"
-      STACK_VERSION: 8.8.0-SNAPSHOT
+      STACK_VERSION: 8.10.3-SNAPSHOT
     matrix:
       setup:
         suite:

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,30 @@
+ARG NODE_JS_VERSION=${NODE_JS_VERSION:-18}
+FROM node:${NODE_JS_VERSION}
+
+ARG BUILDER_UID=1000
+ARG BUILDER_GID=1000
+ENV BUILDER_USER elastic
+ENV BUILDER_GROUP elastic
+
+# install zip util
+RUN apt-get clean -y && \
+    apt-get update -y && \
+    apt-get install -y zip
+
+# Set user permissions and directory
+RUN (id -g ${BUILDER_GID} || groupadd --system -g ${BUILDER_GID} ${BUILDER_GROUP}) \
+    && (id -u ${BUILDER_UID} || useradd --system --shell /bin/bash -u ${BUILDER_UID} -g ${BUILDER_GID} -m elastic) \
+    && mkdir -p /usr/src/elasticsearch-js \
+    && chown -R ${BUILDER_UID}:${BUILDER_GID} /usr/src/
+
+WORKDIR /usr/src/elasticsearch-js
+
+# run remainder of commands as non-root user
+USER ${BUILDER_UID}:${BUILDER_GID}
+
+# install dependencies
+COPY package.json .
+RUN npm install --production=false
+
+# copy project files
+COPY . .


### PR DESCRIPTION
Somehow in https://github.com/elastic/elasticsearch-js/pull/2019 I failed to see that I was causing the 8.10 branch to drift from `main` by "fixing" some problems there instead of backporting fixes from `main`. :facepalm:
