### PR TITLE
onSuccess function for bulk helper

### DIFF
--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -2,6 +2,23 @@
 == Release notes
 
 [discrete]
+=== 8.14.0
+
+[discrete]
+==== Features
+
+[discrete]
+===== Support for Elasticsearch `v8.14.0`
+
+You can find all the API changes
+https://www.elastic.co/guide/en/elasticsearch/reference/8.14/release-notes-8.14.0.html[here].
+
+[discrete]
+===== `onSuccess` callback added to bulk helper
+
+The bulk helper now supports an `onSuccess` callback that will be called for each successful operation. https://github.com/elastic/elasticsearch-js/pull/2199[#2199]
+
+[discrete]
 === 8.13.0
 
 [discrete]

--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -5,15 +5,6 @@
 === 8.14.0
 
 [discrete]
-==== Features
-
-[discrete]
-===== Support for Elasticsearch `v8.14.0`
-
-You can find all the API changes
-https://www.elastic.co/guide/en/elasticsearch/reference/8.14/release-notes-8.14.0.html[here].
-
-[discrete]
 ===== `onSuccess` callback added to bulk helper
 
 The bulk helper now supports an `onSuccess` callback that will be called for each successful operation. https://github.com/elastic/elasticsearch-js/pull/2199[#2199]

--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -98,6 +98,17 @@ const b = client.helpers.bulk({
 })
 ----
 
+|`onSuccess`
+a|A function that is called for each successful operation in the bulk request, which includes the result from Elasticsearch along with the original document that was sent, or `null` for delete operations.
+[source,js]
+----
+const b = client.helpers.bulk({
+  onSuccess ({ result, document }) {
+    console.log(`SUCCESS: Document ${result.index._id} indexed to ${result.index._index}`)
+  } 
+})
+----
+
 |`flushBytes`
 a|The size of the bulk body in bytes to reach before to send it. Default of 5MB. +
 _Default:_ `5000000`

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -570,6 +570,8 @@ export default class Helpers {
       retries = this[kMaxRetries],
       wait = 5000,
       onDrop = noop,
+      // onSuccess does not default to noop, to avoid the performance hit
+      // of deserializing every document in the bulk request
       onSuccess,
       refreshOnCompletion = false,
       ...bulkOptions
@@ -922,12 +924,7 @@ export default class Helpers {
                 }
               } else {
                 stats.successful += 1
-                if (onSuccess != null) {
-                  onSuccess({
-                    result,
-                    document: document()
-                  })
-                }
+                if (onSuccess != null) onSuccess({ result, document: document() })
               }
             }
             callback(null, retry)


### PR DESCRIPTION
For https://github.com/elastic/elasticsearch-js/issues/2090

Includes refactor of the `tryBulk` result processing code, to make iterating over bulk response data easier to understand.
