### PR TITLE
Pass enableClientMeta option to transport

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -407,7 +407,9 @@ export default class Client extends API {
       productCheck: 'Elasticsearch',
       maxResponseSize: options.maxResponseSize,
       maxCompressedResponseSize: options.maxCompressedResponseSize,
-      redaction: options.redaction
+      redaction: options.redaction,
+      // @ts-expect-error new option being added to transport in next minor
+      enableClientMeta: options.enableMetaHeader
     }
     if (options.serverMode !== 'serverless') {
       transportOptions = Object.assign({}, transportOptions, {


### PR DESCRIPTION
Will release in tandem with https://github.com/elastic/elastic-transport-js/pull/285 to ensure telemetry is never leaked when explicitly disabled.
