### PR TITLE
Bump main to 8.14.0

### DIFF
--- a/.buildkite/make.mjs
+++ b/.buildkite/make.mjs
@@ -74,12 +74,13 @@ async function release (args) {
 
 async function bump (args) {
   assert(args.length === 1, 'Bump task expects one parameter')
-  const [version] = args
+  let [version] = args
   const packageJson = JSON.parse(await readFile(
     join(import.meta.url, '..', 'package.json'),
     'utf8'
   ))
 
+  if (version.split('.').length === 2) version = `${version}.0`
   const cleanVersion = semver.clean(version.includes('SNAPSHOT') ? version.split('-')[0] : version)
   assert(semver.valid(cleanVersion), `${cleanVersion} is not seen as a valid semver version. raw version: ${version}`)
   packageJson.version = cleanVersion

--- a/.buildkite/make.mjs
+++ b/.buildkite/make.mjs
@@ -81,7 +81,7 @@ async function bump (args) {
   ))
 
   const cleanVersion = semver.clean(version.includes('SNAPSHOT') ? version.split('-')[0] : version)
-  assert(semver.valid(cleanVersion))
+  assert(semver.valid(cleanVersion), `${cleanVersion} is not seen as a valid semver version. raw version: ${version}`)
   packageJson.version = cleanVersion
   packageJson.versionCanary = `${cleanVersion}-canary.0`
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     env:
       NODE_VERSION: "{{ matrix.nodejs }}"
       TEST_SUITE: "{{ matrix.suite }}"
-      STACK_VERSION: 8.13.0
+      STACK_VERSION: 8.14.0
     matrix:
       setup:
         suite:

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ test/bundlers/**/bundle.js
 test/bundlers/parcel-test/.parcel-cache
 
 lib
+junit-output

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/elasticsearch",
-  "version": "8.13.0",
-  "versionCanary": "8.13.0-canary.0",
+  "version": "8.14.0",
+  "versionCanary": "8.14.0-canary.0",
   "description": "The official Elasticsearch client for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Bumps to 8.14.0, and makes a couple small improvements to the `make.sh bump` script.
