### PR TITLE
9.3 fix tap

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,5 +115,5 @@
     "@elastic/transport": "^9.2.0",
     "apache-arrow": "18.x - 21.x",
     "tslib": "^2.4.0"
-  },
+  }
 }


### PR DESCRIPTION
tried again but got `Error: Unknown config option: statements`

https://github.com/elastic/elasticsearch-js/actions/runs/21646728009/job/62400533032

upgraded tap from 21.1.3 to 21.5.0 (needed for --statements, etc. cli flags)
had to change test command to use cli flags 
removed old/deprecated tap configs