### PR TITLE
Tapfix4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,7 @@
     }
   },
   "scripts": {
-<<<<<<< HEAD
-    "test": "npm run build && npm run lint && tap --plugin=!@tapjs/processinfo",
-=======
-<<<<<<< Updated upstream
-    "test": "npm run build && npm run lint && tap",
-=======
     "test": "npm run build && npm run lint && tap build && tap",
->>>>>>> Stashed changes
->>>>>>> 27d6d3a9c (rebuild tap)
     "test:unit": "npm run build && tap",
     "test:unit-bun": "bun run build && bunx tap",
     "test:esm": "npm run build:esm && tap test/esm/test-import.mjs",


### PR DESCRIPTION
check if tap is using a cached build even though we tried to ignore processinfo. force rebuild is added for tap 