### PR TITLE
Try using default token

### DIFF
--- a/.github/workflows/serverless-patch.yml
+++ b/.github/workflows/serverless-patch.yml
@@ -42,7 +42,6 @@ jobs:
         run: $GITHUB_WORKSPACE/stack/.github/workflows/serverless-patch.sh
       - uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           path: serverless
           title: 'Apply patch from elastic/elasticsearch-js#${{ github.event.pull_request.number }}'
           commit-message: 'Apply patch from elastic/elasticsearch-js#${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Provided token was not able to push a new branch to elasticsearch-serverless-js
