### PR TITLE
Update request-converter version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "@elastic/request-converter": "^8.16.0",
+    "@elastic/request-converter": "^8.15.0",
     "@sinonjs/fake-timers": "github:sinonjs/fake-timers#0bfffc1",
     "@types/debug": "^4.1.7",
     "@types/ms": "^0.7.31",


### PR DESCRIPTION
There is no 8.16 version of the request converter yet, changing it to 8.15.
