### PR TITLE
Bump minimum supported Node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "homepage": "http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "devDependencies": {
     "@elastic/request-converter": "9.3.0",


### PR DESCRIPTION
Transport only supports 20+, so the client should indicate the same.
