### PR TITLE
Ensure estypes is exported in ESM modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,3 +54,5 @@ export type {
   ApiKeyAuth,
   BearerAuth
 } from '@elastic/transport'
+
+export * as estypes from './api/types'

--- a/test/esm/import.test.mjs
+++ b/test/esm/import.test.mjs
@@ -18,14 +18,16 @@ import {
   UndiciConnection,
   WeightedConnectionPool,
   errors,
-  events
+  events,
+  estypes
 } from '../../esm/index.js'
 
 test('ESM imports work correctly', t => {
-  t.plan(4)
+  t.plan(5)
   t.equal(typeof Client, 'function', 'Client should be a function')
   t.equal(typeof errors, 'object', 'errors should be an object')
   t.equal(typeof SniffingTransport, 'function', 'SniffingTransport should be a function')
+  t.equal(typeof estypes, 'object', 'estypes should be an object')
 
   const client = new Client({
     node: 'http://localhost:9200',


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch-js/issues/3173
