### PR TITLE
ES|QL: Object API helper

### DIFF
--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -613,3 +613,97 @@ for await (const doc of scrollSearch) {
   console.log(doc)
 }
 ----
+
+[discrete]
+[[esql-helper]]
+=== ES|QL helper
+
+ES|QL queries can return their results in {ref}/esql-rest.html#esql-rest-format[several formats].
+The default JSON format returned by ES|QL queries contains arrays of values
+for each row, with column names and types returned separately:
+
+[discrete]
+==== Usage
+
+[discrete]
+===== `toRecords`
+
+~Added~ ~in~ ~`v8.14.0`~
+
+The default JSON format returned by ES|QL queries contains arrays of values
+for each row, with column names and types returned separately:
+
+[source,json]
+----
+{
+  "columns": [
+    { "name": "@timestamp", "type": "date" },
+    { "name": "client_ip", "type": "ip" },
+    { "name": "event_duration", "type": "long" },
+    { "name": "message", "type": "keyword" }
+  ],
+  "values": [
+    [
+      "2023-10-23T12:15:03.360Z",
+      "172.21.2.162",
+      3450233,
+      "Connected to 10.1.0.3"
+    ],
+    [
+      "2023-10-23T12:27:28.948Z",
+      "172.21.2.113",
+      2764889,
+      "Connected to 10.1.0.2"
+    ]
+  ]
+}
+----
+
+In many cases, it's preferable to operate on an array of objects, one object per row,
+rather than an array of arrays. The ES|QL `toRecords` helper converts row data into objects.
+
+[source,js]
+----
+await client.helpers
+  .esql({ query: 'FROM sample_data | LIMIT 2' })
+  .toRecords()
+// =>
+// {
+//   "columns": [
+//     { "name": "@timestamp", "type": "date" },
+//     { "name": "client_ip", "type": "ip" },
+//     { "name": "event_duration", "type": "long" },
+//     { "name": "message", "type": "keyword" }
+//   ],
+//   "records": [
+//     {
+//       "@timestamp": "2023-10-23T12:15:03.360Z",
+//       "client_ip": "172.21.2.162",
+//       "event_duration": 3450233,
+//       "message": "Connected to 10.1.0.3"
+//     },
+//     {
+//       "@timestamp": "2023-10-23T12:27:28.948Z",
+//       "client_ip": "172.21.2.113",
+//       "event_duration": 2764889,
+//       "message": "Connected to 10.1.0.2"
+//     },
+//   ]
+// }
+----
+
+In TypeScript, you can declare the type that `toRecords` returns:
+
+[source,ts]
+----
+type EventLog = {
+  '@timestamp': string,
+  client_ip: string,
+  event_duration: number,
+  message: string,
+}
+
+const result = await client.helpers
+  .esql({ query: 'FROM sample_data | LIMIT 2' })
+  .toRecords<EventLog>()
+----

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -981,6 +981,9 @@ export default class Helpers {
     }
 
     const helper: EsqlHelper = {
+      /**
+       * Pivots ES|QL query results into an array of row objects, rather than the default format where each row is an array of values.
+       */
       async toRecords<TDocument>(): Promise<TDocument[]> {
         params.format = 'json'
         // @ts-expect-error it's typed as ArrayBuffer but we know it will be JSON

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -153,8 +153,8 @@ interface EsqlResponse {
   values: EsqlRow[]
 }
 
-export interface EsqlHelper<TDocument = unknown> {
-  toRecords: () => Promise<TDocument[]>
+export interface EsqlHelper {
+  toRecords: <TDocument>() => Promise<TDocument[]>
 }
 
 const { ResponseError, ConfigurationError } = errors
@@ -954,6 +954,11 @@ export default class Helpers {
     }
   }
 
+  /**
+   * Creates an ES|QL helper instance, to help transform the data returned by an ES|QL query into easy-to-use formats.
+   * @param {object} params - Request parameters sent to esql.query()
+   * @returns {object} EsqlHelper instance
+   */
   esql (params: T.EsqlQueryRequest): EsqlHelper {
     // force JSON format to make return type predictable
     params.format = 'json'

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -959,9 +959,12 @@ export default class Helpers {
    * @param {object} params - Request parameters sent to esql.query()
    * @returns {object} EsqlHelper instance
    */
-  esql (params: T.EsqlQueryRequest): EsqlHelper {
-    // force JSON format to make return type predictable
-    params.format = 'json'
+  esql (params: T.EsqlQueryRequest, reqOptions: TransportRequestOptions = {}): EsqlHelper {
+    if (this[kMetaHeader] !== null) {
+      reqOptions.headers = reqOptions.headers ?? {}
+      reqOptions.headers['x-elastic-client-meta'] = `${this[kMetaHeader] as string},h=qo`
+    }
+
     const client = this[kClient]
 
     function toRecords<TDocument> (response: EsqlResponse): TDocument[] {
@@ -979,6 +982,7 @@ export default class Helpers {
 
     const helper: EsqlHelper = {
       async toRecords<TDocument>(): Promise<TDocument[]> {
+        params.format = 'json'
         // @ts-expect-error it's typed as ArrayBuffer but we know it will be JSON
         const response: EsqlResponse = await client.esql.query(params)
         return toRecords(response)

--- a/test/unit/helpers/esql.test.ts
+++ b/test/unit/helpers/esql.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from 'tap'
+import { connection } from '../../utils'
+import { Client } from '../../../'
+
+test('helpers.esql', t => {
+  test('toRecords', t => {
+    t.test('Takes an ESQL response and pivots it to an array of records', async t => {
+      type MyDoc = {
+        '@timestamp': string,
+        client_ip: string,
+        event_duration: number,
+        message: string,
+      }
+
+      const MockConnection = connection.buildMockConnection({
+        onRequest (_params) {
+          return {
+            body: {
+              columns: [
+                { name: '@timestamp', type: 'date' },
+                { name: 'client_ip', type: 'ip' },
+                { name: 'event_duration', type: 'long' },
+                { name: 'message', type: 'keyword' }
+              ],
+              values: [
+                [
+                  '2023-10-23T12:15:03.360Z',
+                  '172.21.2.162',
+                  3450233,
+                  'Connected to 10.1.0.3'
+                ],
+                [
+                  '2023-10-23T12:27:28.948Z',
+                  '172.21.2.113',
+                  2764889,
+                  'Connected to 10.1.0.2'
+                ]
+              ]
+            }
+          }
+        }
+      })
+
+      const client = new Client({
+        node: 'http://localhost:9200',
+        Connection: MockConnection
+      })
+
+      const result: MyDoc[] = await client.helpers.esql({ query: 'FROM sample_data' }).toRecords()
+      t.equal(result.length, 2)
+      t.ok(result[0])
+      t.same(result[0], {
+        '@timestamp': '2023-10-23T12:15:03.360Z',
+        client_ip: '172.21.2.162',
+        event_duration: 3450233,
+        message: 'Connected to 10.1.0.3'
+      })
+    })
+
+    t.end()
+  })
+  t.end()
+})

--- a/test/unit/helpers/esql.test.ts
+++ b/test/unit/helpers/esql.test.ts
@@ -66,7 +66,7 @@ test('ES|QL helper', t => {
       })
 
       const result = await client.helpers.esql({ query: 'FROM sample_data' }).toRecords<MyDoc>()
-      const { records } = result
+      const { records, columns } = result
       t.equal(records.length, 2)
       t.ok(records[0])
       t.same(records[0], {
@@ -75,6 +75,12 @@ test('ES|QL helper', t => {
         event_duration: 3450233,
         message: 'Connected to 10.1.0.3'
       })
+      t.same(columns, [
+        { name: '@timestamp', type: 'date' },
+        { name: 'client_ip', type: 'ip' },
+        { name: 'event_duration', type: 'long' },
+        { name: 'message', type: 'keyword' }
+      ])
       t.end()
     })
 

--- a/test/unit/helpers/esql.test.ts
+++ b/test/unit/helpers/esql.test.ts
@@ -65,10 +65,11 @@ test('ES|QL helper', t => {
         Connection: MockConnection
       })
 
-      const result: MyDoc[] = await client.helpers.esql({ query: 'FROM sample_data' }).toRecords()
-      t.equal(result.length, 2)
-      t.ok(result[0])
-      t.same(result[0], {
+      const result = await client.helpers.esql({ query: 'FROM sample_data' }).toRecords<MyDoc>()
+      const { records } = result
+      t.equal(records.length, 2)
+      t.ok(records[0])
+      t.same(records[0], {
         '@timestamp': '2023-10-23T12:15:03.360Z',
         client_ip: '172.21.2.162',
         event_duration: 3450233,
@@ -81,7 +82,7 @@ test('ES|QL helper', t => {
       const MockConnection = connection.buildMockConnection({
         onRequest (params) {
           const header = params.headers?.['x-elastic-client-meta'] ?? ''
-          t.ok(header.includes('h=qo'))
+          t.ok(header.includes('h=qo'), `Client meta header does not include ESQL helper value: ${header}`)
           return {
             body: {
               columns: [{ name: '@timestamp', type: 'date' }],


### PR DESCRIPTION
Adds a helper function to pivot [ES|QL](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html) results into an array of objects.

See included documentation for details on how to use it.
