### PR TITLE
Update bulk.asciidoc change 'date' property to 'time' to match index creation

### DIFF
--- a/docs/examples/bulk.asciidoc
+++ b/docs/examples/bulk.asciidoc
@@ -35,27 +35,27 @@ async function run () {
     id: 1,
     text: 'If I fall, don\'t bring me back.',
     user: 'jon',
-    date: new Date()
+    time: new Date()
   }, {
     id: 2,
     text: 'Winter is coming',
     user: 'ned',
-    date: new Date()
+    time: new Date()
   }, {
     id: 3,
     text: 'A Lannister always pays his debts.',
     user: 'tyrion',
-    date: new Date()
+    time: new Date()
   }, {
     id: 4,
     text: 'I am the blood of the dragon.',
     user: 'daenerys',
-    date: new Date()
+    time: new Date()
   }, {
     id: 5, // change this value to a string to see the bulk response with errors
     text: 'A girl is Arya Stark of Winterfell. And I\'m going home.',
     user: 'arya',
-    date: new Date()
+    time: new Date()
   }]
 
   const body = dataset.flatMap(doc => [{ index: { _index: 'tweets' } }, doc])


### PR DESCRIPTION
In the code example, the index is created with a property called 'time' but the dataset has a field called 'date.' Updating the 'date' field to match the 'time' property of the index.