### PR TITLE
[DOCS]Removes link pointing to EIS reference docs

### DIFF
--- a/docs/reference.asciidoc
+++ b/docs/reference.asciidoc
@@ -8287,7 +8287,6 @@ Create an Elastic Inference Service (EIS) inference endpoint.
 
 Create an inference endpoint to perform an inference task through the Elastic Inference Service (EIS).
 
-{ref}/infer-service-elastic.html[Endpoint documentation]
 [source,ts]
 ----
 client.inference.putEis({ task_type, eis_inference_id, service, service_settings })


### PR DESCRIPTION
## Overview

EIS won't be released in 8.18/9.0. The docs referencing EIS need to be pulled out from the generated docs. 
This PR pullso out EIS docs from ES: https://github.com/elastic/elasticsearch/pull/126381
The CI on that PR fails as one of the pages in `elasticsearch-js` links to the content I want to remove. This PR deletes the link to unblock the PR in the ES repo.