### PR TITLE
Enable Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>elastic/renovate-config"
+  ],
+  "schedule": [
+    "* * * * 0"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "automerge": true,
+      "labels": [
+        "backport 8.x"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Experimentally enabling Renovate, with conservative configs to only run once a week and only on `devDependencies`.
