### PR TITLE
More fetch depth fix to patch workflow

### DIFF
--- a/.github/workflows/serverless-patch.yml
+++ b/.github/workflows/serverless-patch.yml
@@ -31,6 +31,7 @@ jobs:
           repository: elastic/elasticsearch-js
           ref: main
           path: stack
+          fetch-depth: 0
       - uses: actions/checkout@v4
         with:
           repository: elastic/elasticsearch-serverless-js


### PR DESCRIPTION
Turns out `actions/checkout` only fetches the commit provided by `ref`. `fetch-depth` set to 0 ensures that it actually fetches the full commit history.
