### PR TITLE
Drop support for body param in helpers and tests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -383,9 +383,9 @@ export default class Client extends API {
       maxResponseSize: options.maxResponseSize,
       maxCompressedResponseSize: options.maxCompressedResponseSize,
       vendoredHeaders: {
-        jsonContentType: 'application/vnd.elasticsearch+json; compatible-with=8',
-        ndjsonContentType: 'application/vnd.elasticsearch+x-ndjson; compatible-with=8',
-        accept: 'application/vnd.elasticsearch+json; compatible-with=8,text/plain'
+        jsonContentType: 'application/vnd.elasticsearch+json; compatible-with=9',
+        ndjsonContentType: 'application/vnd.elasticsearch+x-ndjson; compatible-with=9',
+        accept: 'application/vnd.elasticsearch+json; compatible-with=9,text/plain'
       },
       redaction: options.redaction
     })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -910,7 +910,7 @@ export default class Helpers {
 
       function tryBulk (bulkBody: string[], callback: (err: Error | null, bulkBody: string[]) => void): void {
         if (shouldAbort) return callback(null, [])
-        client.bulk(Object.assign({}, bulkOptions, { body: bulkBody }), reqOptions as TransportRequestOptionsWithMeta)
+        client.bulk(Object.assign({}, bulkOptions, { operations: bulkBody }), reqOptions as TransportRequestOptionsWithMeta)
           .then(response => {
             const result = response.body
             const results = zipBulkResults(result.items, bulkBody)

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -22,7 +22,7 @@ import { connection } from '../utils'
 import { Client } from '../..'
 import * as T from '../../lib/api/types'
 
-test('Api without body key and top level body', async t => {
+test('Api with top level body', async t => {
   t.plan(2)
 
   const Connection = connection.buildMockConnection({
@@ -50,37 +50,7 @@ test('Api without body key and top level body', async t => {
   t.equal(response.took, 42)
 })
 
-test('Api with body key and top level body', async t => {
-  t.plan(2)
-
-  const Connection = connection.buildMockConnection({
-    onRequest (opts) {
-      // @ts-expect-error
-      t.same(JSON.parse(opts.body), { query: { match_all: {} } })
-      return {
-        statusCode: 200,
-        body: { took: 42 }
-      }
-    }
-  })
-
-  const client = new Client({
-    node: 'http://localhost:9200',
-    Connection
-  })
-
-  const response = await client.search({
-    index: 'test',
-    allow_no_indices: true,
-    body: {
-      query: { match_all: {} }
-    }
-  })
-
-  t.equal(response.took, 42)
-})
-
-test('Api without body key and keyed body', async t => {
+test('Api with keyed body', async t => {
   t.plan(2)
 
   const Connection = connection.buildMockConnection({
@@ -106,95 +76,6 @@ test('Api without body key and keyed body', async t => {
   })
 
   t.equal(response.result, 'created')
-})
-
-test('Api with body key and keyed body', async t => {
-  t.plan(2)
-
-  const Connection = connection.buildMockConnection({
-    onRequest (opts) {
-      // @ts-expect-error
-      t.same(JSON.parse(opts.body), { foo: 'bar' })
-      return {
-        statusCode: 200,
-        body: { result: 'created' }
-      }
-    }
-  })
-
-  const client = new Client({
-    node: 'http://localhost:9200',
-    Connection
-  })
-
-  const response = await client.create({
-    index: 'test',
-    id: '1',
-    body: { foo: 'bar' }
-  })
-
-  t.equal(response.result, 'created')
-})
-
-test('Using the body key should not mutate the body', async t => {
-  t.plan(2)
-
-  const Connection = connection.buildMockConnection({
-    onRequest (opts) {
-      // @ts-expect-error
-      t.same(JSON.parse(opts.body), { query: { match_all: {} }, sort: 'foo' })
-      return {
-        statusCode: 200,
-        body: { took: 42 }
-      }
-    }
-  })
-
-  const client = new Client({
-    node: 'http://localhost:9200',
-    Connection
-  })
-
-  const body = { query: { match_all: {} } }
-  await client.search({
-    index: 'test',
-    sort: 'foo',
-    body
-  })
-
-  t.same(body, { query: { match_all: {} } })
-})
-
-test('Using the body key with a string value', async t => {
-  t.plan(2)
-
-  const Connection = connection.buildMockConnection({
-    onRequest (opts) {
-      // @ts-expect-error
-      t.same(JSON.parse(opts.body), { query: { match_all: {} } })
-      return {
-        statusCode: 200,
-        body: { took: 42 }
-      }
-    }
-  })
-
-  const client = new Client({
-    node: 'http://localhost:9200',
-    Connection
-  })
-
-  try {
-    const body = { query: { match_all: {} } }
-    await client.search({
-      index: 'test',
-      // @ts-expect-error
-      body: JSON.stringify(body)
-    })
-    t.pass('ok!')
-  } catch (err: any) {
-    t.fail(err)
-  }
 })
 
 test('With generic document', async t => {

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -58,7 +58,7 @@ test('bulk index', t => {
         onRequest (params) {
           t.equal(params.path, '/_bulk')
           t.match(params.headers, {
-            'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8',
+            'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9',
             'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
           })
           // @ts-expect-error
@@ -104,7 +104,7 @@ test('bulk index', t => {
       const MockConnection = connection.buildMockConnection({
         onRequest (params) {
           t.equal(params.path, '/_bulk')
-          t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+          t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
           t.notMatch(params.headers, {
             'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
           })
@@ -150,7 +150,7 @@ test('bulk index', t => {
       const MockConnection = connection.buildMockConnection({
         onRequest (params) {
           t.equal(params.path, '/_bulk')
-          t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+          t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
           // @ts-expect-error
           t.equal(params.body.split('\n').filter(Boolean).length, 6)
           return { body: { errors: false, items: new Array(3).fill({}) } }
@@ -195,7 +195,7 @@ test('bulk index', t => {
             return { body: { acknowledged: true } }
           } else {
             t.equal(params.path, '/_bulk')
-            t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+            t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
             // @ts-expect-error
             const [action, payload] = params.body.split('\n')
             t.same(JSON.parse(action), { index: { _index: 'test' } })
@@ -241,7 +241,7 @@ test('bulk index', t => {
             return { body: { acknowledged: true } }
           } else {
             t.equal(params.path, '/_bulk')
-            t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+            t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
             // @ts-expect-error
             const [action, payload] = params.body.split('\n')
             t.same(JSON.parse(action), { index: { _index: 'test' } })
@@ -283,7 +283,7 @@ test('bulk index', t => {
       const MockConnection = connection.buildMockConnection({
         onRequest (params) {
           t.equal(params.path, '/_bulk')
-          t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+          t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
           // @ts-expect-error
           const [action, payload] = params.body.split('\n')
           t.same(JSON.parse(action), { index: { _index: 'test', _id: count } })
@@ -328,7 +328,7 @@ test('bulk index', t => {
     t.test('Should perform a bulk request (retry)', async t => {
       async function handler (req: http.IncomingMessage, res: http.ServerResponse) {
         t.equal(req.url, '/_bulk')
-        t.match(req.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(req.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
 
         let body = ''
         req.setEncoding('utf8')
@@ -446,7 +446,7 @@ test('bulk index', t => {
     t.test('Should perform a bulk request (failure)', async t => {
       async function handler (req: http.IncomingMessage, res: http.ServerResponse) {
         t.equal(req.url, '/_bulk')
-        t.match(req.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(req.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
 
         let body = ''
         req.setEncoding('utf8')
@@ -587,7 +587,7 @@ test('bulk index', t => {
     t.test('Should abort a bulk request', async t => {
       async function handler (req: http.IncomingMessage, res: http.ServerResponse) {
         t.equal(req.url, '/_bulk')
-        t.match(req.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(req.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
 
         let body = ''
         req.setEncoding('utf8')
@@ -724,7 +724,7 @@ test('bulk index', t => {
       const MockConnection = connection.buildMockConnection({
         onRequest (params) {
           t.equal(params.path, '/_bulk')
-          t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+          t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
           // @ts-expect-error
           const [action, payload] = params.body.split('\n')
           t.same(JSON.parse(action), { index: { _index: 'test', _id: count } })
@@ -815,7 +815,7 @@ test('bulk index', t => {
       const MockConnection = connection.buildMockConnection({
         onRequest (params) {
           t.equal(params.path, '/_bulk')
-          t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+          t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
           // @ts-expect-error
           const [action, payload] = params.body.split('\n')
           t.same(JSON.parse(action), { index: { _index: 'test' } })
@@ -914,7 +914,7 @@ test('bulk index', t => {
       onRequest (params) {
         t.equal(params.path, '/_bulk')
         t.match(params.headers, {
-          'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8',
+          'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9',
           'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
         })
         // @ts-expect-error
@@ -969,7 +969,7 @@ test('bulk create', t => {
     const MockConnection = connection.buildMockConnection({
       onRequest (params) {
         t.equal(params.path, '/_bulk')
-        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
         // @ts-expect-error
         const [action, payload] = params.body.split('\n')
         t.same(JSON.parse(action), { create: { _index: 'test', _id: count } })
@@ -1017,7 +1017,7 @@ test('bulk create', t => {
     const MockConnection = connection.buildMockConnection({
       onRequest (params) {
         t.equal(params.path, '/_bulk')
-        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
         // @ts-expect-error
         const [action, payload] = params.body.split('\n')
         t.same(JSON.parse(action), { create: { _index: 'test', _id: count } })
@@ -1073,7 +1073,7 @@ test('bulk update', t => {
     const MockConnection = connection.buildMockConnection({
       onRequest (params) {
         t.equal(params.path, '/_bulk')
-        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
         // @ts-expect-error
         const [action, payload] = params.body.split('\n')
         t.same(JSON.parse(action), { update: { _index: 'test', _id: count } })
@@ -1122,7 +1122,7 @@ test('bulk update', t => {
     const MockConnection = connection.buildMockConnection({
       onRequest (params) {
         t.equal(params.path, '/_bulk')
-        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
         // @ts-expect-error
         const [action, payload] = params.body.split('\n')
         t.same(JSON.parse(action), { update: { _index: 'test', _id: count } })
@@ -1169,7 +1169,7 @@ test('bulk update', t => {
     const MockConnection = connection.buildMockConnection({
       onRequest (params) {
         t.equal(params.path, '/_bulk')
-        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
         // @ts-expect-error
         const [action, payload] = params.body.split('\n')
         t.same(JSON.parse(action), { update: { _index: 'test', _id: count } })
@@ -1223,7 +1223,7 @@ test('bulk delete', t => {
     const MockConnection = connection.buildMockConnection({
       onRequest (params) {
         t.equal(params.path, '/_bulk')
-        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
         // @ts-expect-error
         t.same(JSON.parse(params.body), { delete: { _index: 'test', _id: count++ } })
         return { body: { errors: false, items: [{}] } }
@@ -1266,7 +1266,7 @@ test('bulk delete', t => {
   t.test('Should perform a bulk request (failure)', async t => {
     async function handler (req: http.IncomingMessage, res: http.ServerResponse) {
       t.equal(req.url, '/_bulk')
-      t.match(req.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+      t.match(req.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
 
       let body = ''
       req.setEncoding('utf8')
@@ -1469,7 +1469,7 @@ test('transport options', t => {
 
         if (params.path === '/_bulk') {
           t.match(params.headers, {
-            'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8',
+            'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9',
             foo: 'bar'
           })
           return { body: { errors: false, items: [{}] } }
@@ -1618,7 +1618,7 @@ test('Flush interval', t => {
     const MockConnection = connection.buildMockConnection({
       onRequest (params) {
         t.equal(params.path, '/_bulk')
-        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
         // @ts-expect-error
         const [action, payload] = params.body.split('\n')
         t.same(JSON.parse(action), { index: { _index: 'test' } })
@@ -1671,7 +1671,7 @@ test('Flush interval', t => {
       onRequest (params) {
         t.ok(count < 2)
         t.equal(params.path, '/_bulk')
-        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8' })
+        t.match(params.headers, { 'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9' })
         // @ts-expect-error
         const [action, payload] = params.body.split('\n')
         t.same(JSON.parse(action), { index: { _index: 'test' } })
@@ -1730,7 +1730,7 @@ test('Flush interval', t => {
       onRequest (params) {
         t.equal(params.path, '/_bulk')
         t.match(params.headers, {
-          'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=8',
+          'content-type': 'application/vnd.elasticsearch+x-ndjson; compatible-with=9',
           'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${transportVersion},hc=${nodeVersion},h=bp`
         })
         // @ts-expect-error

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -1749,12 +1749,12 @@ test('Flush interval', t => {
       datasource: dataset.slice(),
       flushBytes: 1,
       concurrency: 1,
-      onDocument (doc) {
+      onDocument (_doc) {
         return {
           index: { _index: 'test' }
         }
       },
-      onDrop (doc) {
+      onDrop (_doc) {
         t.fail('This should never be called')
       }
     })


### PR DESCRIPTION
- **Update tests and bulk helper to stop using body param**
- **Update compatible-with content-type header for 9.0**
