### PR TITLE
Add test to verify default node filter function

### DIFF
--- a/docs/reference/basic-config.md
+++ b/docs/reference/basic-config.md
@@ -246,12 +246,15 @@ Type: `function`
 Filter that indicates whether a node should be used for a request. Default function definition:
 
 ```js
-function defaultNodeFilter (node) {
-  // avoid master only nodes
-  if (node.roles.master === true &&
-      node.roles.data === false &&
-      node.roles.ingest === false) {
-    return false
+function defaultNodeFilter (conn) {
+  if (conn.roles != null) {
+    if (
+      // avoid master-only nodes
+      conn.roles.master &&
+      !conn.roles.data &&
+      !conn.roles.ingest &&
+      !conn.roles.ml
+    ) return false
   }
   return true
 }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "zx": "7.2.3"
   },
   "dependencies": {
-    "@elastic/transport": "^9.0.0",
+    "@elastic/transport": "^9.0.1",
     "apache-arrow": "^18.0.0",
     "tslib": "^2.4.0"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -132,7 +132,7 @@ export interface ClientOptions {
     * @defaultValue null */
   agent?: HttpAgentOptions | UndiciAgentOptions | agentFn | false
   /** @property nodeFilter A custom function used by the connection pool to determine which nodes are qualified to receive a request
-    * @defaultValue () => true */
+    * @defaultValue A function that uses the Connection `roles` property to avoid master-only nodes */
   nodeFilter?: nodeFilterFn
   /** @property nodeSelector A custom function used by the connection pool to determine which node should receive the next request
     * @defaultValue A "round robin" function that loops sequentially through each node in the pool. */

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -64,6 +64,31 @@ test('Missing node(s)', t => {
   t.end()
 })
 
+test('multi nodes with roles, using default node filter', async t => {
+  const client = new Client({
+    nodes: [
+      {
+        url: new URL('http://node1:9200'),
+        roles: { master: true, data: false, ingest: false, ml: false }
+      },
+      {
+        url: new URL('http://node2:9200'),
+        roles: { master: true, data: true, ingest: false, ml: false }
+      },
+    ]
+  })
+  const conn = client.connectionPool.getConnection({
+    now: Date.now() + 1000 * 60 * 3,
+    requestId: 1,
+    name: 'elasticsearch-js',
+    context: null
+  })
+
+  t.equal(conn?.url.hostname, 'node2')
+
+  t.end()
+})
+
 test('Custom headers', t => {
   const client = new Client({
     node: 'http://localhost:9200',


### PR DESCRIPTION
Turns out https://github.com/elastic/elastic-transport-js/issues/231 doesn't require any actual fix in the client! Adding a test and updating docs anyway.