### PR TITLE
fix: bump default timeout on 8.19 to 10 minutes

### DIFF
--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -82,7 +82,7 @@ _Default:_ `3`
 
 |`requestTimeout`
 |`number` - Max request timeout in milliseconds for each request. +
-_Default:_ `30000`
+_Default:_ `600000`
 
 |`pingTimeout`
 |`number` - Max ping request timeout in milliseconds for each request. +

--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -1,6 +1,17 @@
 [[changelog-client]]
 == Release notes
 [discrete]
+=== 8.19.2
+
+[discrete]
+==== Fixes
+
+[discrete]
+===== Bump default timeout to 10 minutes
+
+In 9.0, the default 30-second timeout was removed from this client. In the meantime, we've decided that increasing the timeout value in 8.x is not a breaking change, so it's been increased to 10 minutes to help avoid premature disconnection of slow requests (e.g. large bulk uploads).
+
+[discrete]
 === 8.19.1
 
 [discrete]

--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -415,7 +415,7 @@ _Default:_ `null`
 
 |`requestTimeout`
 |`number | string` - Max request timeout for the request in milliseconds, it overrides the client default. +
-_Default:_ `30000`
+_Default:_ `600000`
 
 |`retryOnTimeout`
 |`boolean` - Retry requests that have timed out.

--- a/docs/timeout-best-practices.asciidoc
+++ b/docs/timeout-best-practices.asciidoc
@@ -1,9 +1,9 @@
 [[timeout-best-practices]]
 === Timeout best practices
 
-This client is configured by default to operate like many HTTP client libraries do, by using a relatively short (30 second) timeout on all requests sent to {es}, raising a `TimeoutError` when that time period has elapsed without receiving a response. However, {es} will always eventually respond to any request, even if it takes several minutes. The {ref}/modules-network.html#_http_client_configuration[official {es} recommendation] is to disable response timeouts entirely by default.
+This client defaults to a 10-minute (`600000` ms) request timeout. This is intentionally generous: {es} will always eventually respond to any request, even when indexing large payloads, running ML inference pipelines, or operating in Serverless environments with auto-scaling latency. The {ref}/modules-network.html#_http_client_configuration[official {es} recommendation] is to disable response timeouts entirely by default.
 
-Since changing this default would be a breaking change, we won't do that until the next major release. In the meantime, here is our recommendation for properly configuring your client:
+Since removing the timeout completely would be a breaking change, it has only been removed in the 9.x client. In the 8.x client, it defaults to 30 seconds in all client versions prior to 8.19.2, where the timeout default was increased. In the meantime, here is our recommendation for properly configuring your client:
 
 * Ensure keep-alive is enabled; this is the default, so no settings need to be changed, unless you have set `agent` to `false` or provided an alternate `agent` that disables keep-alive
 * If using the default `UndiciConnection`, disable request timeouts by setting `timeout` to `0`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/elasticsearch",
-  "version": "8.19.1",
-  "versionCanary": "8.19.0-canary.0",
+  "version": "8.19.2",
+  "versionCanary": "8.19.2-canary.0",
   "description": "The official Elasticsearch client for Node.js",
   "main": "./index.js",
   "types": "index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -108,7 +108,7 @@ export interface ClientOptions {
     * @defaultValue 3 */
   maxRetries?: number
   /** @property requestTimeout Max request timeout in milliseconds for each request
-    * @defaultValue 30000 */
+    * @defaultValue 600000 */
   requestTimeout?: number
   /** @property pingTimeout Max number of milliseconds a `ClusterConnectionPool` will wait when pinging nodes before marking them dead
     * @defaultValue 3000 */
@@ -272,7 +272,7 @@ export default class Client extends API {
       Serializer,
       ConnectionPool: (opts.cloud != null) ? CloudConnectionPool : WeightedConnectionPool,
       maxRetries: 3,
-      requestTimeout: 30000,
+      requestTimeout: 600000,
       pingTimeout: 3000,
       sniffInterval: false,
       sniffOnStart: false,

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -588,7 +588,7 @@ test('Ensure new client instance stores requestTimeout for each connection', t =
   t.end()
 })
 
-test('Ensure new client does not time out at default (30s) when client sets requestTimeout', async t => {
+test('Ensure new client does not time out at default (10m) when client sets requestTimeout', async t => {
   const clock = FakeTimers.install({ toFake: ['setTimeout', 'clearTimeout'] })
   t.teardown(() => clock.uninstall())
 
@@ -597,7 +597,7 @@ test('Ensure new client does not time out at default (30s) when client sets requ
       t.pass('timeout ended')
       res.setHeader('content-type', 'application/json')
       res.end(JSON.stringify({ success: true }))
-    }, 31000) // default is 30000
+    }, 31000) // well under the 600000ms default
     clock.runToLast()
   }
 
@@ -605,7 +605,7 @@ test('Ensure new client does not time out at default (30s) when client sets requ
 
   const client = new Client({
     node: `http://localhost:${port}`,
-    requestTimeout: 60000
+    requestTimeout: 60000 // override default of 600000
   })
 
   try {
@@ -616,6 +616,14 @@ test('Ensure new client does not time out at default (30s) when client sets requ
     server.stop()
     t.end()
   }
+})
+
+test('Default requestTimeout is 10 minutes (600000ms)', t => {
+  const client = new Client({
+    node: 'http://localhost:9200',
+  })
+  t.equal(client.connectionPool.connections[0].timeout, 600000)
+  t.end()
 })
 
 test('Pass disablePrototypePoisoningProtection option to serializer', async t => {


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch-js/issues/3286.
