### PR TITLE
Bump transport to 8.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "zx": "^7.2.2"
   },
   "dependencies": {
-    "@elastic/transport": "^8.3.4",
+    "@elastic/transport": "^8.4.0",
     "tslib": "^2.4.0"
   },
   "tap": {


### PR DESCRIPTION
Updates `@elastic/transport` to [v8.4.0](https://github.com/elastic/elastic-transport-js/releases/tag/v8.4.0).
