### PR TITLE
ci: update docs-actions pin to 281c0cdf (v1)

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -11,6 +11,6 @@ permissions:
   pull-requests: read
 jobs:
   build:
-    uses: elastic/docs-actions/.github/workflows/docs-build.yml@076f02ba436863237d90f1b7e7bc6b7a91eff4e3 # v1
+    uses: elastic/docs-actions/.github/workflows/docs-build.yml@281c0cdf228c40c66703fb60e1b0464b3ca07dec # v1
     with:
       enable-vale-linting: true


### PR DESCRIPTION
## Summary

The `chore(deps): pin dependencies` commit (#3269) locked `elastic/docs-actions` at `076f02ba`, which was the SHA for `v1` at the time. Since then, `v1` moved to `281c0cdf`, which fixes the vale job: the old commit called `elastic/vale-rules/lint@main` (a path with no `action.yml`), while the new commit correctly calls `elastic/docs-actions/vale/lint@v1`.

This causes the vale CI step to fail on all PRs that touch docs, including the auto-generated `elasticmachine` PRs.

## Test plan

- [ ] Vale CI step passes on this PR
- [ ] Vale CI step passes on subsequent auto-generated PRs after this merges