### PR TITLE
`fields` added to `top_hits` aggregation

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -4062,6 +4062,7 @@ export interface AggregationsTopHitsAggregate extends AggregationsAggregateBase 
 export interface AggregationsTopHitsAggregation extends AggregationsMetricAggregationBase {
   docvalue_fields?: Fields
   explain?: boolean
+  fields?: (QueryDslFieldAndFormat | Field)[]
   from?: integer
   highlight?: SearchHighlight
   script_fields?: Record<string, ScriptField>


### PR DESCRIPTION
The following query works and returns the `fields` information requested in the `top_hits` aggregation. However, the typescript definition for top hits aggregations (`AggregationsTopHitsAggregation`) is missing the `fields` entry. 

```js
{
  "aggregations": {
    "theAggName": {
      "top_hits": {
        "fields": [
          {
            "field": "@timestamp",
            "format": "strict_date_optional_time"
          },
          "_index"
        ]
      }
    }
  }
}
```
So typescript throws the following error:
`Object literal may only specify known properties, but 'fields' does not exist in type 'AggregationsTopHitsAggregation'. Did you mean to write 'field'?`

This PR adds the `fields` property to the `AggregationsTopHitsAggregation` type with:

`fields?: (QueryDslFieldAndFormat | Field)[]`

 I've tested it works using the `QueryDslFieldAndFormat` and `string` types, and the array is required.