### PR TITLE
ci: add AI backport resolver (gh-aw prompt + issue_comment trigger)

### DIFF
--- a/.github/workflows/ai-backport-trigger.yml
+++ b/.github/workflows/ai-backport-trigger.yml
@@ -1,0 +1,48 @@
+name: AI Backport Trigger
+# Listens for backport bot failure comments and dispatches the gh-aw AI Backport Resolver.
+# The gh-aw workflow uses workflow_dispatch (so its pre_activation check passes for any caller),
+# while this file handles the issue_comment event detection from trusted bots.
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.issue.pull_request
+      && (
+        github.event.comment.user.login == 'github-actions[bot]'
+        || github.event.comment.user.login == 'elastic-vault-github-plugin-prod[bot]'
+      )
+      && contains(github.event.comment.body, 'To backport manually, run these commands')
+    permissions:
+      actions: write
+    steps:
+      - name: Parse comment and dispatch resolver
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body;
+
+            const branchMatch = body.match(/git worktree add \.worktrees\/\S+ (\S+)/);
+            const shaMatch = body.match(/cherry-pick -x --mainline 1 ([a-f0-9]+)/);
+
+            if (!branchMatch || !shaMatch) {
+              core.warning('Could not parse base_branch or commit_sha from backport comment.');
+              return;
+            }
+
+            const base_branch = branchMatch[1];
+            const commit_sha = shaMatch[1];
+            const pr_number = String(context.payload.issue.number);
+
+            core.info(`Dispatching AI Backport Resolver for PR #${pr_number} -> ${base_branch} @ ${commit_sha}`);
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'resolve-conflicts.lock.yml',
+              ref: 'main',
+              inputs: { pr_number, base_branch, commit_sha },
+            });

--- a/.github/workflows/resolve-conflicts.lock.yml
+++ b/.github/workflows/resolve-conflicts.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"139fe9058001760212cf29b538f9b09a47d4faa5032404d26d3a02b4129dd508","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d91219e5ccc6ae5b3a889a43909e842762152b1d4eac1a2ec31fa51777c8fc69","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LITELLM_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# When the backport bot fails, parse the failure comment and use Claude to resolve cherry-pick conflicts and create the backport PR
+# Given a PR number and backport failure details, use Claude to resolve cherry-pick conflicts and create the backport PR
 #
 # Secrets used:
 #   - GH_AW_CI_TRIGGER_TOKEN
@@ -50,27 +50,37 @@
 
 name: "AI Backport Resolver"
 on:
-  issue_comment:
-    types:
-    - created
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        default: ""
+        description: "Agent caller context (used internally by Agentic Workflows)."
+        required: false
+        type: string
+      base_branch:
+        description: Target branch to backport to (e.g. 9.4)
+        required: true
+      commit_sha:
+        description: Commit SHA to cherry-pick
+        required: true
+      pr_number:
+        description: PR number that failed to backport
+        required: true
 
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"
+  group: "gh-aw-${{ github.workflow }}"
 
 run-name: "AI Backport Resolver"
 
 jobs:
   activation:
-    needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
     outputs:
-      body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
@@ -81,8 +91,6 @@ jobs:
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
       stale_lock_file_failed: ${{ steps.check-lock-file.outputs.stale_lock_file_failed == 'true' }}
-      text: ${{ steps.sanitized.outputs.text }}
-      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -90,8 +98,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
-          parent-span-id: ${{ needs.pre_activation.outputs.setup-parent-span-id || needs.pre_activation.outputs.setup-span-id }}
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "AI Backport Resolver"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/resolve-conflicts.lock.yml@${{ github.ref }}
@@ -171,17 +177,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_version_updates.cjs');
             await main();
-      - name: Compute current body text
-        id: sanitized
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,elastic.litellm-prod.ai,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
-            await main();
       - name: Create prompt with built-in context
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -194,28 +189,27 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_0f7dbd7a9d870b90_EOF'
+          cat << 'GH_AW_PROMPT_c7253a8294bd5fe1_EOF'
           <system>
-          GH_AW_PROMPT_0f7dbd7a9d870b90_EOF
+          GH_AW_PROMPT_c7253a8294bd5fe1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0f7dbd7a9d870b90_EOF'
+          cat << 'GH_AW_PROMPT_c7253a8294bd5fe1_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_0f7dbd7a9d870b90_EOF
+          GH_AW_PROMPT_c7253a8294bd5fe1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_0f7dbd7a9d870b90_EOF'
+          cat << 'GH_AW_PROMPT_c7253a8294bd5fe1_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_0f7dbd7a9d870b90_EOF
+          GH_AW_PROMPT_c7253a8294bd5fe1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_0f7dbd7a9d870b90_EOF'
+          cat << 'GH_AW_PROMPT_c7253a8294bd5fe1_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -247,15 +241,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_0f7dbd7a9d870b90_EOF
+          GH_AW_PROMPT_c7253a8294bd5fe1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
-            cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
-          fi
-          cat << 'GH_AW_PROMPT_0f7dbd7a9d870b90_EOF'
+          cat << 'GH_AW_PROMPT_c7253a8294bd5fe1_EOF'
           </system>
           {{#runtime-import .github/workflows/resolve-conflicts.md}}
-          GH_AW_PROMPT_0f7dbd7a9d870b90_EOF
+          GH_AW_PROMPT_c7253a8294bd5fe1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -280,9 +271,7 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -302,9 +291,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
-                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
               }
             });
       - name: Validate prompt placeholders
@@ -391,33 +378,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          COMMENT_USER: ${{ github.event.comment.user.login }}
-          GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          BASE_BRANCH: ${{ github.event.inputs.base_branch }}
+          COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: Parse backport failure comment and attempt cherry-pick
-        run: |
-          # Only act on backport bot failure comments
-          if [[ "$COMMENT_USER" != "github-actions[bot]" && "$COMMENT_USER" != "elastic-vault-github-plugin-prod[bot]" ]]; then
-            echo "skip" > /tmp/gh-aw/agent/status.txt
-            exit 0
-          fi
-          if ! echo "$COMMENT_BODY" | grep -q "To backport manually, run these commands"; then
-            echo "skip" > /tmp/gh-aw/agent/status.txt
-            exit 0
-          fi
-
-          # Parse target branch and commit SHA from the comment
-          BASE_BRANCH=$(echo "$COMMENT_BODY" | grep -oP 'git worktree add \.worktrees/\S+ \K\S+')
-          COMMIT_SHA=$(echo "$COMMENT_BODY" | grep -oP 'cherry-pick -x --mainline 1 \K[a-f0-9]+')
-
-          if [[ -z "$BASE_BRANCH" || -z "$COMMIT_SHA" ]]; then
-            echo "skip" > /tmp/gh-aw/agent/status.txt
-            echo "Could not parse base branch or commit SHA from comment."
-            exit 0
-          fi
-
-          PR_NUMBER="$GH_AW_GITHUB_EVENT_ISSUE_NUMBER"
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        name: Cherry-pick and detect conflicts
+        run: |-
           PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q .title)
           BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${BASE_BRANCH}"
 
@@ -431,11 +397,8 @@ jobs:
           git config user.name "github-actions[bot]"
 
           git fetch origin "$BASE_BRANCH"
-          git fetch origin "$COMMIT_SHA" 2>/dev/null || true
           git checkout "$BASE_BRANCH"
 
-          # Use --no-commit so staged/conflicted changes are left in the workspace
-          # for the agent to resolve and safe-outputs to commit
           set +e
           git cherry-pick -x --mainline 1 --no-commit "$COMMIT_SHA" 2>&1
           CHERRY_EXIT=$?
@@ -519,9 +482,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d7a5e4470d4d4614_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_032b89023dd934ae_EOF'
           {"create_pull_request":{"labels":["backport"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_d7a5e4470d4d4614_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_032b89023dd934ae_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -733,7 +696,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_a6b7c05482797209_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_fe8f7bdf53716d87_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -773,7 +736,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a6b7c05482797209_EOF
+          GH_AW_MCP_CONFIG_fe8f7bdf53716d87_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1301,7 +1264,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: "AI Backport Resolver"
-          WORKFLOW_DESCRIPTION: "When the backport bot fails, parse the failure comment and use Claude to resolve cherry-pick conflicts and create the backport PR"
+          WORKFLOW_DESCRIPTION: "Given a PR number and backport failure details, use Claude to resolve cherry-pick conflicts and create the backport PR"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1419,41 +1382,6 @@ jobs:
                 core.setFailed(msg);
               }
             }
-
-  pre_activation:
-    if: >
-      github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-      setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
-      setup-span-id: ${{ steps.setup.outputs.span-id }}
-      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-        env:
-          GH_AW_SETUP_WORKFLOW_NAME: "AI Backport Resolver"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/resolve-conflicts.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.142"
-          GH_AW_INFO_ENGINE_ID: "claude"
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
 
   safe_outputs:
     needs:

--- a/.github/workflows/resolve-conflicts.md
+++ b/.github/workflows/resolve-conflicts.md
@@ -1,9 +1,18 @@
 ---
 name: AI Backport Resolver
-description: When the backport bot fails, parse the failure comment and use Claude to resolve cherry-pick conflicts and create the backport PR
+description: Given a PR number and backport failure details, use Claude to resolve cherry-pick conflicts and create the backport PR
 on:
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number that failed to backport"
+        required: true
+      base_branch:
+        description: "Target branch to backport to (e.g. 9.4)"
+        required: true
+      commit_sha:
+        description: "Commit SHA to cherry-pick"
+        required: true
 engine:
   id: claude
   model: "llm-gateway/claude-sonnet-4-6"
@@ -13,33 +22,13 @@ engine:
 checkout:
   fetch-depth: 0
 steps:
-  - name: Parse backport failure comment and attempt cherry-pick
+  - name: Cherry-pick and detect conflicts
     env:
-      COMMENT_BODY: ${{ github.event.comment.body }}
-      COMMENT_USER: ${{ github.event.comment.user.login }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.inputs.pr_number }}
+      BASE_BRANCH: ${{ github.event.inputs.base_branch }}
+      COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
     run: |
-      # Only act on backport bot failure comments
-      if [[ "$COMMENT_USER" != "github-actions[bot]" && "$COMMENT_USER" != "elastic-vault-github-plugin-prod[bot]" ]]; then
-        echo "skip" > /tmp/gh-aw/agent/status.txt
-        exit 0
-      fi
-      if ! echo "$COMMENT_BODY" | grep -q "To backport manually, run these commands"; then
-        echo "skip" > /tmp/gh-aw/agent/status.txt
-        exit 0
-      fi
-
-      # Parse target branch and commit SHA from the comment
-      BASE_BRANCH=$(echo "$COMMENT_BODY" | grep -oP 'git worktree add \.worktrees/\S+ \K\S+')
-      COMMIT_SHA=$(echo "$COMMENT_BODY" | grep -oP 'cherry-pick -x --mainline 1 \K[a-f0-9]+')
-
-      if [[ -z "$BASE_BRANCH" || -z "$COMMIT_SHA" ]]; then
-        echo "skip" > /tmp/gh-aw/agent/status.txt
-        echo "Could not parse base branch or commit SHA from comment."
-        exit 0
-      fi
-
-      PR_NUMBER="${{ github.event.issue.number }}"
       PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q .title)
       BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${BASE_BRANCH}"
 
@@ -53,11 +42,8 @@ steps:
       git config user.name "github-actions[bot]"
 
       git fetch origin "$BASE_BRANCH"
-      git fetch origin "$COMMIT_SHA" 2>/dev/null || true
       git checkout "$BASE_BRANCH"
 
-      # Use --no-commit so staged/conflicted changes are left in the workspace
-      # for the agent to resolve and safe-outputs to commit
       set +e
       git cherry-pick -x --mainline 1 --no-commit "$COMMIT_SHA" 2>&1
       CHERRY_EXIT=$?


### PR DESCRIPTION
Adds AI-powered backport conflict resolution using GitHub Agentic Workflows (gh-aw).

## Files

- **`ai-backport-trigger.yml`** — triggers on `issue_comment` from the backport bot (`elastic-vault-github-plugin-prod[bot]`). Parses the target branch, commit SHA, and PR number from the failure comment, then dispatches the gh-aw workflow via `workflow_dispatch`.
- **`resolve-conflicts.md`** — the gh-aw prompt. Uses `workflow_dispatch` so gh-aw's `pre_activation` security gate is not hit (it blocks `author_association: NONE` bot comments on `issue_comment` triggers).
- **`resolve-conflicts.lock.yml`** — compiled lock file (do not edit directly, regenerate with `gh aw compile`).

## How it works

1. Backport bot posts a failure comment on a PR.
2. `ai-backport-trigger.yml` fires, parses the comment, and calls `workflow_dispatch` on the gh-aw workflow with `pr_number`, `base_branch`, and `commit_sha`.
3. The gh-aw workflow checks out the base branch, attempts the cherry-pick with `--no-commit`, then uses Claude (via LiteLLM) to resolve any conflicts and open a backport PR.

## Requires

`LITELLM_API_KEY` secret in this repo.