### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -2,6 +2,7 @@ project: 'Node.js client'
 exclude:
   - examples/proxy/README.md
 cross_links:
+  - docs-content
   - elasticsearch
 toc:
   - toc: reference

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -764,7 +764,7 @@ Get script contexts.
 
 Get a list of supported script contexts and their methods.
 
-[Endpoint documentation](elasticsearch://docs/reference/scripting-languages/painless/painless-contexts.md)
+[Endpoint documentation](elasticsearch://reference/scripting-languages/painless/painless-contexts.md)
 
 ```ts
 client.getScriptContext()
@@ -1534,7 +1534,7 @@ The API uses several *contexts*, which control how scripts are run, what variabl
 
 Each context requires a script, but additional parameters depend on the context you’re using for that script.
 
-[Endpoint documentation](elasticsearch://docs/reference/scripting-languages/painless/painless-api-examples.md)
+[Endpoint documentation](elasticsearch://reference/scripting-languages/painless/painless-api-examples.md)
 
 ```ts
 client.scriptsPainlessExecute({ ... })
@@ -5261,7 +5261,7 @@ client.ilm.stop({ ... })
 
 Add an index block. Limits the operations allowed on an index by blocking specific operation types.
 
-[Index block settings](elasticsearch://docs/reference/elasticsearch/index-settings/index-block.md)
+[Index block settings](elasticsearch://reference/elasticsearch/index-settings/index-block.md)
 
 ```ts
 client.indices.addBlock({ index, block })
@@ -7375,7 +7375,7 @@ client.ingest.deletePipeline({ id })
 
 Get GeoIP statistics. Get download statistics for GeoIP2 databases that are used with the GeoIP processor.
 
-[Endpoint documentation](elasticsearch://docs/reference/ingestion-tools/enrich-processor/geoip-processor.md)
+[Endpoint documentation](elasticsearch://reference/ingestion-tools/enrich-processor/geoip-processor.md)
 
 ```ts
 client.ingest.geoIpStats()
@@ -7446,7 +7446,7 @@ client.ingest.getPipeline({ ... })
 
 Run a grok processor. Extract structured fields out of a single text field within a document. You must choose which field to extract matched fields from, as well as the grok pattern you expect will match. A grok pattern is like a regular expression that supports aliased expressions that can be reused.
 
-[Endpoint documentation](elasticsearch://docs/reference/ingestion-tools/enrich-processor/grok-processor.md)
+[Endpoint documentation](elasticsearch://reference/ingestion-tools/enrich-processor/grok-processor.md)
 
 ```ts
 client.ingest.processorGrok()

--- a/docs/reference/connecting.md
+++ b/docs/reference/connecting.md
@@ -133,7 +133,7 @@ Running {{es}} without security enabled is not recommended.
 ::::
 
 
-If your cluster is configured with [security explicitly disabled](elasticsearch://docs/reference/elasticsearch/configuration-reference/security-settings.md) then you can connect via HTTP:
+If your cluster is configured with [security explicitly disabled](elasticsearch://reference/elasticsearch/configuration-reference/security-settings.md) then you can connect via HTTP:
 
 ```js
 const { Client } = require('@elastic/elasticsearch')
@@ -332,7 +332,7 @@ The supported request specific options are:
 | Option | Description |
 | --- | ----------- |
 | `ignore` | `number[]` -  HTTP status codes which should not be considered errors for this request.<br>*Default:* `null` |
-| `requestTimeout` | `number` or `string` - Max request timeout for the request in milliseconds. This overrides the client default, which is to not time out at all. See [Elasticsearch best practices for HTML clients](elasticsearch://docs/reference/elasticsearch/configuration-reference/networking-settings.md#_http_client_configuration) for more info.<br>_Default:* No timeout |
+| `requestTimeout` | `number` or `string` - Max request timeout for the request in milliseconds. This overrides the client default, which is to not time out at all. See [Elasticsearch best practices for HTML clients](elasticsearch://reference/elasticsearch/configuration-reference/networking-settings.md#_http_client_configuration) for more info.<br>_Default:* No timeout |
 | `retryOnTimeout` | `boolean` - Retry requests that have timed out.*Default:* `false` |
 | `maxRetries` | `number` - Max number of retries for the request, it overrides the client default.<br>*Default:* `3` |
 | `compression` | `string` or  `boolean` - Enables body compression for the request.<br>*Options:* `false`, `'gzip'`<br>*Default:* `false` |
@@ -341,7 +341,7 @@ The supported request specific options are:
 |`querystring` | `object` - Custom querystring for the request.<br>*Default:* `null` |
 | `id` | `any` - Custom request ID. *(overrides the top level request id generator)*<br>*Default:* `null` |
 | `context` | `any` - Custom object per request. *(you can use it to pass data to the clients events)*<br>*Default:* `null` |
-| `opaqueId` | `string` - Set the `X-Opaque-Id` HTTP header. See [X-Opaque-Id HTTP header](elasticsearch://docs/reference/elasticsearch/rest-apis/api-conventions.md#x-opaque-id) *Default:* `null` |
+| `opaqueId` | `string` - Set the `X-Opaque-Id` HTTP header. See [X-Opaque-Id HTTP header](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#x-opaque-id) *Default:* `null` |
 | `maxResponseSize` | `number` - When configured, it verifies that the uncompressed response size is lower than the configured number, if it’s higher it will abort the request. It cannot be higher than buffer.constants.MAX_STRING_LENTGH<br>*Default:* `null` |
 | `maxCompressedResponseSize` | `number` - When configured, it verifies that the compressed response size is lower than the configured number, if it’s higher it will abort the request. It cannot be higher than buffer.constants.MAX_LENTGH<br>*Default:* `null` |
 | `signal` | `AbortSignal` - The AbortSignal instance to allow request abortion.<br>*Default:* `null` |

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -312,7 +312,7 @@ child.search({
 
 ## X-Opaque-Id support [_x_opaque_id_support]
 
-To improve observability, the client offers an easy way to configure the `X-Opaque-Id` header. If you set the `X-Opaque-Id` in a specific request, this allows you to discover this identifier in the [deprecation logs](docs-content://deploy-manage/monitor/logging-configuration/update-elasticsearch-logging-levels.md#deprecation-logging), helps you with [identifying search slow log origin](elasticsearch://docs/reference/elasticsearch/index-settings/slow-log.md) as well as [identifying running tasks](https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-tasks).
+To improve observability, the client offers an easy way to configure the `X-Opaque-Id` header. If you set the `X-Opaque-Id` in a specific request, this allows you to discover this identifier in the [deprecation logs](docs-content://deploy-manage/monitor/logging-configuration/update-elasticsearch-logging-levels.md#deprecation-logging), helps you with [identifying search slow log origin](elasticsearch://reference/elasticsearch/index-settings/slow-log.md) as well as [identifying running tasks](https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-tasks).
 
 The `X-Opaque-Id` should be configured in each request, for doing that you can use the `opaqueId` option, as you can see in the following example. The resulting header will be `{ 'X-Opaque-Id': 'my-search' }`.
 


### PR DESCRIPTION
Follow up to #2635 

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).