### PR TITLE
fix globby

### DIFF
--- a/.buildkite/run-client.sh
+++ b/.buildkite/run-client.sh
@@ -6,7 +6,7 @@ script_path=$(dirname "$(realpath -s "$0")")
 set -euo pipefail
 repo=$(pwd)
 
-export NODE_VERSION=${NODE_VERSION:-20}
+export NODE_VERSION=${NODE_VERSION:-22}
 
 echo "--- :javascript: Building Docker image"
 docker build \

--- a/.buildkite/run-client.sh
+++ b/.buildkite/run-client.sh
@@ -35,4 +35,9 @@ docker run \
   --name elasticsearch-js \
   --rm \
   elastic/elasticsearch-js \
-  bash -c "npm run test:integration; [ -f ./report-junit.xml ] && mv ./report-junit.xml /junit-output/junit-$BUILDKITE_JOB_ID.xml || echo 'No JUnit artifact found'"
+  bash -c "npm run test:integration; TEST_EXIT=\$?; [ -f ./report-junit.xml ] && mv ./report-junit.xml /junit-output/junit-$BUILDKITE_JOB_ID.xml || echo 'No JUnit artifact found'; exit \$TEST_EXIT"
+
+if [ ! -f "$repo/junit-output/junit-$BUILDKITE_JOB_ID.xml" ]; then
+  echo "No JUnit artifact produced, creating empty placeholder"
+  echo '<?xml version="1.0" encoding="UTF-8"?><testsuites></testsuites>' > "$repo/junit-output/junit-$BUILDKITE_JOB_ID.xml"
+fi

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "homepage": "http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "devDependencies": {
     "@elastic/request-converter": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:coverage-report": "npm run build && tap --coverage && nyc report --reporter=text-lcov > coverage.lcov",
     "test:coverage-ui": "npm run build && tap --coverage --coverage-report=html",
     "test:integration-build": "npm run build && node test/integration/index.js",
-    "test:integration": "npm run test:integration-build && env tap run --jobs=1 --disable-coverage --reporter=junit --reporter-file=report-junit.xml generated-tests/",
+    "test:integration": "npm run test:integration-build && env tap run --jobs=1 --allow-empty-coverage --allow-incomplete-coverage --reporter=junit --reporter-file=report-junit.xml generated-tests/",
     "lint": "eslint",
     "lint:fix": "eslint . --fix ",
     "license-checker": "license-checker --production --onlyAllow='MIT;Apache-2.0;Apache1.1;ISC;BSD-3-Clause;BSD-2-Clause;0BSD'",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:coverage-report": "npm run build && tap --coverage && nyc report --reporter=text-lcov > coverage.lcov",
     "test:coverage-ui": "npm run build && tap --coverage --coverage-report=html",
     "test:integration-build": "npm run build && node test/integration/index.js",
-    "test:integration": "npm run test:integration-build && env tap run --jobs=1 --reporter=junit --reporter-file=report-junit.xml generated-tests/",
+    "test:integration": "npm run test:integration-build && env tap run --jobs=1 --no-coverage --reporter=junit --reporter-file=report-junit.xml generated-tests/",
     "lint": "eslint",
     "lint:fix": "eslint . --fix ",
     "license-checker": "license-checker --production --onlyAllow='MIT;Apache-2.0;Apache1.1;ISC;BSD-3-Clause;BSD-2-Clause;0BSD'",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:coverage-report": "npm run build && tap --coverage && nyc report --reporter=text-lcov > coverage.lcov",
     "test:coverage-ui": "npm run build && tap --coverage --coverage-report=html",
     "test:integration-build": "npm run build && node test/integration/index.js",
-    "test:integration": "npm run test:integration-build && env tap run --jobs=1 --no-coverage --reporter=junit --reporter-file=report-junit.xml generated-tests/",
+    "test:integration": "npm run test:integration-build && env tap run --jobs=1 --disable-coverage --reporter=junit --reporter-file=report-junit.xml generated-tests/",
     "lint": "eslint",
     "lint:fix": "eslint . --fix ",
     "license-checker": "license-checker --production --onlyAllow='MIT;Apache-2.0;Apache1.1;ISC;BSD-3-Clause;BSD-2-Clause;0BSD'",

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -14,7 +14,6 @@ const assert = require('node:assert')
 const url = require('node:url')
 const fs = require('node:fs')
 const path = require('node:path')
-const globby = require('globby')
 const semver = require('semver')
 
 const buildTests = require('./test-builder')
@@ -31,12 +30,11 @@ async function loadDownloadArtifacts () {
 }
 
 const getAllFiles = async dir => {
-  const files = await globby(dir, {
-    expandDirectories: {
-      extensions: ['yml', 'yaml']
-    }
-  })
-  return files.sort()
+  const entries = await fs.promises.readdir(dir, { recursive: true })
+  return entries
+    .filter(f => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .map(f => path.join(dir, f))
+    .sort()
 }
 
 async function doTestBuilder (version, clientOptions) {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -33,6 +33,7 @@ const getAllFiles = async dir => {
   const entries = await fs.promises.readdir(dir, { recursive: true })
   return entries
     .filter(f => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .filter(f => !f.split(path.sep).some(part => part.startsWith('.')))
     .map(f => path.join(dir, f))
     .sort()
 }


### PR DESCRIPTION
## Summary

- Removes the `globby` dependency from `test/integration/index.js`, which was missing from `package.json` and causing a `Cannot find module 'globby'` crash in the integration test Buildkite pipeline
- Replaces it with Node's built-in `fs.promises.readdir` with `{ recursive: true }`, filtering out dotfiles/hidden directories (e.g. `.github/`) which `globby` excluded by default but `readdir` does not
- Fixes `run-client.sh` to correctly preserve the test exit code (previously swallowed by the `||` chain) and create a fallback empty JUnit artifact if none was produced, preventing the `junit-annotate` step from hard-failing
- Adds `--disable-coverage` to the `tap run` command in `test:integration`, since `tap run` with explicit paths ignores the `disable-coverage: true` config and was exiting with code 1 due to coverage thresholds even when all tests passed
- Bumps minimum Node.js engine requirement from `>=20` to `>=22` (Node 20 is EOL as of April 2026) and updates the default `NODE_VERSION` in `.buildkite/run-client.sh` accordingly

## Test plan

- [x] Integration tests pass on Buildkite across Node 20, 22, and 24 (3267 tests, 0 failures)
- [x] JUnit artifacts are uploaded and annotated correctly