### PR TITLE
Export ClientOptions and NodeOptions from the ESM entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ test/bundlers/**/bundled.js
 test/bundlers/parcel-test/.parcel-cache
 
 lib
-esm/
+/esm/
 src/version.generated.ts
 junit-output
 bun.lockb

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable @typescript-eslint/array-type */
-/* eslint-disable @typescript-eslint/no-empty-interface */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 /**
  * We are still working on this type, it will arrive soon.
  * If it's critical for you, please open an issue.

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,3 +56,5 @@ export type {
 } from '@elastic/transport'
 
 export * as estypes from './api/types'
+
+export type { ClientOptions, NodeOptions } from './client'

--- a/test/esm/fixtures/client-options.ts
+++ b/test/esm/fixtures/client-options.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ClientOptions, NodeOptions } from '@elastic/elasticsearch'
+
+export const clientOptions: ClientOptions = {
+  node: 'http://localhost:9200'
+}
+
+export const nodeOptions: NodeOptions = {
+  url: new URL('http://localhost:9200')
+}

--- a/test/esm/fixtures/tsconfig.json
+++ b/test/esm/fixtures/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@elastic/elasticsearch": ["../../../esm/index.d.ts"]
+    }
+  },
+  "include": ["client-options.ts"]
+}

--- a/test/esm/types.test.mjs
+++ b/test/esm/types.test.mjs
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test } from 'tap'
+import { execFileSync } from 'node:child_process'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const tscPath = join(__dirname, '../../node_modules/typescript/bin/tsc')
+const tsconfigPath = join(__dirname, 'fixtures/tsconfig.json')
+
+test('ClientOptions and NodeOptions are exported from the ESM entry point types', t => {
+  t.plan(1)
+
+  execFileSync(process.execPath, [tscPath, '-p', tsconfigPath], {
+    stdio: 'pipe'
+  })
+
+  t.pass('ESM entry point types resolve with bundler moduleResolution')
+})


### PR DESCRIPTION
## Summary

- Re-export `ClientOptions` and `NodeOptions` from `src/index.ts` so the generated `esm/index.d.ts` matches the hand-maintained root `index.d.ts`
- Add an ESM type-resolution test that verifies these types are importable with `moduleResolution: bundler`
- Narrow `.gitignore` from `esm/` to `/esm/` so new files under `test/esm/` are not accidentally ignored

## Context

The root `index.d.ts` already exported `ClientOptions` and `NodeOptions`, but `src/index.ts` (which generates `esm/index.d.ts`) did not. This caused TypeScript consumers using `moduleResolution: bundler` to fail when importing these types from `@elastic/elasticsearch`, while the `/lib/client` subpath still worked.

## Test plan

- [x] `npm run test:esm`
- [x] `npx tap test/unit/ test/esm/` (659 tests passing)

Made with [Cursor](https://cursor.com)