### PR TITLE
Fix link to timeout best practices

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -9,6 +9,6 @@ The client is designed to be easily configured for your needs. In the following 
 
 - [Basic configuration](/reference/basic-config.md)
 - [Advanced configuration](/reference/advanced-config.md)
-- [Timeout best practices](docs-content://troubleshoot/elasticsearch/elasticsearch-client-javascript-api/nodejs.md)
+- [Timeout best practices](/reference/timeout-best-practices.md)
 - [Creating a child client](/reference/child.md)
 - [Testing](/reference/client-testing.md)


### PR DESCRIPTION
[Preview](https://docs-v3-preview.elastic.dev/elastic/elasticsearch-js/pull/2729/reference/configuration) (third link)

Missed this in https://github.com/elastic/elasticsearch-js/pull/2727 -- update the link to timeout best practices now that it's back in this repo.