### PR TITLE
Restore title from release note setup PR

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,5 +1,5 @@
 ---
-navigation_title: "JavaScript client release notes"
+navigation_title: "Elasticsearch JavaScript Client"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/changelog-client.html
 ---


### PR DESCRIPTION
This PR reverts the navigation title change in https://github.com/elastic/elasticsearch-js/pull/2713, to what @KOTungseth did in https://github.com/elastic/elasticsearch-js/pull/2665 -- so that it looks like the other client docs.

right now it's a mismatch:
<img width="254" alt="Screenshot 2025-04-07 at 6 03 13 PM" src="https://github.com/user-attachments/assets/d58ab9ae-49d0-4483-9bac-499afc513792" />
