### PR TITLE
Basic helper for ES|QL's Apache Arrow output format

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   },
   "dependencies": {
     "@elastic/transport": "^8.8.1",
+    "@apache-arrow/esnext-cjs": "^17.0.0",
     "tslib": "^2.4.0"
   },
   "tap": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "zx": "^7.2.2"
   },
   "dependencies": {
-    "@elastic/transport": "^8.8.1",
+    "@elastic/transport": "^8.9.0",
     "@apache-arrow/esnext-cjs": "^17.0.0",
     "tslib": "^2.4.0"
   },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,6 +25,7 @@ import assert from 'node:assert'
 import * as timersPromises from 'node:timers/promises'
 import { Readable } from 'node:stream'
 import { errors, TransportResult, TransportRequestOptions, TransportRequestOptionsWithMeta } from '@elastic/transport'
+import { Table, tableFromIPC } from '@apache-arrow/esnext-cjs'
 import Client from './client'
 import * as T from './api/types'
 
@@ -155,6 +156,7 @@ export interface EsqlResponse {
 
 export interface EsqlHelper {
   toRecords: <TDocument>() => Promise<EsqlToRecords<TDocument>>
+  toArrow: () => Promise<Table<any>>
 }
 
 export interface EsqlToRecords<TDocument> {
@@ -997,6 +999,13 @@ export default class Helpers {
         const records: TDocument[] = toRecords(response)
         const { columns } = response
         return { records, columns }
+      },
+
+      async toArrow (): Promise<Table<any>> {
+        params.format = 'arrow'
+
+        const response = await client.esql.query(params, reqOptions)
+        return tableFromIPC(response)
       }
     }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,7 +25,7 @@ import assert from 'node:assert'
 import * as timersPromises from 'node:timers/promises'
 import { Readable } from 'node:stream'
 import { errors, TransportResult, TransportRequestOptions, TransportRequestOptionsWithMeta } from '@elastic/transport'
-import { Table, tableFromIPC } from '@apache-arrow/esnext-cjs'
+import { Table, TypeMap, tableFromIPC } from '@apache-arrow/esnext-cjs'
 import Client from './client'
 import * as T from './api/types'
 
@@ -156,7 +156,7 @@ export interface EsqlResponse {
 
 export interface EsqlHelper {
   toRecords: <TDocument>() => Promise<EsqlToRecords<TDocument>>
-  toArrow: () => Promise<Table<any>>
+  toArrow: () => Promise<Table<TypeMap>>
 }
 
 export interface EsqlToRecords<TDocument> {
@@ -1001,7 +1001,7 @@ export default class Helpers {
         return { records, columns }
       },
 
-      async toArrow (): Promise<Table<any>> {
+      async toArrow (): Promise<Table<TypeMap>> {
         params.format = 'arrow'
 
         const response = await client.esql.query(params, reqOptions)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -991,6 +991,7 @@ export default class Helpers {
        */
       async toRecords<TDocument>(): Promise<EsqlToRecords<TDocument>> {
         params.format = 'json'
+        params.columnar = false
         // @ts-expect-error it's typed as ArrayBuffer but we know it will be JSON
         const response: EsqlResponse = await client.esql.query(params, reqOptions)
         const records: TDocument[] = toRecords(response)

--- a/test/unit/helpers/esql.test.ts
+++ b/test/unit/helpers/esql.test.ts
@@ -143,6 +143,32 @@ test('ES|QL helper', t => {
       t.end()
     })
 
+    t.test('ESQL helper uses correct x-elastic-client-meta helper value', async t => {
+      const binaryContent = '/////zABAAAQAAAAAAAKAA4ABgANAAgACgAAAAAABAAQAAAAAAEKAAwAAAAIAAQACgAAAAgAAAAIAAAAAAAAAAIAAAB8AAAABAAAAJ7///8UAAAARAAAAEQAAAAAAAoBRAAAAAEAAAAEAAAAjP///wgAAAAQAAAABAAAAGRhdGUAAAAADAAAAGVsYXN0aWM6dHlwZQAAAAAAAAAAgv///wAAAQAEAAAAZGF0ZQAAEgAYABQAEwASAAwAAAAIAAQAEgAAABQAAABMAAAAVAAAAAAAAwFUAAAAAQAAAAwAAAAIAAwACAAEAAgAAAAIAAAAEAAAAAYAAABkb3VibGUAAAwAAABlbGFzdGljOnR5cGUAAAAAAAAAAAAABgAIAAYABgAAAAAAAgAGAAAAYW1vdW50AAAAAAAA/////7gAAAAUAAAAAAAAAAwAFgAOABUAEAAEAAwAAABgAAAAAAAAAAAABAAQAAAAAAMKABgADAAIAAQACgAAABQAAABYAAAABQAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAQAAAAAAAAAIAAAAAAAAACgAAAAAAAAAMAAAAAAAAAABAAAAAAAAADgAAAAAAAAAKAAAAAAAAAAAAAAAAgAAAAUAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAHwAAAAAAAAAAAACgmZkTQAAAAGBmZiBAAAAAAAAAL0AAAADAzMwjQAAAAMDMzCtAHwAAAAAAAADV6yywkgEAANWPBquSAQAA1TPgpZIBAADV17mgkgEAANV7k5uSAQAA/////wAAAAA='
+
+      const MockConnection = connection.buildMockConnection({
+        onRequest (params) {
+          const header = params.headers?.['x-elastic-client-meta'] ?? ''
+          t.ok(header.includes('h=qa'), `Client meta header does not include ESQL helper value: ${header}`)
+          return {
+            body: Buffer.from(binaryContent, 'base64'),
+            statusCode: 200,
+            headers: {
+              'content-type': 'application/vnd.elasticsearch+arrow+stream'
+            }
+          }
+        }
+      })
+
+      const client = new Client({
+        node: 'http://localhost:9200',
+        Connection: MockConnection
+      })
+
+      await client.helpers.esql({ query: 'FROM sample_data' }).toArrow()
+      t.end()
+    })
+
     t.end()
   })
   t.end()

--- a/test/unit/helpers/esql.test.ts
+++ b/test/unit/helpers/esql.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { test } from 'tap'
+import { Table } from '@apache-arrow/esnext-cjs'
 import { connection } from '../../utils'
 import { Client } from '../../../'
 
@@ -104,6 +105,41 @@ test('ES|QL helper', t => {
       })
 
       await client.helpers.esql({ query: 'FROM sample_data' }).toRecords()
+      t.end()
+    })
+
+    t.end()
+  })
+
+  test('toArrow', t => {
+    t.test('Parses a binary response into an Arrow table', async t => {
+      const binaryContent = '/////zABAAAQAAAAAAAKAA4ABgANAAgACgAAAAAABAAQAAAAAAEKAAwAAAAIAAQACgAAAAgAAAAIAAAAAAAAAAIAAAB8AAAABAAAAJ7///8UAAAARAAAAEQAAAAAAAoBRAAAAAEAAAAEAAAAjP///wgAAAAQAAAABAAAAGRhdGUAAAAADAAAAGVsYXN0aWM6dHlwZQAAAAAAAAAAgv///wAAAQAEAAAAZGF0ZQAAEgAYABQAEwASAAwAAAAIAAQAEgAAABQAAABMAAAAVAAAAAAAAwFUAAAAAQAAAAwAAAAIAAwACAAEAAgAAAAIAAAAEAAAAAYAAABkb3VibGUAAAwAAABlbGFzdGljOnR5cGUAAAAAAAAAAAAABgAIAAYABgAAAAAAAgAGAAAAYW1vdW50AAAAAAAA/////7gAAAAUAAAAAAAAAAwAFgAOABUAEAAEAAwAAABgAAAAAAAAAAAABAAQAAAAAAMKABgADAAIAAQACgAAABQAAABYAAAABQAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAQAAAAAAAAAIAAAAAAAAACgAAAAAAAAAMAAAAAAAAAABAAAAAAAAADgAAAAAAAAAKAAAAAAAAAAAAAAAAgAAAAUAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAHwAAAAAAAAAAAACgmZkTQAAAAGBmZiBAAAAAAAAAL0AAAADAzMwjQAAAAMDMzCtAHwAAAAAAAADV6yywkgEAANWPBquSAQAA1TPgpZIBAADV17mgkgEAANV7k5uSAQAA/////wAAAAA='
+
+      const MockConnection = connection.buildMockConnection({
+        onRequest (_params) {
+          return {
+            body: Buffer.from(binaryContent, 'base64'),
+            statusCode: 200,
+            headers: {
+              'content-type': 'application/vnd.elasticsearch+arrow+stream'
+            }
+          }
+        }
+      })
+
+      const client = new Client({
+        node: 'http://localhost:9200',
+        Connection: MockConnection
+      })
+
+      const result = await client.helpers.esql({ query: 'FROM sample_data' }).toArrow()
+      t.ok(result instanceof Table)
+
+      const table = [...result]
+      t.same(table[0], [
+        ["amount", 4.900000095367432],
+        ["date", 1729532586965],
+      ])
       t.end()
     })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "ES2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,
@@ -21,7 +21,8 @@
     "importHelpers": true,
     "outDir": "lib",
     "lib": [
-      "esnext"
+      "ES2019",
+      "dom"
     ]
   },
   "formatCodeOptions": {


### PR DESCRIPTION
New helper function `client.helper.esql(...).toArrow()` returns the results of an [ES|QL query](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-getting-started.html) as an [Arrow `Table`](https://arrow.apache.org/docs/js/classes/Arrow_dom.Table.html). For #2269.
