### PR TITLE
[DOCS] Comment out broken link breaking docs build

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -10168,7 +10168,7 @@ index will not be deleted
 ==== get_node_stats
 Retrieves transform usage information for transform nodes.
 
-{ref}/get-transform-node-stats.html[Endpoint documentation]
+//{ref}/get-transform-node-stats.html[Endpoint documentation]
 [source,ts]
 ----
 client.transform.getNodeStats()


### PR DESCRIPTION
```
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/8.15/api-reference.html contains broken links to:
INFO:build_docs:   - en/elasticsearch/reference/8.15/get-transform-node-stats.html
```

See https://github.com/elastic/docs/pull/3029