### PR TITLE
fix(ci): use x-access-token format for git clone in codegen

### DIFF
--- a/.github/make.sh
+++ b/.github/make.sh
@@ -176,7 +176,7 @@ else
     --rm \
     $product \
     /bin/bash -c "cd /usr/src && \
-      git clone --branch $GENERATOR_BRANCH https://$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-js.git && \
+      git clone --branch $GENERATOR_BRANCH https://x-access-token:$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-js.git && \
       mkdir -p /usr/src/elastic-client-generator-js/output && \
       cd /usr/src/elasticsearch-js && \
       node .buildkite/make.mjs --task $TASK ${TASK_ARGS[*]}"


### PR DESCRIPTION
## Summary

Backport of #3332 to `8.19`.

The weekly codegen CI was failing with:

```
fatal: could not read Password for 'https://***@github.com': No such device or address
```

The clone URL used `https://$TOKEN@github.com/...` which puts the token as the git username. Git then tries to prompt for a password interactively - which fails inside the Docker container with no TTY.

Fix: use `https://x-access-token:$TOKEN@github.com/...` so the token is the password.

## Test plan

- [ ] Weekly codegen run succeeds for `8.19` branch