### PR TITLE
Drop @ts-expect-error

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -408,7 +408,6 @@ export default class Client extends API {
       maxResponseSize: options.maxResponseSize,
       maxCompressedResponseSize: options.maxCompressedResponseSize,
       redaction: options.redaction,
-      // @ts-expect-error new option being added to transport in next minor
       enableMetaHeader: options.enableMetaHeader
     }
     if (options.serverMode !== 'serverless') {


### PR DESCRIPTION
Follow-up to https://github.com/elastic/elasticsearch-js/pull/2943. There's a chicken-and-egg problem with this new option so I'm going to let the TypeScript type checker fail on this PR so that it can succeed in https://github.com/elastic/elastic-transport-js/pull/285.
