### PR TITLE
Stop running scheduled integration tests

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -41,11 +41,3 @@ spec:
         build_branches: false
         separate_pull_request_statuses: true
       cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: "!main"
-      schedules:
-        main:
-          branch: "main"
-          cronline: "@daily"
-        8_x:
-          branch: "8.x"
-          cronline: "@daily"


### PR DESCRIPTION
We're running them on PRs again now, so this is now more noisy than useful.
