### PR TITLE
[Docs] Restore timeout best practices

### DIFF
--- a/docs/reference/timeout-best-practices.md
+++ b/docs/reference/timeout-best-practices.md
@@ -1,0 +1,13 @@
+---
+mapped_pages:
+  - https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/timeout-best-practices.html
+---
+
+# Timeout best practices [timeout-best-practices]
+
+Starting in 9.0.0, this client is configured to not time out any HTTP request by default. {{es}} will always eventually respond to any request, even if it takes several minutes. Reissuing a request that it has not responded to yet can cause performance side effects. See the [official {{es}} recommendations for HTTP clients](elasticsearch://reference/elasticsearch/configuration-reference/networking-settings.md#_http_client_configuration) for more information.
+
+Prior to 9.0, this client was configured by default to operate like many HTTP client libraries do, by using a relatively short (30 second) timeout on all requests sent to {{es}}, raising a `TimeoutError` when that time period elapsed without receiving a response.
+
+If you need to set timeouts on Elasticsearch requests, setting the `requestTimeout` value to a millisecond value will cause this client to operate as it did prior to 9.0.
+

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -32,3 +32,4 @@ toc:
       - file: update_by_query_examples.md
       - file: reindex_examples.md
   - file: client-helpers.md
+  - file: timeout-best-practices.md


### PR DESCRIPTION
👀 [Preview](https://docs-v3-preview.elastic.dev/elastic/elasticsearch-js/pull/2727/reference/timeout-best-practices) 
(the release notes section at the bottom of the left nav won't be there in the full build)

This PR restores a page that was incorrectly migrated to [docs-content](https://github.com/elastic/docs-content).

I'll open a separate PR to remove this from the docs-content repo once this is merged.