### PR TITLE
Throw an explicit error when asStream is used with bulk helper

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -527,6 +527,8 @@ export default class Helpers {
    * @return {object} The possible operations to run with the datasource.
    */
   bulk<TDocument = unknown> (options: BulkHelperOptions<TDocument>, reqOptions: TransportRequestOptions = {}): BulkHelper<TDocument> {
+    assert(!(reqOptions.asStream ?? false), 'bulk helper: the asStream request option is not supported')
+
     const client = this[kClient]
     const { serializer } = client
     if (this[kMetaHeader] !== null) {

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -18,6 +18,7 @@
  */
 
 import FakeTimers from '@sinonjs/fake-timers'
+import { AssertionError } from 'assert'
 import { createReadStream } from 'fs'
 import * as http from 'http'
 import { join } from 'path'
@@ -1334,6 +1335,37 @@ test('transport options', t => {
       failed: 0,
       aborted: false
     })
+  })
+
+  t.test('Should not allow asStream request option', async t => {
+    t.plan(2)
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+    })
+
+    try {
+      await client.helpers.bulk({
+        datasource: dataset.slice(),
+        flushBytes: 1,
+        concurrency: 1,
+        onDocument (doc) {
+          return { index: { _index: 'test' } }
+        },
+        onDrop (doc) {
+          t.fail('This should never be called')
+        },
+        refreshOnCompletion: true
+      }, {
+        headers: {
+          foo: 'bar'
+        },
+        asStream: true,
+      })
+    } catch (err: any) {
+      t.ok(err instanceof AssertionError)
+      t.equal(err.message, 'bulk helper: the asStream request option is not supported')
+    }
   })
 
   t.end()


### PR DESCRIPTION
The `bulk` helper does not support `asStream`, as it assumes the response will be parsed JSON rather than a raw stream. It currently takes a lot of debugging to understand why the helper fails in this case, so this adds an explicit check and throws an error with a clear message.

Thanks to @achyutjhunjhunwala for catching this (pun intended)!
