### PR TITLE
tap fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,14 +121,14 @@
       "test/unit/",
       "test/esm/"
     ],
-    "coverage": {
-      "exclude": [
-        "*/api/**"
-      ]
-    },
     "statements": 96,
     "branches": 90,
     "lines": 96,
     "functions": 88
+  },
+  "nyc": {
+    "exclude": [
+      "*/api/**"
+    ]
   }
 }


### PR DESCRIPTION
fix extending https://github.com/elastic/elasticsearch-js/pull/3151
- reran workflow job but got `Error: Unknown config option: coverage` 

upon investigating the error form `Tap v21` https://node-tap.org/coverage/, code coverage doesnt seem supported anymore within package.json and is instead done by `cli` 
since our code coverage needs exclusions, we will use `taps` suggested istanbul reporter `nyc` as shown in the changes