### PR TITLE
feat: expose maxPathLength client option

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "zx": "8.8.5"
   },
   "dependencies": {
-    "@elastic/transport": "^9.3.5",
+    "@elastic/transport": "^9.4.0",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -181,6 +181,9 @@ export interface ClientOptions {
   /** @property maxCompressedResponseSize When configured, verifies that the compressed response size is lower than the configured number. If it's higher, it will abort the request. It cannot be higher than `buffer.constants.MAX_LENGTH`
     * @defaultValue null */
   maxCompressedResponseSize?: number
+  /** @property maxUrlLength Maximum allowed byte length of the request URL (`path` + optional `?querystring`). When exceeded, the request is rejected before it is sent. Aligns with Elasticsearch's `http.max_initial_line_length` (default 4kb); leave headroom for the HTTP method and version. Disabled when unset.
+    * @defaultValue null */
+  maxUrlLength?: number | null
   /** @property redaction Options for how to redact potentially sensitive data from metadata attached to `Error` objects
     * @remarks Read https://www.elastic.co/docs/reference/elasticsearch/clients/javascript/advanced-config#redaction for more details
     * @defaultValue Configuration that will replace known sources of sensitive data */
@@ -291,6 +294,7 @@ export default class Client extends API {
       enableMetaHeader: true,
       maxResponseSize: null,
       maxCompressedResponseSize: null,
+      maxUrlLength: null,
       serverMode: 'stack'
     }, opts, { headers, redaction })
 
@@ -414,6 +418,8 @@ export default class Client extends API {
       productCheck: 'Elasticsearch',
       maxResponseSize: options.maxResponseSize,
       maxCompressedResponseSize: options.maxCompressedResponseSize,
+      // @ts-expect-error maxUrlLength lands in @elastic/transport with the paired release
+      maxUrlLength: options.maxUrlLength,
       redaction: options.redaction,
 
       // @ts-ignore enableMetaHeader will be available in transport v9.1.1

--- a/src/client.ts
+++ b/src/client.ts
@@ -418,7 +418,6 @@ export default class Client extends API {
       productCheck: 'Elasticsearch',
       maxResponseSize: options.maxResponseSize,
       maxCompressedResponseSize: options.maxCompressedResponseSize,
-      // @ts-expect-error maxPathLength lands in @elastic/transport with the paired release
       maxPathLength: options.maxPathLength,
       redaction: options.redaction,
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -181,9 +181,9 @@ export interface ClientOptions {
   /** @property maxCompressedResponseSize When configured, verifies that the compressed response size is lower than the configured number. If it's higher, it will abort the request. It cannot be higher than `buffer.constants.MAX_LENGTH`
     * @defaultValue null */
   maxCompressedResponseSize?: number
-  /** @property maxUrlLength Maximum allowed byte length of the request URL (`path` + optional `?querystring`). When exceeded, the request is rejected before it is sent. Aligns with Elasticsearch's `http.max_initial_line_length` (default 4kb); leave headroom for the HTTP method and version. Disabled when unset.
+  /** @property maxPathLength Maximum allowed byte length of the request path (`path` + optional `?querystring`). Does not include scheme or hostname. When exceeded, the request is rejected before it is sent. Aligns with Elasticsearch's `http.max_initial_line_length` (default 4kb); leave headroom for the HTTP method and version. Disabled when unset.
     * @defaultValue null */
-  maxUrlLength?: number | null
+  maxPathLength?: number | null
   /** @property redaction Options for how to redact potentially sensitive data from metadata attached to `Error` objects
     * @remarks Read https://www.elastic.co/docs/reference/elasticsearch/clients/javascript/advanced-config#redaction for more details
     * @defaultValue Configuration that will replace known sources of sensitive data */
@@ -294,7 +294,7 @@ export default class Client extends API {
       enableMetaHeader: true,
       maxResponseSize: null,
       maxCompressedResponseSize: null,
-      maxUrlLength: null,
+      maxPathLength: null,
       serverMode: 'stack'
     }, opts, { headers, redaction })
 
@@ -418,8 +418,8 @@ export default class Client extends API {
       productCheck: 'Elasticsearch',
       maxResponseSize: options.maxResponseSize,
       maxCompressedResponseSize: options.maxCompressedResponseSize,
-      // @ts-expect-error maxUrlLength lands in @elastic/transport with the paired release
-      maxUrlLength: options.maxUrlLength,
+      // @ts-expect-error maxPathLength lands in @elastic/transport with the paired release
+      maxPathLength: options.maxPathLength,
       redaction: options.redaction,
 
       // @ts-ignore enableMetaHeader will be available in transport v9.1.1

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -872,3 +872,23 @@ test('custom transport: disable otel via env var', async t => {
   t.equal(exporter.getFinishedSpans().length, 0)
   t.end()
 })
+
+test('Passes maxUrlLength to Transport', t => {
+  let captured: Record<string, unknown> | undefined
+  class CaptureTransport extends Transport {
+    constructor (opts: ConstructorParameters<typeof Transport>[0]) {
+      super(opts)
+      captured = opts as unknown as Record<string, unknown>
+    }
+  }
+
+  // eslint-disable-next-line no-new
+  new Client({
+    node: 'http://localhost:9200',
+    Transport: CaptureTransport as typeof Transport,
+    maxUrlLength: 3500
+  })
+
+  t.equal(captured?.maxUrlLength, 3500)
+  t.end()
+})

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -873,7 +873,7 @@ test('custom transport: disable otel via env var', async t => {
   t.end()
 })
 
-test('Passes maxUrlLength to Transport', t => {
+test('Passes maxPathLength to Transport', t => {
   let captured: Record<string, unknown> | undefined
   class CaptureTransport extends Transport {
     constructor (opts: ConstructorParameters<typeof Transport>[0]) {
@@ -886,9 +886,9 @@ test('Passes maxUrlLength to Transport', t => {
   new Client({
     node: 'http://localhost:9200',
     Transport: CaptureTransport as typeof Transport,
-    maxUrlLength: 3500
+    maxPathLength: 3500
   })
 
-  t.equal(captured?.maxUrlLength, 3500)
+  t.equal(captured?.maxPathLength, 3500)
   t.end()
 })


### PR DESCRIPTION
## Summary
- Adds `ClientOptions.maxPathLength` and forwards it to `@elastic/transport` `TransportOptions.maxPathLength`.
- When set, the transport rejects requests whose `path` + `?querystring` byte length exceeds the limit **before** sending (avoids EPIPE / 414 from Elasticsearch's ~4kb `http.max_initial_line_length`).
- Does **not** include scheme or hostname (origin-form request-target only).
- Disabled by default (`null`) so consumers can choose the budget — Kibana can set e.g. `3500` in `configureClient` / `parseClientOptions` once this and the transport change are released and bumped.

Depends on: https://github.com/elastic/elastic-transport-js/pull/400

## Test plan
- [x] Unit test `Passes maxPathLength to Transport`
- [x] Full unit suite locally (640 pass, Node 22)
- [ ] After transport publish + bump: `new Client({ maxPathLength: 3500, ... })` rejects oversized `indices.resolveIndex` paths with `ConfigurationError`