### PR TITLE
Switch 8.9 clients to only get patch updates to transport

### DIFF
--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -2,6 +2,17 @@
 == Release notes
 
 [discrete]
+=== 8.9.2
+
+[discrete]
+==== Fixes
+
+[discrete]
+===== Bump @elastic/transport to `~8.3.4`
+
+Switching from `^8.3.4` to `~8.3.4` ensures 8.9 client users are not required to update to Node.js v18+, which is a new requirement set by `@elastic/transport` v8.5.0. See https://github.com/elastic/elastic-transport-js/issues/91[elastic/elastic-transport-js#91] for details.
+
+[discrete]
 === 8.9.1
 
 [discrete]
@@ -36,6 +47,17 @@ In the https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/curre
 ===== Updated `user-agent` header https://github.com/elastic/elasticsearch-js/pull/1954[#1954]
 
 The `user-agent` header the client used to connect to Elasticsearch was using a non-standard format that has been improved.
+
+[discrete]
+=== 8.8.2
+
+[discrete]
+==== Fixes
+
+[discrete]
+===== Bump @elastic/transport to `~8.3.2`
+
+Switching from `^8.3.2` to `~8.3.2` ensures 8.8 client users are not required to update to Node.js v18+, which is a new requirement set by `@elastic/transport` v8.5.0. See https://github.com/elastic/elastic-transport-js/issues/91[elastic/elastic-transport-js#91] for details.
 
 [discrete]
 === 8.8.1
@@ -83,6 +105,17 @@ https://www.elastic.co/guide/en/elasticsearch/reference/8.8/release-notes-8.8.0.
 Prior releases contained a bug where type declarations for legacy types that include a `body` key were not actually importing the type that includes the `body` key.
 
 [discrete]
+=== 8.7.3
+
+[discrete]
+==== Fixes
+
+[discrete]
+===== Bump @elastic/transport to `~8.3.1`
+
+Switching from `^8.3.1` to `~8.3.1` ensures 8.7 client users are not required to update to Node.js v18+, which is a new requirement set by `@elastic/transport` v8.5.0. See https://github.com/elastic/elastic-transport-js/issues/91[elastic/elastic-transport-js#91] for details.
+
+[discrete]
 === 8.7.0
 
 [discrete]
@@ -90,6 +123,17 @@ Prior releases contained a bug where type declarations for legacy types that inc
 
 You can find all the API changes
 https://www.elastic.co/guide/en/elasticsearch/reference/8.7/release-notes-8.7.0.html[here].
+
+[discrete]
+=== 8.6.1
+
+[discrete]
+==== Fixes
+
+[discrete]
+===== Bump @elastic/transport to `~8.3.1`
+
+Switching from `^8.3.1` to `~8.3.1` ensures 8.6 client users are not required to update to Node.js v18+, which is a new requirement set by `@elastic/transport` v8.5.0. See https://github.com/elastic/elastic-transport-js/issues/91[elastic/elastic-transport-js#91] for details.
 
 [discrete]
 === 8.6.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/elasticsearch",
-  "version": "8.9.1",
-  "versionCanary": "8.9.1-canary.1",
+  "version": "8.9.2",
+  "versionCanary": "8.9.2-canary.0",
   "description": "The official Elasticsearch client for Node.js",
   "main": "index.js",
   "types": "index.d.ts",
@@ -86,7 +86,7 @@
     "zx": "^7.2.2"
   },
   "dependencies": {
-    "@elastic/transport": "^8.3.4",
+    "@elastic/transport": "~8.3.4",
     "tslib": "^2.4.0"
   },
   "tap": {


### PR DESCRIPTION
Transport version 8.5.0+ requires Node.js 18+. This ensures 8.9 users are not forced to upgrade Node.

See https://github.com/elastic/elastic-transport-js/issues/91.
