### PR TITLE
Switch 8.6 clients to only get patch updates to transport

### DIFF
--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -2,6 +2,13 @@
 == Release notes
 
 [discrete]
+=== 8.6.1
+
+[discrete]
+===== Bump @elastic/transport to ~8.3.1
+Switching from `^8.3.1` to `~8.3.1` ensures 8.6 client users are not required to update to Node.js v18+, which is a new requirement set by `@elastic/transport` v8.5.0. See https://github.com/elastic/elastic-transport-js/issues/91[elastic/elastic-transport-js#91] for details.
+
+[discrete]
 === 8.6.0
 
 [discrete]

--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -5,7 +5,7 @@
 === 8.6.1
 
 [discrete]
-===== Bump @elastic/transport to ~8.3.1
+===== Bump @elastic/transport to `~8.3.1`
 Switching from `^8.3.1` to `~8.3.1` ensures 8.6 client users are not required to update to Node.js v18+, which is a new requirement set by `@elastic/transport` v8.5.0. See https://github.com/elastic/elastic-transport-js/issues/91[elastic/elastic-transport-js#91] for details.
 
 [discrete]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/elasticsearch",
-  "version": "8.6.0",
-  "versionCanary": "8.6.0-canary.0",
+  "version": "8.6.1",
+  "versionCanary": "8.6.1-canary.0",
   "description": "The official Elasticsearch client for Node.js",
   "main": "index.js",
   "types": "index.d.ts",
@@ -81,7 +81,7 @@
     "zx": "^6.1.0"
   },
   "dependencies": {
-    "@elastic/transport": "^8.3.1",
+    "@elastic/transport": "~8.3.1",
     "tslib": "^2.4.0"
   },
   "tap": {


### PR DESCRIPTION
Transport version 8.5.0+ requires Node.js 18+. This ensures 8.6 users are not forced to upgrade Node.

See https://github.com/elastic/elastic-transport-js/issues/91.