### PR TITLE
Fix typo in documentation (example query)

### DIFF
--- a/docs/examples/reindex.asciidoc
+++ b/docs/examples/reindex.asciidoc
@@ -55,7 +55,7 @@ async function run () {
     source: {
       index: 'game-of-thrones',
       query: {
-        match: { character: 'stark' }
+        match: { house: 'stark' }
       }
     },
     dest: {


### PR DESCRIPTION
Fix typo in example query (on [this page](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/reindex_examples.html)).
We want to match all documents where `house=stark`, not where `character=stark`.