### PR TITLE
fix: backport globby removal and junit CI fixes to 9.4

### DIFF
--- a/.buildkite/run-client.sh
+++ b/.buildkite/run-client.sh
@@ -35,4 +35,9 @@ docker run \
   --name elasticsearch-js \
   --rm \
   elastic/elasticsearch-js \
-  bash -c "npm run test:integration; [ -f ./report-junit.xml ] && mv ./report-junit.xml /junit-output/junit-$BUILDKITE_JOB_ID.xml || echo 'No JUnit artifact found'"
+  bash -c "npm run test:integration; TEST_EXIT=\$?; [ -f ./report-junit.xml ] && mv ./report-junit.xml /junit-output/junit-$BUILDKITE_JOB_ID.xml || echo 'No JUnit artifact found'; exit \$TEST_EXIT"
+
+if [ ! -f "$repo/junit-output/junit-$BUILDKITE_JOB_ID.xml" ]; then
+  echo "No JUnit artifact produced, creating empty placeholder"
+  echo '<?xml version="1.0" encoding="UTF-8"?><testsuites></testsuites>' > "$repo/junit-output/junit-$BUILDKITE_JOB_ID.xml"
+fi

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:coverage-report": "npm run build && tap --coverage && nyc report --reporter=text-lcov > coverage.lcov",
     "test:coverage-ui": "npm run build && tap --coverage --coverage-report=html",
     "test:integration-build": "npm run build && node test/integration/index.js",
-    "test:integration": "npm run test:integration-build && env tap run --jobs=1 --reporter=junit --reporter-file=report-junit.xml generated-tests/",
+    "test:integration": "npm run test:integration-build && env tap run --jobs=1 --allow-empty-coverage --allow-incomplete-coverage --reporter=junit --reporter-file=report-junit.xml generated-tests/",
     "lint": "eslint",
     "lint:fix": "eslint . --fix ",
     "license-checker": "license-checker --production --onlyAllow='MIT;Apache-2.0;Apache1.1;ISC;BSD-3-Clause;BSD-2-Clause;0BSD'",

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -14,7 +14,6 @@ const assert = require('node:assert')
 const url = require('node:url')
 const fs = require('node:fs')
 const path = require('node:path')
-const globby = require('globby')
 const semver = require('semver')
 
 const buildTests = require('./test-builder')
@@ -31,12 +30,12 @@ async function loadDownloadArtifacts () {
 }
 
 const getAllFiles = async dir => {
-  const files = await globby(dir, {
-    expandDirectories: {
-      extensions: ['yml', 'yaml']
-    }
-  })
-  return files.sort()
+  const entries = await fs.promises.readdir(dir, { recursive: true })
+  return entries
+    .filter(f => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .filter(f => !f.split(path.sep).some(part => part.startsWith('.')))
+    .map(f => path.join(dir, f))
+    .sort()
 }
 
 async function doTestBuilder (version, clientOptions) {


### PR DESCRIPTION
## Summary

Backport of #3264 to the 9.4 branch, which fixes CI for auto-generated PRs like #3300.

- Removes `globby` dependency from `test/integration/index.js`, replacing it with native `fs.promises.readdir` (globby was never in package.json on 9.4, causing `test:integration-build` to crash)
- Fixes `.buildkite/run-client.sh` to preserve the test exit code and always produce a JUnit XML artifact (empty placeholder if tests fail before tap runs), so the junit-annotate step has something to download
- Adds `--allow-empty-coverage --allow-incomplete-coverage` flags to the `tap` run in `test:integration`

## Test plan

- [ ] CI on this PR passes (all 3 node matrix jobs produce junit artifacts, annotate step succeeds)
- [ ] #3300 can be re-run against 9.4 after this merges