### PR TITLE
[DOCS] Add examples for ES quickstart

### DIFF
--- a/docs/examples/36b86b97feedcf5632824eefc251d6ed.asciidoc
+++ b/docs/examples/36b86b97feedcf5632824eefc251d6ed.asciidoc
@@ -1,0 +1,14 @@
+// getting-started.asciidoc:245
+
+[source, js]
+----
+const resp = await client.search({
+    index: 'books',
+    query: {
+        match: {
+            name: "brave"
+        }
+    }
+});
+console.log(resp);
+----

--- a/docs/examples/8575c966b004fb124c7afd6bb5827b50.asciidoc
+++ b/docs/examples/8575c966b004fb124c7afd6bb5827b50.asciidoc
@@ -1,0 +1,15 @@
+// getting-started.asciidoc:65
+
+[source,js]
+----
+resp = await client.index({
+  index: 'books',
+  document: {
+    name: "Snow Crash",
+    author: "Neal Stephenson",
+    release_date: "1992-06-01",
+    page_count: 470
+  }
+});
+console.log(resp);
+----

--- a/docs/examples/bcc75fc01b45e482638c65b8fbdf09fa.asciidoc
+++ b/docs/examples/bcc75fc01b45e482638c65b8fbdf09fa.asciidoc
@@ -1,0 +1,9 @@
+// getting-started.asciidoc:228
+
+[source,js]
+----
+resp = await client.search({
+  index: 'books'
+});
+console.log(resp.hits.hits);
+----

--- a/docs/examples/d04f0c8c44e8b4fb55f2e7d9d05977e7.asciidoc
+++ b/docs/examples/d04f0c8c44e8b4fb55f2e7d9d05977e7.asciidoc
@@ -1,0 +1,42 @@
+// getting-started.asciidoc:104
+
+resp = await client.bulk({
+  operations: [
+    { index: { _index: 'books' } },
+    {
+      name: "Revelation Space",
+      author: "Alastair Reynolds",
+      release_date: "2000-03-15",
+      page_count: 585
+    },
+    { index: { _index: 'books' } },
+    {
+      name: "1984",
+      author: "George Orwell",
+      release_date: "1985-06-01",
+      page_count: 328
+    },
+    { index: { _index: 'books' } },
+    {
+      name: "Fahrenheit 451",
+      author: "Ray Bradbury",
+      release_date: "1953-10-15",
+      page_count: 227
+    },
+    { index: { _index: 'books' } },
+    {
+      name: "Brave New World",
+      author: "Aldous Huxley",
+      release_date: "1932-06-01",
+      page_count: 268
+    },
+    { index: { _index: 'books' } },
+    {
+      name: "The Handmaids Tale",
+      author: "Margaret Atwood",
+      release_date: "1985-06-01",
+      page_count: 311
+    }
+  ]
+});
+console.log(resp);


### PR DESCRIPTION
- Adds js snippets for [quickstart](https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started.html)
