### PR TITLE
Bump 8.19.3

### DIFF
--- a/docs/changelog.asciidoc
+++ b/docs/changelog.asciidoc
@@ -1,6 +1,17 @@
 [[changelog-client]]
 == Release notes
 [discrete]
+=== 8.19.3
+
+[discrete]
+==== Fixes
+
+[discrete]
+===== Support path prefix in node URL
+
+Fixes a long-standing issue where Elasticsearch nodes configured with a URL path prefix (e.g. `https://host/elastic/`) would fail with an `invalid url` error. The underlying transport was stripping the path when creating the connection pool. Upgrade to `@elastic/transport@8.10.2` to get the fix.
+
+[discrete]
 === 8.19.2
 
 [discrete]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/elasticsearch",
-  "version": "8.19.2",
+  "version": "8.19.3",
   "versionCanary": "8.19.2-canary.0",
   "description": "The official Elasticsearch client for Node.js",
   "main": "./index.js",
@@ -90,7 +90,7 @@
     "zx": "7.2.3"
   },
   "dependencies": {
-    "@elastic/transport": "^8.9.6",
+    "@elastic/transport": "^8.10.2",
     "apache-arrow": "18.x - 21.x",
     "tslib": "^2.4.0"
   },


### PR DESCRIPTION
Release prep for 8.19.3.

Bumps `@elastic/transport` to `^8.10.2`.
Changes since 8.19.2:
- fix: support path prefix in node URL (elastic/elastic-transport-js#388) — nodes configured with a URL path prefix (e.g. `https://host/elastic/`) no longer fail with `invalid url`.