### PR TITLE
chore: upgrade fetch-github-token to v1.5.3

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Fetch ephemeral GitHub token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3 # v1.0.0
+        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.0.0
         with:
           vault-instance: "ci-prod"
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Fetch ephemeral GitHub token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.0.0
+        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.3
         with:
           vault-instance: "ci-prod"
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Fetch ephemeral GitHub token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@8a7604dfdd4e7fe21f969bfe9ff96e17635ea577 # v1.0.0
+        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3 # v1.0.0
         with:
           vault-instance: "ci-prod"
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -127,7 +127,7 @@ jobs:
           fi
       - name: Fetch ephemeral GitHub token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@8a7604dfdd4e7fe21f969bfe9ff96e17635ea577 # v1.0.0
+        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3 # v1.0.0
         with:
           vault-instance: "ci-prod"
       - name: Publish version on GitHub

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -127,7 +127,7 @@ jobs:
           fi
       - name: Fetch ephemeral GitHub token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3 # v1.0.0
+        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.0.0
         with:
           vault-instance: "ci-prod"
       - name: Publish version on GitHub

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -127,7 +127,7 @@ jobs:
           fi
       - name: Fetch ephemeral GitHub token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.0.0
+        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.3
         with:
           vault-instance: "ci-prod"
       - name: Publish version on GitHub


### PR DESCRIPTION
## Summary

Upgrades `elastic/ci-gh-actions/fetch-github-token` to `v1.5.3` across all affected workflow files.

## Reason

Version `v1.5.3` includes a fix for a security concern related to new GitHub token formats. Previous pinned versions (including commit SHAs and older semver tags) do not handle the updated token format correctly.

See: https://github.com/elastic/ci-gh-actions/releases/tag/v1.5.3

## Changes

Bumps `fetch-github-token` references from older versions/SHAs to `v1.5.3`.

---
*This PR was created automatically to address a security concern in CI workflows.*