### PR TITLE
Disable Dockerfile Node.js upgrades by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,15 @@
       "labels": [
         "backport 8.x"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "node"
+      ],
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Updates like [this](https://github.com/elastic/elasticsearch-js/pull/2498) are not necessary.