### PR TITLE
Another attempt to get Renovate to stop trying to upgrade a Docker image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,12 @@
         "dockerfile"
       ],
       "pinDigests": false
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
The Docker image version is dictated by an upstream env var so the change it keeps trying to make will have no effect anyway.
