### PR TITLE
tap fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,9 +121,11 @@
       "test/unit/",
       "test/esm/"
     ],
-    "coverage-exclude": [
-      "*/api/**"
-    ],
+    "coverage": {
+      "exclude": [
+        "*/api/**"
+      ]
+    },
     "statements": 96,
     "branches": 90,
     "lines": 96,


### PR DESCRIPTION
fix the follow `@tap` issue when publishing via npm workflow https://github.com/elastic/elasticsearch-js/actions/runs/21644664363/job/62393470705
```
> @elastic/elasticsearch@9.3.0 lint
> ts-standard src

/home/runner/work/elasticsearch-js/elasticsearch-js/node_modules/@tapjs/config/src/index.ts:406
        this.jack.setConfigValues(rest as OptionsResults<C>, resolved)
                  ^

Error: Unknown config option: coverage-exclude
    at TapConfig.extendConfigData (/home/runner/work/elasticsearch-js/elasticsearch-js/node_modules/@tapjs/config/src/index.ts:406:19)
    at TapConfig.loadConfigData (/home/runner/work/elasticsearch-js/elasticsearch-js/node_modules/@tapjs/config/src/index.ts:361:18)
    at TapConfig.loadConfigFile (/home/runner/work/elasticsearch-js/elasticsearch-js/node_modules/@tapjs/config/src/index.ts:448:21)
    at async TapConfig.load (/home/runner/work/elasticsearch-js/elasticsearch-js/node_modules/@tapjs/config/src/index.ts:567:15)
    at async <anonymous> (/home/runner/work/elasticsearch-js/elasticsearch-js/node_modules/@tapjs/run/src/main-config.ts:7:37) {
  extendedFrom: [
    '/home/runner/work/elasticsearch-js/elasticsearch-js/package.json'
  ],
  [cause]: {
    code: 'JACKSPEAK',
    found: 'coverage-exclude',
    path: '/home/runner/work/elasticsearch-js/elasticsearch-js/package.json'
  }
}
```
