### PR TITLE
acceptedParams metadata on all API requests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -41,6 +41,8 @@ import transportPackageJson from '@elastic/transport/package.json'
 
 const kChild = Symbol('elasticsearchjs-child')
 const kInitialOptions = Symbol('elasticsearchjs-initial-options')
+export const kAcceptedParams = Symbol('elasticsearchjs-accepted-params')
+
 let clientVersion: string = packageJson.version
 /* istanbul ignore next */
 if (clientVersion.includes('-')) {

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -6,6 +6,7 @@
 import { test } from 'tap'
 import { connection } from '../utils'
 import { Client } from '../..'
+import { Transport } from '@elastic/transport'
 import * as T from '../../lib/api/types'
 
 test('Api with top level body', async t => {
@@ -167,3 +168,98 @@ test('With generic document and aggregation', async t => {
   t.ok(Array.isArray(response.aggregations?.unique.buckets))
 })
 
+test('Api request metadata', t => {
+  t.test('name', async t => {
+    class TestTransport extends Transport {
+      // @ts-expect-error
+      async request(params, options) {
+        t.equal(params.meta.name, 'synonyms.put_synonym_rule')
+        return super.request(params, options)
+      }
+    }
+
+    const Connection = connection.buildMockConnection({
+      onRequest () {
+        return {
+          statusCode: 200,
+          body: { took: 42 }
+        }
+      }
+    })
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+      // @ts-expect-error
+      Transport: TestTransport,
+      Connection
+    })
+    // @ts-expect-error
+    await client.synonyms.putSynonymRule({ set_id: "foo", rule_id: "bar" })
+  })
+
+  t.test('pathParts', async t => {
+    class TestTransport extends Transport {
+      // @ts-expect-error
+      async request(params, options) {
+        t.strictSame(params.meta.pathParts, {
+          set_id: 'foo',
+          rule_id: 'bar'
+        })
+        return super.request(params, options)
+      }
+    }
+
+    const Connection = connection.buildMockConnection({
+      onRequest () {
+        return {
+          statusCode: 200,
+          body: { took: 42 }
+        }
+      }
+    })
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+      // @ts-expect-error
+      Transport: TestTransport,
+      Connection
+    })
+    // @ts-expect-error
+    await client.synonyms.putSynonymRule({ set_id: "foo", rule_id: "bar" })
+  })
+
+  t.test('acceptedParams', async t => {
+    class TestTransport extends Transport {
+      // @ts-expect-error
+      async request(params, options) {
+        t.strictSame(params.meta.acceptedParams, [
+          'set_id',
+          'rule_id',
+          'synonyms',
+          'refresh',
+        ])
+        return super.request(params, options)
+      }
+    }
+
+    const Connection = connection.buildMockConnection({
+      onRequest () {
+        return {
+          statusCode: 200,
+          body: { took: 42 }
+        }
+      }
+    })
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+      // @ts-expect-error
+      Transport: TestTransport,
+      Connection
+    })
+    // @ts-expect-error
+    await client.synonyms.putSynonymRule({ set_id: "foo", rule_id: "bar" })
+  })
+
+  t.end()
+})


### PR DESCRIPTION
In draft form until the code generator is updated to include the new metadata.

Part of https://github.com/elastic/elasticsearch-js/issues/2902