### PR TITLE
Bump version to 9.0.0-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/elasticsearch",
-  "version": "9.0.0-alpha.1",
+  "version": "9.0.0-alpha.2",
   "versionCanary": "9.0.0-canary.0",
   "description": "The official Elasticsearch client for Node.js",
   "main": "./index.js",


### PR DESCRIPTION
Waiting on https://github.com/elastic/elasticsearch-js/pull/2573.
