### PR TITLE
Remove dangling references to typesWithBodyKey

### DIFF
--- a/docs/reference/typescript.md
+++ b/docs/reference/typescript.md
@@ -13,8 +13,6 @@ The types are not 100% complete yet. Some APIs are missing (the newest ones, e.g
 The client is developed against the [latest](https://www.npmjs.com/package/typescript?activeTab=versions) version of TypeScript. Furthermore, unless you have set `skipLibCheck` to `true`, you should configure `esModuleInterop` to `true`.
 ::::
 
-
-
 ## Example [_example]
 
 ```ts
@@ -74,7 +72,6 @@ async function run () {
 run().catch(console.log)
 ```
 
-
 ## Request & Response types [_request_response_types]
 
 You can import the full TypeScript requests & responses definitions as it follows:
@@ -82,10 +79,3 @@ You can import the full TypeScript requests & responses definitions as it follow
 ```ts
 import { estypes } from '@elastic/elasticsearch'
 ```
-
-If you need the legacy definitions with the body, you can do the following:
-
-```ts
-import { estypesWithBody } from '@elastic/elasticsearch'
-```
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,5 @@ import SniffingTransport from './lib/sniffingTransport'
 
 export * from '@elastic/transport'
 export * as estypes from './lib/api/types'
-export * as estypesWithBody from './lib/api/typesWithBodyKey'
 export { Client, SniffingTransport }
 export type { ClientOptions, NodeOptions } from './lib/client'


### PR DESCRIPTION
This was removed for 9.0.
