### PR TITLE
Bump to 8.13.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     env:
       NODE_VERSION: "{{ matrix.nodejs }}"
       TEST_SUITE: "{{ matrix.suite }}"
-      STACK_VERSION: 8.13.0-SNAPSHOT
+      STACK_VERSION: 8.13.1-SNAPSHOT
     matrix:
       setup:
         suite:

--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -2,6 +2,17 @@
 == Release notes
 
 [discrete]
+=== 8.13.1
+
+[discrete]
+==== Fixes
+
+[discrete]
+===== Upgrade transport version to 8.4.1 https://github.com/elastic/elasticsearch-js/pull/2200[#2200]
+
+v8.13.0 was released depending on v8.4.0 of `@elastic/transport` instead of v8.4.1, which fixes a bug related to data redaction on error objects.
+
+[discrete]
 === 8.13.0
 
 [discrete]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/elasticsearch",
-  "version": "8.13.0",
-  "versionCanary": "8.13.0-canary.0",
+  "version": "8.13.1",
+  "versionCanary": "8.13.1-canary.0",
   "description": "The official Elasticsearch client for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
8.13.0 was released still depending on `@elastic/transport` v8.4.0 even though v8.4.1 had already been released.
