### PR TITLE
Stop defaulting to snapshots for integration tests

### DIFF
--- a/.buildkite/make.mjs
+++ b/.buildkite/make.mjs
@@ -94,7 +94,7 @@ async function bump (args) {
   const pipeline = await readFile(join(import.meta.url, '..', '.buildkite', 'pipeline.yml'), 'utf8')
   await writeFile(
     join(import.meta.url, '..', '.buildkite', 'pipeline.yml'),
-    pipeline.replace(/STACK_VERSION: [0-9]+[0-9\.]*[0-9](?:\-SNAPSHOT)?/, `STACK_VERSION: ${cleanVersion}-SNAPSHOT`),
+    pipeline.replace(/STACK_VERSION: [0-9]+[0-9\.]*[0-9](?:\-SNAPSHOT)?/, `STACK_VERSION: ${cleanVersion}`),
     'utf8'
   )
 }

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     env:
       NODE_VERSION: "{{ matrix.nodejs }}"
       TEST_SUITE: "{{ matrix.suite }}"
-      STACK_VERSION: 8.13.0-SNAPSHOT
+      STACK_VERSION: 8.13.0
     matrix:
       setup:
         suite:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -39,12 +39,9 @@ spec:
       cancel_intermediate_builds: true
       cancel_intermediate_builds_branch_filter: '!main'
       schedules:
-        main_semi_daily:
+        main:
           branch: 'main'
-          cronline: '0 */12 * * *'
-        8_13_semi_daily:
+          cronline: '@daily'
+        8_13:
           branch: '8.13'
-          cronline: '0 */12 * * *'
-        8_12_daily:
-          branch: '8.12'
           cronline: '@daily'


### PR DESCRIPTION
Integration tests running against snapshots appear to be flaky for unknown reasons. Stop using `SNAPSHOT` builds by default for now until we can work it out.

Also reduces the number of scheduled integration test runs per day.
