### PR TITLE
ci: add auto-pr workflow via clients-team-automations

### DIFF
--- a/.github/auto-pr-context.md
+++ b/.github/auto-pr-context.md
@@ -1,0 +1,22 @@
+# Auto PR context — elasticsearch-js
+
+This repo is the official Elasticsearch client for Node.js. Source code lives under `src/` and generated API bindings are under `src/api/`.
+
+## File layout
+
+- `src/` — main client source (TypeScript)
+- `src/api/api/` — one file per API namespace (e.g. `search.ts`, `index.ts`, `bulk.ts`)
+- `src/api/types.ts` — generated TypeScript types for request/response bodies
+- `src/client.ts` — core client class
+- `src/helpers.ts` — higher-level helpers (bulk helper, scroll helper, etc.)
+
+## Fix conventions
+
+- `src/api/api/` and `src/api/types.ts` are auto-generated — do **not** modify them directly
+- Only modify files outside of `src/api/` unless the issue explicitly calls for a type or API binding change
+- Follow existing TypeScript patterns and use the same import style as surrounding code
+- Do not modify `dist/`, `esm/`, or any compiled output
+
+## Search hints
+
+Error messages, method names, or option names in the issue body typically map to files in `src/` (excluding `src/api/`).

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,14 @@
+name: Auto PR
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  auto-pr:
+    if: startsWith(github.event.label.name, 'auto-pr')
+    uses: elastic/clients-team-automations/.github/workflows/auto-pr.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      search_directory: src
+    secrets:
+      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-pr.yml` — thin caller to `elastic/clients-team-automations/.github/workflows/auto-pr.yml` that triggers on any `auto-pr*` label being applied to an issue
- Adds `.github/auto-pr-context.md` — domain-specific context telling Claude which files to look at (under `src/`, excluding auto-generated `src/api/`) when creating a fix PR

## Setup

Requires a `LITELLM_API_KEY` secret in this repo (same key already used by other client repos).

## Related

- Reusable workflow: https://github.com/elastic/clients-team-automations/blob/main/.github/workflows/auto-pr.yml
- Docs: https://github.com/elastic/clients-team-automations/blob/main/README.md