### PR TITLE
Add token permission to backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,6 +21,8 @@ jobs:
           && contains(github.event.label.name, 'backport')
         )
       )
+    permissions:
+      id-token: write
     steps:
       - name: Fetch ephemeral GitHub token
         id: fetch-token


### PR DESCRIPTION
Backport workflow didn't have correct permissions to fetch a Github token from Vault.
