### PR TITLE
Support Apache Arrow 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "dependencies": {
     "@elastic/transport": "^9.0.1",
-    "apache-arrow": "^18.0.0",
+    "apache-arrow": "18.x - 19.x",
     "tslib": "^2.4.0"
   },
   "tap": {


### PR DESCRIPTION
Apache Arrow 19.0.0 came out and is compatible with the client's usage. We want this project to be compatible with as many versions of Arrow as possible, to ensure it isn't interfering with existing Arrow usage in a project, so setting this to work with any 18.x or 19.x version.
