### PR TITLE
Fix egregious option typo

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -409,7 +409,7 @@ export default class Client extends API {
       maxCompressedResponseSize: options.maxCompressedResponseSize,
       redaction: options.redaction,
       // @ts-expect-error new option being added to transport in next minor
-      enableClientMeta: options.enableMetaHeader
+      enableMetaHeader: options.enableMetaHeader
     }
     if (options.serverMode !== 'serverless') {
       transportOptions = Object.assign({}, transportOptions, {


### PR DESCRIPTION
Fixes the obvious typo I made in https://github.com/elastic/elasticsearch-js/pull/2942 by actually using the correct option name. :facepalm:
