### PR TITLE
excluded processinfo tap

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -8,3 +8,5 @@ branches: 90
 lines: 96
 functions: 88
 jobs: 1
+plugin:
+  - "!@tapjs/processinfo"


### PR DESCRIPTION
still failed https://github.com/elastic/elasticsearch-js/actions/runs/21679088949/job/62507915932
```
Error: spawn E2BIG
    at ChildProcess.spawn (node:internal/child_process:421:11)
    at spawn (node:child_process:796:9)
    at ProcessInfo.spawn (/home/runner/work/elasticsearch-js/elasticsearch-js/node_modules/@tapjs/processinfo/src/child_process.ts:198:10)
```
 
should ignore processinfo maybe since it spawns the child processes...educated guess 
   
[tap documentation for excluding
](https://node-tap.org/plugins/)