### PR TITLE
codegenfix

### DIFF
--- a/.github/make.sh
+++ b/.github/make.sh
@@ -208,8 +208,7 @@ if [[ "$CMD" == "codegen" ]]; then
   if [ -n "$(git status --porcelain)" ]; then
     echo -e "\033[32;1mTARGET: successfully generated client v$VERSION\033[0m"
   else
-    echo -e "\033[31;1mTARGET: failed generating client v$VERSION\033[0m"
-    exit 1
+    echo -e "\033[33;1mTARGET: codegen completed for v$VERSION (no changes - code already up to date)\033[0m"
   fi
 fi
 


### PR DESCRIPTION
automated codegen failure suggests the workflow checks for generated changes are too strict 
Current: when no changes are generated, workflow fails. 
Update: when no changes are generated, we continue/succeed, 

```
$ mv /usr/src/elasticsearch-js/src/api/reference.asciidoc /usr/src/elasticsearch-js/docs/reference.asciidoc
$ npm run build
...
TARGET: failed generating client v8.18
Error: Process completed with exit code 1.
```

impacts 9.0 and 8.18

<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->
