### PR TITLE
Add support for auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+name: Automerge
+
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: reitermarkus/automerge@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash
+          do-not-merge-labels: never-merge
+          pull-request-author-associations: OWNER

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,7 +2,7 @@
 name: Node CI
 
 on:
-  pull_request_target: {}
+  pull_request: {}
 
 jobs:
   paths-filter:

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "@elastic/request-converter": "^8.16.0",
+    "@elastic/request-converter": "^8.15.2",
     "@sinonjs/fake-timers": "github:sinonjs/fake-timers#0bfffc1",
     "@types/debug": "^4.1.7",
     "@types/ms": "^0.7.31",


### PR DESCRIPTION
Auto-merge PRs opened by owners of this repo. This repo is already configured to require status checks to pass (unit tests, license check, CLA, docs build) and a review approving before merging.

In effect, combining this with the auto-approve action I'm experimenting with, which will only run for PRs created by `elasticmachine`, this should auto-merge automated codegen PRs _only_ once all tests pass. It will also auto-merge PRs created by owners of this repo, but only if approved by another owner, which is a rare occurrence on this repo.
