### PR TITLE
Github action for publishing to npm with provenance metadata

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,27 @@
+name: Publish Package to npm
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Git branch to build and publish'
+        required: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm
+      - run: npm install
+      - run: npm test
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
A GitHub action that, when manually triggered, will publish the specified branch to npm as the latest release, including [a provenance statement](https://docs.npmjs.com/generating-provenance-statements) to increase supply-chain security and confidence.
