### PR TITLE
chore: update ESM patching for apache-arrow

### DIFF
--- a/scripts/fix-esm-require.js
+++ b/scripts/fix-esm-require.js
@@ -6,20 +6,19 @@
 const fs = require('fs')
 const path = require('path')
 
-// Fix the package.json require in client.js for ESM
-const clientPath = path.join(__dirname, '..', 'esm', 'client.js')
-const helpersPath = path.join(__dirname, '..', 'esm', 'helpers.js')
+function injectCreateRequire (filePath, hasRequireCheck, transform) {
+  if (!fs.existsSync(filePath)) {
+    console.log(`${filePath} not found, skipping fix`)
+    return
+  }
 
-// Fix client.js
-if (fs.existsSync(clientPath)) {
-  let content = fs.readFileSync(clientPath, 'utf8')
+  let content = fs.readFileSync(filePath, 'utf8')
 
-  // Check if we need to add createRequire
-  const hasPackageRequire = content.includes('require(\'../package.json\')') ||
-                            content.includes('require(\'@elastic/transport/package.json\')')
+  if (transform) {
+    content = transform(content)
+  }
 
-  if (!content.includes('createRequire') && hasPackageRequire) {
-    // Find the last import statement
+  if (!content.includes('createRequire') && hasRequireCheck(content)) {
     const lastImportIndex = content.lastIndexOf('import ')
     const newlineAfterImport = content.indexOf('\n', lastImportIndex)
 
@@ -27,27 +26,21 @@ if (fs.existsSync(clientPath)) {
       const beforeImport = content.substring(0, newlineAfterImport + 1)
       const afterImport = content.substring(newlineAfterImport + 1)
 
-      content = beforeImport + 'import { createRequire } from \'node:module\';\nconst require = createRequire(import.meta.url);\n' + afterImport
+      content = beforeImport + 'import { createRequire } from \'node:module\';\nconst require = createRequire(import.meta.url ?? __filename);\n' + afterImport
     }
-
-    fs.writeFileSync(clientPath, content, 'utf8')
-    console.log(`Fixed package.json loading in ${clientPath}`)
   }
-} else {
-  console.log('client.js not found, skipping fix')
+
+  fs.writeFileSync(filePath, content, 'utf8')
+  console.log(`Fixed require() usage in ${filePath}`)
 }
 
-// Fix helpers.js - remove incorrect .js extension from apache-arrow import
-if (fs.existsSync(helpersPath)) {
-  let content = fs.readFileSync(helpersPath, 'utf8')
+injectCreateRequire(
+  path.join(__dirname, '..', 'esm', 'client.js'),
+  content => content.includes('require(\'../package.json\')') || content.includes('require(\'@elastic/transport/package.json\')')
+)
 
-  // Fix the apache-arrow import that tsc-esm-fix incorrectly modified
-  const originalApacheImport = 'import { tableFromIPC, AsyncRecordBatchStreamReader } from \'apache-arrow/Arrow.node.js\';'
-  const fixedApacheImport = 'import { tableFromIPC, AsyncRecordBatchStreamReader } from \'apache-arrow/Arrow.node\';'
-
-  if (content.includes(originalApacheImport)) {
-    content = content.replace(originalApacheImport, fixedApacheImport)
-    fs.writeFileSync(helpersPath, content, 'utf8')
-    console.log(`Fixed apache-arrow import in ${helpersPath}`)
-  }
-}
+injectCreateRequire(
+  path.join(__dirname, '..', 'esm', 'helpers.js'),
+  content => content.includes('require(\'apache-arrow/'),
+  content => content.replace(/require\('apache-arrow\/Arrow\.node\.js'\)/g, 'require(\'apache-arrow/Arrow.node\')')
+)

--- a/test/esm/import.test.mjs
+++ b/test/esm/import.test.mjs
@@ -4,6 +4,7 @@
  */
 
 import { test } from 'tap'
+import { tableFromJSON, RecordBatchStreamWriter } from 'apache-arrow'
 import {
   BaseConnection,
   BaseConnectionPool,
@@ -53,4 +54,49 @@ test('ESM imports from @elastic/transport should work correctly', t => {
   t.equal(typeof UndiciConnection, 'function', 'UndiciConnection should be a function')
   t.equal(typeof WeightedConnectionPool, 'function', 'WeightedConnectionPool should be a function')
   t.equal(typeof events, 'object', 'events should be an object')
+})
+
+test('Apache Arrow loads correctly via ESM helpers', async t => {
+  const testRecords = [
+    { amount: 4.9 },
+    { amount: 8.2 },
+    { amount: 15.5 },
+  ]
+
+  const arrowTable = tableFromJSON(testRecords)
+  const rawData = await RecordBatchStreamWriter.writeAll(arrowTable).toUint8Array()
+
+  class MockConnection extends BaseConnection {
+    async request (_params, _options) {
+      return {
+        body: Buffer.from(rawData),
+        statusCode: 200,
+        headers: {
+          'content-type': 'application/vnd.elasticsearch+arrow+stream',
+          'x-elastic-product': 'Elasticsearch',
+          'content-length': String(rawData.byteLength),
+        },
+      }
+    }
+  }
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection,
+  })
+
+  t.test('toArrowTable returns an Arrow Table instance', async t => {
+    const result = await client.helpers.esql({ query: 'FROM test' }).toArrowTable()
+    t.equal(result.constructor.name, 'Table', 'result should be an Arrow Table')
+    t.equal(result.numRows, testRecords.length, 'table should have correct number of rows')
+    t.end()
+  })
+
+  t.test('toArrowReader returns a readable Arrow stream', async t => {
+    const reader = await client.helpers.esql({ query: 'FROM test' }).toArrowReader()
+    t.ok(reader.isStream(), 'result should be an Arrow stream reader')
+    t.end()
+  })
+
+  t.end()
 })

--- a/test/unit/helpers/bulk.test.ts
+++ b/test/unit/helpers/bulk.test.ts
@@ -2082,3 +2082,31 @@ test('Flush interval', t => {
 
   t.end()
 })
+
+test('finally', async t => {
+  const MockConnection = connection.buildMockConnection({
+    onRequest (_params) {
+      return {
+        body: { errors: false, items: [{ index: {} }] }
+      }
+    }
+  })
+
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  let finallyCalled = false
+  await client.helpers.bulk({
+    datasource: [{ user: 'jon', age: 23 }],
+    onDocument (_) {
+      return { index: { _index: 'test' } }
+    }
+  }).finally(() => {
+    finallyCalled = true
+  })
+
+  t.equal(finallyCalled, true)
+  t.end()
+})

--- a/test/unit/sniffingTransport.test.ts
+++ b/test/unit/sniffingTransport.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test } from 'tap'
+import { connection } from '../utils'
+import { Client, SniffingTransport } from '../..'
+
+test('SniffingTransport', t => {
+  t.test('sniff - success', t => {
+    t.plan(3)
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+      Connection: connection.MockConnectionSniff
+    })
+
+    const transport = client.transport as SniffingTransport
+    transport.diagnostic.once('sniff', (err, result) => {
+      t.equal(err, null)
+      t.ok(result != null)
+      t.ok(result?.meta.sniff.hosts.length > 0)
+    })
+
+    transport.sniff({ reason: 'test' })
+  })
+
+  t.test('sniff - already sniffing, exits early', t => {
+    const client = new Client({
+      node: 'http://localhost:9200',
+      Connection: connection.MockConnectionSniff
+    })
+
+    const transport = client.transport as SniffingTransport
+    transport.isSniffing = true
+
+    let sniffEventFired = false
+    transport.diagnostic.once('sniff', () => { sniffEventFired = true })
+    transport.sniff({ reason: 'test' })
+
+    t.equal(sniffEventFired, false, 'sniff diagnostic should not fire when already sniffing')
+    t.equal(transport.isSniffing, true)
+    t.end()
+  })
+
+  t.test('sniff - error', t => {
+    t.plan(1)
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+      Connection: connection.MockConnectionError
+    })
+
+    const transport = client.transport as SniffingTransport
+    transport.diagnostic.once('sniff', (err) => {
+      t.ok(err != null)
+    })
+
+    transport.sniff({ reason: 'test' })
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Ensures ESM patch still works now that apache-arrow is imported dynamically.

Also adds tests to keep coverage above threshold.