### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds explicit \`permissions:\` block to \`.github/workflows/stale.yml\`
- \`actions/stale\` requires write access to label and close stale issues/PRs

## Motivation

InfoSec is changing GITHUB_TOKEN default permissions from read/write to read-only on July 15th. This PR adds explicit permissions blocks to all workflows that require write access before that change takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)