### PR TITLE
Set up publish workflows for OIDC

### DIFF
--- a/.github/workflows/npm-publish-unstable.yml
+++ b/.github/workflows/npm-publish-unstable.yml
@@ -76,5 +76,3 @@ jobs:
 
           # publish to npm
           npm publish --provenance --access public --tag "unstable"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,8 +44,6 @@ jobs:
             tag=$(echo "$tag_meta" | cut -d '.' -f1)
             npm publish --provenance --access public --tag "$tag"
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish version on GitHub
         run: |
           version=$(jq -r .version package.json)


### PR DESCRIPTION
Dropping explicit npm token usage in preparation for using [trusted publishers](https://docs.npmjs.com/trusted-publishers).

Fixes https://github.com/elastic/elasticsearch-js/issues/2996