### PR TITLE
update script command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   },
   "scripts": {
-    "test": "npm run build && npm run lint && tap",
+    "test": "npm run build && npm run lint && tap --plugin=!@tapjs/processinfo",
     "test:unit": "npm run build && tap",
     "test:unit-bun": "bun run build && bunx tap",
     "test:esm": "npm run build:esm && tap test/esm/test-import.mjs",


### PR DESCRIPTION
failed again after uupdating taprc with the same error https://github.com/elastic/elasticsearch-js/pull/3157/changes

assumption is that taprc may not be read properly then? deduce by adding the ignore cli param directly into script commands 