### PR TITLE
ci: use a catch-all test to validate that required checks have passed

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -196,3 +196,18 @@ jobs:
           else
             exit 0;
           fi
+
+  ci:
+    name: CI Result
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - license
+      - test-bundler
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi


### PR DESCRIPTION
Follows the pattern established in elastic/cli so we don't have to continually move the "required checks" config on the repo to reflect shifts in Node.js and OS version support that show up in CI job names.
