### PR TITLE
Upgraded @types/node package to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@sinonjs/fake-timers": "github:sinonjs/fake-timers#0bfffc1",
     "@types/debug": "^4.1.7",
     "@types/ms": "^0.7.31",
-    "@types/node": "^17.0.31",
+    "@types/node": "^18.11.9",
     "@types/sinonjs__fake-timers": "^8.1.2",
     "@types/split2": "^3.2.1",
     "@types/stoppable": "^1.1.1",


### PR DESCRIPTION
Trying to build the client started to return errors after a recent update of the `undici` package. Updating from the v17 of `@types/node` to v18 appears to address the issue.

This is the what I'm getting as output with the v17 package:

```
> tsc && rm lib/package.json && mv lib/src/* lib/ && rm -rf lib/src

node_modules/undici/types/eventsource.d.ts:13:9 - error TS2304: Cannot find name 'Event'.

13   open: Event
           ~~~~~

node_modules/undici/types/eventsource.d.ts:16:31 - error TS2304: Cannot find name 'EventTarget'.

16 interface EventSource extends EventTarget {
                                 ~~~~~~~~~~~

node_modules/undici/types/eventsource.d.ts:23:35 - error TS2304: Cannot find name 'Event'.

23   onopen: (this: EventSource, ev: Event) => any
                                     ~~~~~

node_modules/undici/types/filereader.d.ts:7:14 - error TS2304: Cannot find name 'EventTarget'.

7   __proto__: EventTarget & FileReader
               ~~~~~~~~~~~

node_modules/undici/types/filereader.d.ts:47:14 - error TS2304: Cannot find name 'Event'.

47   __proto__: Event & ProgressEvent
                ~~~~~

node_modules/undici/types/patch.d.ts:28:24 - error TS2304: Cannot find name 'Event'.

28   handleEvent (object: Event): void
                          ~~~~~

node_modules/undici/types/patch.d.ts:32:9 - error TS2304: Cannot find name 'Event'.

32   (evt: Event): void
           ~~~~~

node_modules/undici/types/websocket.d.ts:20:9 - error TS2304: Cannot find name 'Event'.

20   open: Event
           ~~~~~

node_modules/undici/types/websocket.d.ts:23:29 - error TS2304: Cannot find name 'EventTarget'.

23 interface WebSocket extends EventTarget {
                               ~~~~~~~~~~~

node_modules/undici/types/websocket.d.ts:83:30 - error TS2304: Cannot find name 'Event'.

83 interface CloseEvent extends Event {
                                ~~~~~

node_modules/undici/types/websocket.d.ts:102:41 - error TS2304: Cannot find name 'Event'.

102 interface MessageEvent<T = any> extends Event {
                                            ~~~~~

node_modules/undici/types/websocket.d.ts:133:30 - error TS2304: Cannot find name 'Event'.

133 interface ErrorEvent extends Event {
                                 ~~~~~


Found 12 errors in 4 files.

Errors  Files
     3  node_modules/undici/types/eventsource.d.ts:13
     2  node_modules/undici/types/filereader.d.ts:7
     2  node_modules/undici/types/patch.d.ts:28
     5  node_modules/undici/types/websocket.d.ts:20
```