### PR TITLE
Parse branch name during code gen including 'x'

### DIFF
--- a/.github/make.sh
+++ b/.github/make.sh
@@ -65,7 +65,7 @@ codegen)
   if [ -v "$VERSION" ] || [[ -z "$VERSION" ]]; then
     # fall back to branch name or `main` if no VERSION is set
     branch_name=$(git rev-parse --abbrev-ref HEAD)
-    if [[ "$branch_name" =~ ^[0-9]+\.[0-9]+ ]]; then
+    if [[ "$branch_name" =~ ^[0-9]+\.([0-9]+|x) ]]; then
       echo -e "\033[36;1mTARGET: codegen -> No VERSION argument found, using branch name: \`$branch_name\`\033[0m"
       VERSION="$branch_name"
     else


### PR DESCRIPTION
Codegen needs to checkout the correct branch of the generator, but was incorrectly matching on `8.x`.
