### PR TITLE
Force Bash for unit tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -50,14 +50,17 @@ jobs:
           npm install
 
       - name: Lint
+        shell: bash
         run: |
           [ "$CODE_CHANGED" = "true" ] && npm run lint || exit 0
 
       - name: Unit test
+        shell: bash
         run: |
           [ "$CODE_CHANGED" = "true" ] && npm run test:unit || exit 0
 
       - name: ECMAScript module test
+        shell: bash
         run: |
           [ "$CODE_CHANGED" = "true" ] && npm run test:esm || exit 0
 
@@ -111,13 +114,16 @@ jobs:
           bun install
 
       - name: Lint
+        shell: bash
         run: |
           [ "$CODE_CHANGED" = "true" ] && bun run lint || exit 0
 
       - name: Unit test
+        shell: bash
         run: |
           [ "$CODE_CHANGED" = "true" ] && bun run test:unit-bun || exit 0
 
       - name: ECMAScript module test
+        shell: bash
         run: |
           [ "$CODE_CHANGED" = "true" ] && bun run test:esm || exit 0


### PR DESCRIPTION
You have to specify `bash` on Windows when you do much more than run a simple command in a step.
