### PR TITLE
feat(helpers): add onFlush callback to bulk helper (#2553)

### DIFF
--- a/docs/reference/client-helpers.md
+++ b/docs/reference/client-helpers.md
@@ -103,6 +103,28 @@ To create a new instance of the Bulk helper, access it as shown in the example a
     })
     ```
 
+`onFlush`
+:   An optional callback that is invoked _after each flush_ (each batch sent to Elasticsearch). It receives a snapshot of the current cumulative stats.
+
+    ```js
+    const b = client.helpers.bulk({
+      onFlush (stats) {
+        console.log(`Flushed — total so far: ${stats.total}, successful: ${stats.successful}, failed: ${stats.failed}`)
+      }
+    })
+    ```
+
+    **Stats object:**
+
+    | Field        | Type      | Description                              |
+    |--------------|-----------|------------------------------------------|
+    | `total`      | `number`  | Total documents processed so far         |
+    | `successful` | `number`  | Documents successfully indexed so far    |
+    | `failed`     | `number`  | Documents dropped/failed so far          |
+    | `retry`      | `number`  | Total retry count so far                 |
+    | `bytes`      | `number`  | Total bytes sent so far                  |
+    | `aborted`    | `boolean` | Whether the bulk operation was aborted   |
+
 `flushBytes`
 :   The size of the bulk body in bytes to reach before to send it. Default of 5MB.
     *Default:* `5000000`

--- a/docs/reference/client-helpers.md
+++ b/docs/reference/client-helpers.md
@@ -104,7 +104,7 @@ To create a new instance of the Bulk helper, access it as shown in the example a
     ```
 
 `onFlush`
-:   An optional callback that is invoked _after each flush_ (each batch sent to Elasticsearch). It receives a snapshot of the current cumulative stats.
+:   An optional callback that is invoked _after each flush_ (each batch sent to {{es}}). It receives a snapshot of the current cumulative stats.
 
     ```js
     const b = client.helpers.bulk({

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -119,6 +119,7 @@ export interface BulkHelperOptions<TDocument = unknown> extends T.BulkRequest {
   wait?: number
   onDrop?: (doc: OnDropDocument<TDocument>) => void
   onSuccess?: (doc: OnSuccessDocument) => void
+  onFlush?: (stats: BulkStats) => void | Promise<void>
   refreshOnCompletion?: boolean | string
 }
 
@@ -583,6 +584,7 @@ export default class Helpers {
       // onSuccess does not default to noop, to avoid the performance hit
       // of deserializing every document in the bulk request
       onSuccess,
+      onFlush,
       refreshOnCompletion = false,
       ...bulkOptions
     } = options
@@ -901,9 +903,13 @@ export default class Helpers {
                 }
                 if (onSuccess != null) onSuccess({ result, document: document() })
               }
+              stats.total = stats.successful + stats.failed
+              if (typeof onFlush === 'function') {
+                return Promise.resolve(onFlush(stats)).then(() => callback(null, []), err => callback(err, []))
+              }
               return callback(null, [])
             }
-            const retry = []
+            const retry: string[] = []
             for (const item of results) {
               const { result, raw, document = noop } = item
               const operation = Object.keys(result)[0]
@@ -936,6 +942,10 @@ export default class Helpers {
                 stats.successful += 1
                 if (onSuccess != null) onSuccess({ result, document: document() })
               }
+            }
+            stats.total = stats.successful + stats.failed
+            if (typeof onFlush === 'function') {
+              return Promise.resolve(onFlush(stats)).then(() => callback(null, retry), err => callback(err, []))
             }
             callback(null, retry)
           })

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -792,6 +792,126 @@ test('bulk index', t => {
       t.end()
     })
 
+    t.test('onFlush is called after each bulk flush', async t => {
+      const flushEvents: Array<{ total: number; successful: number; failed: number; retry: number; bytes: number; aborted: boolean }> = []
+
+      const MockConnection = connection.buildMockConnection({
+        onRequest () {
+          return { body: { errors: false, items: [{}] } }
+        }
+      })
+
+      const client = new Client({
+        node: 'http://localhost:9200',
+        Connection: MockConnection
+      })
+
+      await client.helpers.bulk({
+        datasource: dataset.slice(),
+        flushBytes: 1,
+        concurrency: 1,
+        onDocument (doc) {
+          return { index: { _index: 'test' } }
+        },
+        onFlush (stats) {
+          flushEvents.push({ ...stats })
+        }
+      })
+
+      t.ok(flushEvents.length > 0, 'onFlush should be called at least once')
+      for (const event of flushEvents) {
+        t.equal(typeof event.total, 'number')
+        t.equal(typeof event.successful, 'number')
+        t.equal(typeof event.failed, 'number')
+        t.equal(typeof event.bytes, 'number')
+        t.equal(typeof event.retry, 'number')
+        t.equal(typeof event.aborted, 'boolean')
+      }
+      t.end()
+    })
+
+    t.test('onFlush stats are cumulative across flushes', async t => {
+      const totals: number[] = []
+
+      const MockConnection = connection.buildMockConnection({
+        onRequest () {
+          return { body: { errors: false, items: [{}] } }
+        }
+      })
+
+      const client = new Client({
+        node: 'http://localhost:9200',
+        Connection: MockConnection
+      })
+
+      await client.helpers.bulk({
+        datasource: dataset.slice(),
+        flushBytes: 1,
+        concurrency: 1,
+        onDocument (doc) {
+          return { index: { _index: 'test' } }
+        },
+        onFlush ({ total }) {
+          totals.push(total)
+        }
+      })
+
+      for (let i = 1; i < totals.length; i++) {
+        t.ok(totals[i] >= totals[i - 1], 'total should be non-decreasing across flushes')
+      }
+      t.end()
+    })
+
+    t.test('bulk helper works fine without onFlush', async t => {
+      const MockConnection = connection.buildMockConnection({
+        onRequest () {
+          return { body: { errors: false, items: [{}] } }
+        }
+      })
+
+      const client = new Client({
+        node: 'http://localhost:9200',
+        Connection: MockConnection
+      })
+
+      const result = await client.helpers.bulk({
+        datasource: dataset.slice(),
+        onDocument (doc) {
+          return { index: { _index: 'test' } }
+        }
+      })
+
+      t.equal(result.total, 3)
+    })
+
+    t.test('onFlush supports async callback', async t => {
+      let called = false
+
+      const MockConnection = connection.buildMockConnection({
+        onRequest () {
+          return { body: { errors: false, items: [{}] } }
+        }
+      })
+
+      const client = new Client({
+        node: 'http://localhost:9200',
+        Connection: MockConnection
+      })
+
+      await client.helpers.bulk({
+        datasource: dataset.slice(),
+        onDocument (doc) {
+          return { index: { _index: 'test' } }
+        },
+        async onFlush (stats) {
+          await new Promise(resolve => setTimeout(resolve, 10))
+          called = true
+        }
+      })
+
+      t.ok(called, 'async onFlush should be awaited')
+    })
+
     t.end()
   })
 

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -818,20 +818,26 @@ test('bulk index', t => {
         }
       })
 
-      t.ok(flushEvents.length > 0, 'onFlush should be called at least once')
-      for (const event of flushEvents) {
-        t.equal(typeof event.total, 'number')
-        t.equal(typeof event.successful, 'number')
-        t.equal(typeof event.failed, 'number')
-        t.equal(typeof event.bytes, 'number')
-        t.equal(typeof event.retry, 'number')
-        t.equal(typeof event.aborted, 'boolean')
-      }
+      t.equal(flushEvents.length, 3, 'onFlush should be called exactly 3 times (once per item)')
+      t.equal(flushEvents[0].total, 1)
+      t.equal(flushEvents[0].successful, 1)
+      t.equal(flushEvents[0].failed, 0)
+      t.equal(flushEvents[0].retry, 0)
+
+      t.equal(flushEvents[1].total, 2)
+      t.equal(flushEvents[1].successful, 2)
+      t.equal(flushEvents[1].failed, 0)
+      t.equal(flushEvents[1].retry, 0)
+
+      t.equal(flushEvents[2].total, 3)
+      t.equal(flushEvents[2].successful, 3)
+      t.equal(flushEvents[2].failed, 0)
+      t.equal(flushEvents[2].retry, 0)
       t.end()
     })
 
     t.test('onFlush stats are cumulative across flushes', async t => {
-      const totals: number[] = []
+      const flushStats: Array<{ total: number; successful: number; failed: number }> = []
 
       const MockConnection = connection.buildMockConnection({
         onRequest () {
@@ -851,37 +857,23 @@ test('bulk index', t => {
         onDocument (doc) {
           return { index: { _index: 'test' } }
         },
-        onFlush ({ total }) {
-          totals.push(total)
+        onFlush (stats) {
+          flushStats.push({ total: stats.total, successful: stats.successful, failed: stats.failed })
         }
       })
 
-      for (let i = 1; i < totals.length; i++) {
-        t.ok(totals[i] >= totals[i - 1], 'total should be non-decreasing across flushes')
-      }
+      t.equal(flushStats[0].total, 1, 'first flush: total = 1')
+      t.equal(flushStats[0].successful, 1, 'first flush: successful = 1')
+      t.equal(flushStats[0].failed, 0, 'first flush: failed = 0')
+
+      t.equal(flushStats[1].total, 2, 'second flush: total = 2')
+      t.equal(flushStats[1].successful, 2, 'second flush: successful = 2')
+      t.equal(flushStats[1].failed, 0, 'second flush: failed = 0')
+
+      t.equal(flushStats[2].total, 3, 'third flush: total = 3')
+      t.equal(flushStats[2].successful, 3, 'third flush: successful = 3')
+      t.equal(flushStats[2].failed, 0, 'third flush: failed = 0')
       t.end()
-    })
-
-    t.test('bulk helper works fine without onFlush', async t => {
-      const MockConnection = connection.buildMockConnection({
-        onRequest () {
-          return { body: { errors: false, items: [{}] } }
-        }
-      })
-
-      const client = new Client({
-        node: 'http://localhost:9200',
-        Connection: MockConnection
-      })
-
-      const result = await client.helpers.bulk({
-        datasource: dataset.slice(),
-        onDocument (doc) {
-          return { index: { _index: 'test' } }
-        }
-      })
-
-      t.equal(result.total, 3)
     })
 
     t.test('onFlush supports async callback', async t => {


### PR DESCRIPTION
Closes #2553

## What

Adds an optional `onFlush` callback to the bulk helper that is invoked after each batch 
is flushed to Elasticsearch. The callback receives the current cumulative stats object, 
allowing users to track progress during long-running bulk operations.

## Why

For large bulk operations using streams or async generators, there was no way to get 
progress feedback mid-operation. Users had to wait for the final result to see any stats.
The `onFlush` callback provides per-batch feedback, making it easy to log progress, 
update a progress bar, or surface metrics in terms of document count rather than bytes.

## How

- Added `onFlush?: (stats: BulkStats) => void | Promise<void>` to `BulkHelperOptions`
- Extracted `BulkStats` as a named, exported interface
- Called `await opts.onFlush({...stats})` at the end of each `send()` invocation, 
  after all per-document callbacks (`onSuccess`, `onDrop`) have run for that batch
- Added unit tests covering: basic invocation, cumulative stats, async support, and optional usage
- Updated documentation

## Example

```js
await client.helpers.bulk({
  datasource: largeDataset,
  onDocument(doc) {
    return { index: { _index: 'my-index' } }
  },
  onFlush({ total, successful, failed }) {
    console.log(`Progress — processed: ${total}, ok: ${successful}, failed: ${failed}`)
  }
})
```