### PR TITLE
Slack alerts for integration test suite

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -28,6 +28,9 @@ spec:
     spec:
       repository: elastic/elasticsearch-js
       pipeline_file: .buildkite/pipeline.yml
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
+        SLACK_NOTIFICATIONS_CHANNEL: "#devtools-notify-javascript"
       teams:
         devtools-team:
           access_level: MANAGE_BUILD_AND_READ

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -48,6 +48,9 @@ spec:
         8_x:
           branch: "8.x"
           cronline: "@daily"
-        8_14:
-          branch: "8.16"
+        8_17:
+          branch: "8.17"
+          cronline: "@daily"
+        8_18:
+          branch: "8.18"
           cronline: "@daily"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "zx": "7.2.3"
   },
   "dependencies": {
-    "@elastic/transport": "9.0.0-alpha.3",
+    "@elastic/transport": "9.0.0-alpha.1",
     "apache-arrow": "^18.0.0",
     "tslib": "^2.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "zx": "7.2.3"
   },
   "dependencies": {
-    "@elastic/transport": "9.0.0-alpha.1",
+    "@elastic/transport": "9.0.0-alpha.3",
     "apache-arrow": "^18.0.0",
     "tslib": "^2.4.0"
   },


### PR DESCRIPTION
Notifies Slack channel on integration test failure, updates what branches are tested. Also bumps transport to alpha.3 version.
