### PR TITLE
Run tests against Node.js 24

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
     env:
       NODE_VERSION: "{{ matrix.nodejs }}"
       TEST_SUITE: "platinum"
-      STACK_VERSION: 9.0.0
+      STACK_VERSION: 9.1.0
       GITHUB_TOKEN_PATH: "secret/ci/elastic-elasticsearch-js/github-token"
       TEST_ES_STACK: "1"
     matrix:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
         nodejs:
           - "20"
           - "22"
-          - "23"
+          - "24"
     command: ./.buildkite/run-tests.sh
     artifact_paths: "./junit-output/junit-*.xml"
   - wait: ~

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 23.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -73,7 +73,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Install
         run: |

--- a/.github/workflows/npm-publish-unstable.yml
+++ b/.github/workflows/npm-publish-unstable.yml
@@ -52,7 +52,7 @@ jobs:
           ref: main
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm install -g npm
       - run: npm install


### PR DESCRIPTION
Node.js 24 was released in May 2025 but the newest version used by the test suite is 23.
