### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/getting-started.md
+++ b/docs/reference/getting-started.md
@@ -45,15 +45,11 @@ const client = new Client({
 
 Your Elasticsearch endpoint can be found on the **My deployment** page of your deployment:
 
-:::{image} images/es-endpoint.jpg
-:alt: Finding Elasticsearch endpoint
-:::
+![Finding Elasticsearch endpoint](images/es-endpoint.jpg)
 
 You can generate an API key on the **Management** page under Security.
 
-:::{image} images/create-api-key.png
-:alt: Create API key
-:::
+![Create API key](images/create-api-key.png)
 
 For other connection options, refer to the [*Connecting*](/reference/connecting.md) section.
 


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 
* Can you please add the appropriate labels needed for backporting?