### PR TITLE
Merge serverless functionality from @elastic/elasticsearch-serverless

### DIFF
--- a/docs/reference/basic-config.md
+++ b/docs/reference/basic-config.md
@@ -20,7 +20,7 @@ const client = new Client({
 
 ### `node` or `nodes`
 
-The Elasticsearch endpoint to use. It can be a single string or an array of strings:
+The {{es}} endpoint to use. It can be a single string or an array of strings:
 
 ```js
 node: 'http://localhost:9200'
@@ -418,4 +418,4 @@ Options for how to redact potentially sensitive data from metadata attached to `
 Type: `string`<br>
 Default: `"stack"`
 
-Setting to `"stack"` sets defaults assuming a traditional (non-serverless) Elasticsearch instance. Setting to `"serverless"` sets defaults to work more seamlessly with [Elastic Cloud Serverless](https://www.elastic.co/guide/en/serverless/current/intro.html), like enabling compression and disabling features that assume the possibility of multiple Elasticsearch nodes.
+Setting to `"stack"` sets defaults assuming a traditional (non-serverless) {{es}} instance. Setting to `"serverless"` sets defaults to work more seamlessly with [Elastic Cloud Serverless](https://www.elastic.co/guide/en/serverless/current/intro.html), like enabling compression and disabling features that assume the possibility of multiple {{es}} nodes.

--- a/docs/reference/basic-config.md
+++ b/docs/reference/basic-config.md
@@ -26,6 +26,10 @@ The Elasticsearch endpoint to use. It can be a single string or an array of stri
 node: 'http://localhost:9200'
 ```
 
+```js
+nodes: ['http://localhost:9200', 'http://localhost:9201']
+```
+
 Or it can be an object (or an array of objects) that represents the node:
 
 ```js
@@ -52,7 +56,6 @@ Default: `null`
 
 Your authentication data. You can use both basic authentication and [ApiKey](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key).
  See [Authentication](/reference/connecting.md#authentication) for more details.
- 
 
 Basic authentication:
 
@@ -113,7 +116,7 @@ Max ping request timeout in milliseconds for each request.
 Type: `number, boolean`<br>
 Default: `false`
 
-Perform a sniff operation every `n` milliseconds. 
+Perform a sniff operation every `n` milliseconds.
 
 :::{tip}
 Sniffing might not be the best solution. Before using the various `sniff` options, review this [blog post](https://www.elastic.co/blog/elasticsearch-sniffing-best-practices-what-when-why-how).
@@ -182,7 +185,7 @@ Options: `'gzip'`, `false`
 Type: `http.SecureContextOptions`<br>
 Default: `null`
 
-The [tls configuraton](https://nodejs.org/api/tls.md).
+The [tls configuraton](https://nodejs.org/api/tls.html).
 
 ---
 
@@ -192,7 +195,6 @@ Type: `string, URL`<br>
 Default: `null`
 
 If you are using an http(s) proxy, you can put its url here. The client will automatically handle the connection to it.
- 
 
 ```js
 const client = new Client({
@@ -213,7 +215,7 @@ const client = new Client({
 Type: `http.AgentOptions, function`<br>
 Default: `null`
 
-http agent [options](https://nodejs.org/api/http.md#http_new_agent_options), or a function that returns an actual http agent instance. If you want to disable the http agent use entirely (and disable the `keep-alive` feature), set the agent to `false`.
+http agent [options](https://nodejs.org/api/http.html#http_new_agent_options), or a function that returns an actual http agent instance. If you want to disable the http agent use entirely (and disable the `keep-alive` feature), set the agent to `false`.
 
 ```js
 const client = new Client({
@@ -395,3 +397,25 @@ Type: `number`<br>
 Default: `null`
 
 When configured, `maxCompressedResponseSize` verifies that the compressed response size is lower than the configured number. If it’s higher, the request will be canceled. The `maxCompressedResponseSize` cannot be higher than the value of `buffer.constants.MAX_STRING_LENGTH`.
+
+---
+
+### `redaction`
+
+Type: `object`<br>
+Default: A configuration that will replace known sources of sensitive data in `Error` metadata
+
+Options for how to redact potentially sensitive data from metadata attached to `Error` objects
+
+::::{note}
+[Read about redaction](/reference/advanced-config.md#redaction) for more details
+::::
+
+---
+
+### `serverMode`
+
+Type: `string`<br>
+Default: `"stack"`
+
+Setting to `"stack"` sets defaults assuming a traditional (non-serverless) Elasticsearch instance. Setting to `"serverless"` sets defaults to work more seamlessly with [Elastic Cloud Serverless](https://www.elastic.co/guide/en/serverless/current/intro.html), like enabling compression and disabling features that assume the possibility of multiple Elasticsearch nodes.

--- a/docs/reference/client-helpers.md
+++ b/docs/reference/client-helpers.md
@@ -11,14 +11,11 @@ The client comes with an handy collection of helpers to give you a more comforta
 The client helpers are experimental, and the API may change in the next minor releases. The helpers will not work in any Node.js version lower than 10.
 ::::
 
-
-
 ## Bulk helper [bulk-helper]
 
 Added in `v7.7.0`
 
 Running bulk requests can be complex due to the shape of the API, this helper aims to provide a nicer developer experience around the Bulk API.
-
 
 ### Usage [_usage_3]
 
@@ -67,9 +64,7 @@ To create a new instance of the Bulk helper, access it as shown in the example a
 | `wait` | How much time to wait before retries in milliseconds.<br> *Default:* 5000.<br><br>```js<br>const b = client.helpers.bulk({<br>  wait: 3000<br>})<br>```<br> |
 | `refreshOnCompletion` | If `true`, at the end of the bulk operation it runs a refresh on all indices or on the specified indices.<br> *Default:* false.<br><br>```js<br>const b = client.helpers.bulk({<br>  refreshOnCompletion: true<br>  // or<br>  refreshOnCompletion: 'index-name'<br>})<br>```<br> |
 
-
 ### Supported operations [_supported_operations]
-
 
 #### Index [_index_2]
 
@@ -84,7 +79,6 @@ client.helpers.bulk({
 })
 ```
 
-
 #### Create [_create_4]
 
 ```js
@@ -97,7 +91,6 @@ client.helpers.bulk({
   }
 })
 ```
-
 
 #### Update [_update_3]
 
@@ -116,7 +109,6 @@ client.helpers.bulk({
 })
 ```
 
-
 #### Delete [_delete_10]
 
 ```js
@@ -130,7 +122,6 @@ client.helpers.bulk({
 })
 ```
 
-
 ### Abort a bulk operation [_abort_a_bulk_operation]
 
 If needed, you can abort a bulk operation at any time. The bulk helper returns a [thenable](https://promisesaplus.com/), which has an `abort` method.
@@ -138,7 +129,6 @@ If needed, you can abort a bulk operation at any time. The bulk helper returns a
 ::::{note}
 The abort method stops the execution of the bulk operation, but if you are using a concurrency higher than one, the operations that are already running will not be stopped.
 ::::
-
 
 ```js
 const { createReadStream } = require('fs')
@@ -164,7 +154,6 @@ const b = client.helpers.bulk({
 console.log(await b)
 ```
 
-
 ### Passing custom options to the Bulk API [_passing_custom_options_to_the_bulk_api]
 
 You can pass any option supported by the link: [Bulk API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-bulk) to the helper, and the helper uses those options in conjunction with the Bulk API call.
@@ -180,7 +169,6 @@ const result = await client.helpers.bulk({
   pipeline: 'my-pipeline'
 })
 ```
-
 
 ### Usage with an async generator [_usage_with_an_async_generator]
 
@@ -214,7 +202,6 @@ const result = await client.helpers.bulk({
 console.log(result)
 ```
 
-
 ### Modifying a document before operation [_modifying_a_document_before_operation]
 
 Added in `v8.8.2`
@@ -241,13 +228,11 @@ const result = await client.helpers.bulk({
 console.log(result)
 ```
 
-
 ## Multi search helper [multi-search-helper]
 
 Added in `v7.8.0`
 
 If you send search request at a high rate, this helper might be useful for you. It uses the multi search API under the hood to batch the requests and improve the overall performances of your application. The `result` exposes a `documents` property as well, which allows you to access directly the hits sources.
-
 
 ### Usage [_usage_4]
 
@@ -278,7 +263,6 @@ To create a new instance of the multi search (msearch) helper, you should access
 | `retries` | How many times an operation is retried before to resolve the request. An operation is retried only in case of a 429 error.<br> *Default:* Client max retries.<br><br>```js<br>const m = client.helpers.msearch({<br>  retries: 3<br>})<br>```<br> |
 | `wait` | How much time to wait before retries in milliseconds.<br> *Default:* 5000.<br><br>```js<br>const m = client.helpers.msearch({<br>  wait: 3000<br>})<br>```<br> |
 
-
 ### Stopping the msearch helper [_stopping_the_msearch_helper]
 
 If needed, you can stop an msearch processor at any time. The msearch helper returns a [thenable](https://promisesaplus.com/), which has an `stop` method.
@@ -290,7 +274,6 @@ The `stop` method accepts an optional error, that will be dispatched every subse
 ::::{note}
 The stop method stops the execution of the msearch processor, but if you are using a concurrency higher than one, the operations that are already running will not be stopped.
 ::::
-
 
 ```js
 const { Client } = require('@elastic/elasticsearch')
@@ -318,7 +301,6 @@ m.search(
 setImmediate(() => m.stop())
 ```
 
-
 ## Search helper [search-helper]
 
 Added in `v7.7.0`
@@ -339,7 +321,6 @@ for (const doc of documents) {
   console.log(doc)
 }
 ```
-
 
 ## Scroll search helper [scroll-search-helper]
 
@@ -362,7 +343,6 @@ for await (const result of scrollSearch) {
 }
 ```
 
-
 ### Clear a scroll search [_clear_a_scroll_search]
 
 If needed, you can clear a scroll search by calling `result.clear()`:
@@ -375,7 +355,6 @@ for await (const result of scrollSearch) {
 }
 ```
 
-
 ### Quickly getting the documents [_quickly_getting_the_documents]
 
 If you only need the documents from the result of a scroll search, you can access them via `result.documents`:
@@ -385,7 +364,6 @@ for await (const result of scrollSearch) {
   console.log(result.documents)
 }
 ```
-
 
 ## Scroll documents helper [scroll-documents-helper]
 
@@ -408,14 +386,11 @@ for await (const doc of scrollSearch) {
 }
 ```
 
-
 ## ES|QL helper [esql-helper]
 
 ES|QL queries can return their results in [several formats](docs-content://explore-analyze/query-filter/languages/esql-rest.md#esql-rest-format). The default JSON format returned by ES|QL queries contains arrays of values for each row, with column names and types returned separately:
 
-
 ### Usage [_usage_5]
-
 
 #### `toRecords` [_torecords]
 
@@ -494,7 +469,6 @@ const result = await client.helpers
   .toRecords<EventLog>()
 ```
 
-
 #### `toArrowReader` [_toarrowreader]
 
 Added in `v8.16.0`
@@ -515,7 +489,6 @@ for (const recordBatch of reader) {
   }
 }
 ```
-
 
 #### `toArrowTable` [_toarrowtable]
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,13 +7,8 @@ mapped_pages:
 
 The client is designed to be easily configured for your needs. In the following section, you can see the possible options that you can use to configure it.
 
-* [Basic configuration](/reference/basic-config.md)
-* [Advanced configuration](/reference/advanced-config.md)
-* [Timeout best practices](docs-content://troubleshoot/elasticsearch/elasticsearch-client-javascript-api/nodejs.md)
-* [Creating a child client](/reference/child.md)
-* [Testing](/reference/client-testing.md)
-
-
-
-
-
+- [Basic configuration](/reference/basic-config.md)
+- [Advanced configuration](/reference/advanced-config.md)
+- [Timeout best practices](docs-content://troubleshoot/elasticsearch/elasticsearch-client-javascript-api/nodejs.md)
+- [Creating a child client](/reference/child.md)
+- [Testing](/reference/client-testing.md)

--- a/docs/reference/connecting.md
+++ b/docs/reference/connecting.md
@@ -11,7 +11,6 @@ This page contains the information you need to connect and use the Client with {
 
 This document contains code snippets to show you how to connect to various {{es}} providers.
 
-
 ### Elastic Cloud [auth-ec]
 
 If you are using [Elastic Cloud](https://www.elastic.co/cloud), the client offers an easy way to connect to it via the `cloud` option. You must pass the Cloud ID that you can find in the cloud console, then your username and password inside the `auth` option.
@@ -20,11 +19,9 @@ If you are using [Elastic Cloud](https://www.elastic.co/cloud), the client offer
 When connecting to Elastic Cloud, the client will automatically enable both request and response compression by default, since it yields significant throughput improvements. Moreover, the client will also set the tls option `secureProtocol` to `TLSv1_2_method` unless specified otherwise. You can still override this option by configuring them.
 ::::
 
-
 ::::{important}
 Do not enable sniffing when using Elastic Cloud, since the nodes are behind a load balancer, Elastic Cloud will take care of everything for you. Take a look [here](https://www.elastic.co/blog/elasticsearch-sniffing-best-practices-what-when-why-how) to know more.
 ::::
-
 
 ```js
 const { Client } = require('@elastic/elasticsearch')
@@ -39,6 +36,24 @@ const client = new Client({
 })
 ```
 
+## Connecting to an Elastic Cloud Serverless instance [connect-serverless]
+
+The Node.js client is built to support connecting to [Elastic Cloud Serverless](https://www.elastic.co/guide/en/serverless/current/intro.html). By setting the `serverMode` option to `"serverless"`, several default options will be modified to better suit the serverless environment.
+
+```js
+const { Client } = require('@elastic/elasticsearch')
+const client = new Client({
+  cloud: {
+    id: '<cloud-id>'
+  },
+  auth: {
+    username: 'elastic',
+    password: 'changeme'
+  },
+  serverMode: 'serverless'
+})
+
+```
 
 ## Connecting to a self-managed cluster [connect-self-managed-new]
 
@@ -62,7 +77,6 @@ When you start {{es}} for the first time you’ll see a distinct block like the 
 
 Depending on the circumstances there are two options for verifying the HTTPS connection, either verifying with the CA certificate itself or via the HTTP CA certificate fingerprint.
 
-
 ### TLS configuration [auth-tls]
 
 The generated root CA certificate can be found in the `certs` directory in your {{es}} config location (`$ES_CONF_PATH/certs/http_ca.crt`). If you’re running {{es}} in Docker there is [additional documentation for retrieving the CA certificate](docs-content://deploy-manage/deploy/self-managed/install-elasticsearch-with-docker.md).
@@ -83,7 +97,6 @@ const client = new Client({
   }
 })
 ```
-
 
 ### CA fingerprint [auth-ca-fingerprint]
 
@@ -125,13 +138,11 @@ The output of `openssl x509` will look something like this:
 SHA256 Fingerprint=A5:2D:D9:35:11:E8:C6:04:5E:21:F1:66:54:B7:7C:9E:E0:F3:4A:EA:26:D9:F4:03:20:B5:31:C4:74:67:62:28
 ```
 
-
 ## Connecting without security enabled [connect-no-security]
 
 ::::{warning}
 Running {{es}} without security enabled is not recommended.
 ::::
-
 
 If your cluster is configured with [security explicitly disabled](elasticsearch://reference/elasticsearch/configuration-reference/security-settings.md) then you can connect via HTTP:
 
@@ -142,11 +153,9 @@ const client = new Client({
 })
 ```
 
-
 ## Authentication strategies [auth-strategies]
 
 Following you can find all the supported authentication strategies.
-
 
 ### ApiKey authentication [auth-apikey]
 
@@ -155,7 +164,6 @@ You can use the [ApiKey](https://www.elastic.co/docs/api/doc/elasticsearch/opera
 ::::{note}
 If you provide both basic authentication credentials and the ApiKey configuration, the ApiKey takes precedence.
 ::::
-
 
 ```js
 const { Client } = require('@elastic/elasticsearch')
@@ -180,7 +188,6 @@ const client = new Client({
 })
 ```
 
-
 ### Bearer authentication [auth-bearer]
 
 You can provide your credentials by passing the `bearer` token parameter via the `auth` option. Useful for [service account tokens](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-service-token). Be aware that it does not handle automatic token refresh.
@@ -195,7 +202,6 @@ const client = new Client({
 })
 ```
 
-
 ### Basic authentication [auth-basic]
 
 You can provide your credentials by passing the `username` and `password` parameters via the `auth` option.
@@ -203,7 +209,6 @@ You can provide your credentials by passing the `username` and `password` parame
 ::::{note}
 If you provide both basic authentication credentials and the Api Key configuration, the Api Key will take precedence.
 ::::
-
 
 ```js
 const { Client } = require('@elastic/elasticsearch')
@@ -224,7 +229,6 @@ const client = new Client({
   node: 'https://username:password@localhost:9200'
 })
 ```
-
 
 ## Usage [client-usage]
 
@@ -278,8 +282,6 @@ In this case, the result will be:
 The body is a boolean value when you use `HEAD` APIs.
 ::::
 
-
-
 ### Aborting a request [_aborting_a_request]
 
 If needed, you can abort a running request by using the `AbortController` standard.
@@ -287,7 +289,6 @@ If needed, you can abort a running request by using the `AbortController` standa
 ::::{warning}
 If you abort a request, the request will fail with a `RequestAbortedError`.
 ::::
-
 
 ```js
 const AbortController = require('node-abort-controller')
@@ -307,7 +308,6 @@ const result = await client.search({
   }
 }, { signal: abortController.signal })
 ```
-
 
 ### Request specific options [_request_specific_options]
 
@@ -352,7 +352,6 @@ The supported request specific options are:
 
 This section illustrates the best practices for leveraging the {{es}} client in a Function-as-a-Service (FaaS) environment. The most influential optimization is to initialize the client outside of the function, the global scope. This practice does not only improve performance but also enables background functionality as – for example – [sniffing](https://www.elastic.co/blog/elasticsearch-sniffing-best-practices-what-when-why-how). The following examples provide a skeleton for the best practices.
 
-
 ### GCP Cloud Functions [_gcp_cloud_functions]
 
 ```js
@@ -369,7 +368,6 @@ exports.testFunction = async function (req, res) {
 }
 ```
 
-
 ### AWS Lambda [_aws_lambda]
 
 ```js
@@ -385,7 +383,6 @@ exports.handler = async function (event, context) {
   // use the client
 }
 ```
-
 
 ### Azure Functions [_azure_functions]
 
@@ -410,7 +407,6 @@ Resources used to assess these recommendations:
 * [Azure Functions Python developer guide](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-python?tabs=azurecli-linux%2Capplication-level#global-variables)
 * [AWS Lambda: Comparing the effect of global scope](https://docs.aws.amazon.com/lambda/latest/operatorguide/global-scope.html)
 
-
 ## Connecting through a proxy [client-connect-proxy]
 
 Added in `v7.10.0`
@@ -420,7 +416,6 @@ If you need to pass through an http(s) proxy for connecting to {{es}}, the clien
 ::::{important}
 In versions 8.0+ of the client, the default `Connection` type is set to `UndiciConnection`, which does not support proxy configurations. To use a proxy, you will need to use the `HttpConnection` class from `@elastic/transport` instead.
 ::::
-
 
 ```js
 import { HttpConnection } from '@elastic/transport'
@@ -454,7 +449,6 @@ const client = new Client({
   Connection: HttpConnection,
 })
 ```
-
 
 ## Error handling [client-error-handling]
 
@@ -506,7 +500,6 @@ const client = new Client({
 })
 ```
 
-
 ## Closing a client’s connections [close-connections]
 
 If you would like to close all open connections being managed by an instance of the client, use the `close()` function:
@@ -517,7 +510,6 @@ const client = new Client({
 });
 client.close();
 ```
-
 
 ## Automatic product check [product-check]
 


### PR DESCRIPTION
`@elastic/elasticsearch-serverless` is being deprecated, so all appropriate serverless functionality is being merged back into the main stack client.

This PR exposes a new option, `serverMode`, which can be either `"stack"` or `"serverless"`. `"stack"` keeps all defaults consistent with current behavior. `"serverless"` modifies a few defaults:

- turns off sniffing and ignores any sniffing-related options
- ignores all nodes passed in config except the first one, and ignores any node filtering and selecting options
- enables compression and `TLSv1_2_method` (same as when configured for Elastic Cloud)
- adds an `elastic-api-version` HTTP header to all requests
- uses `CloudConnectionPool` by default instead of `WeightedConnectionPool`
- turns off vendored `content-type` and `accept` headers in favor or standard MIME types

Also adds documentation to reflect the change.

Fixes #2459.
