### PR TITLE
ci: fix Node 18 tap crypto error

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -54,10 +54,14 @@ jobs:
           npm run lint
 
       - name: Unit test
+        env:
+          NODE_OPTIONS: ${{ matrix.node-version == '18.x' && '--experimental-global-webcrypto' || '' }}
         run: |
           npm run test:unit
 
       - name: ECMAScript module test
+        env:
+          NODE_OPTIONS: ${{ matrix.node-version == '18.x' && '--experimental-global-webcrypto' || '' }}
         run: |
           npm run test:esm
 


### PR DESCRIPTION
Same fix as elastic/elastic-transport-js#398.

`@tapjs/processinfo` accesses `crypto` as a bare ESM global (via `uuid`), which Node 18 doesn't expose without `--experimental-global-webcrypto`. Sets `NODE_OPTIONS` per test step, scoped to Node 18 only.