### PR TITLE
Add `_id` to the result of `helpers.search`

### DIFF
--- a/test/unit/helpers/search.test.ts
+++ b/test/unit/helpers/search.test.ts
@@ -24,14 +24,14 @@ import { connection } from '../../utils'
 test('Search should have an additional documents property', async t => {
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
-      t.equal(params.querystring, 'filter_path=hits.hits._source')
+      t.equal(params.querystring, 'filter_path=hits.hits._id%2Chits.hits._source')
       return {
         body: {
           hits: {
             hits: [
-              { _source: { one: 'one' } },
-              { _source: { two: 'two' } },
-              { _source: { three: 'three' } }
+              { _id: '1', _source: { one: 'one' } },
+              { _id: '2', _source: { two: 'two' } },
+              { _id: '3', _source: { three: 'three' } }
             ]
           }
         }
@@ -49,16 +49,16 @@ test('Search should have an additional documents property', async t => {
     query: { match_all: {} }
   })
   t.same(result, [
-    { one: 'one' },
-    { two: 'two' },
-    { three: 'three' }
+    { _id: '1', one: 'one' },
+    { _id: '2', two: 'two' },
+    { _id: '3', three: 'three' }
   ])
 })
 
 test('kGetHits fallback', async t => {
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
-      t.equal(params.querystring, 'filter_path=hits.hits._source')
+      t.equal(params.querystring, 'filter_path=hits.hits._id%2Chits.hits._source')
       return { body: {} }
     }
   })
@@ -78,14 +78,14 @@ test('kGetHits fallback', async t => {
 test('Merge filter paths (snake_case)', async t => {
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
-      t.equal(params.querystring, 'filter_path=foo%2Chits.hits._source')
+      t.equal(params.querystring, 'filter_path=foo%2Chits.hits._id%2Chits.hits._source')
       return {
         body: {
           hits: {
             hits: [
-              { _source: { one: 'one' } },
-              { _source: { two: 'two' } },
-              { _source: { three: 'three' } }
+              { _id: '1', _source: { one: 'one' } },
+              { _id: '2', _source: { two: 'two' } },
+              { _id: '3', _source: { three: 'three' } }
             ]
           }
         }
@@ -104,9 +104,9 @@ test('Merge filter paths (snake_case)', async t => {
     query: { match_all: {} }
   })
   t.same(result, [
-    { one: 'one' },
-    { two: 'two' },
-    { three: 'three' }
+    { _id: '1', one: 'one' },
+    { _id: '2', two: 'two' },
+    { _id: '3', three: 'three' }
   ])
 })
 


### PR DESCRIPTION
# Overview
This PR adds the `_id` field to the object returned by `helpers.search`.

# Motivation
A vast majority of my use cases require knowing the IDs of the documents being fetched, which is why I end up using instead the regular `search` function instead of the `helpers.search` handy helper.

# Additional considerations

At first I thought about adding an extra parameter to the function (`extraOptions`?), but after some consideration, I'm not sure that changing the existing behavior would be disruptive.  
Still, I don't mind re-implementing this feature in any other manner.

## Some notes
1. `_id` is an illegal field name, meaning `_source` will never include it.
2. Here is the `@es_quirk` I'm referring to in the comments (exists since version 8.14.0):
    ```
   /**
      * @es_quirk '_id' is not available when using 'stored_fields: _none_'
      * on a search request. Otherwise the field is always present on hits.
   */
   ```
    (In the code I rather not quote it.)