### PR TITLE
ci: fix npm view parsing broken by npm 12

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           # set unstable version value
           unstable_tag="unstable.$(date --utc +%Y%m%d%H%M%S)"
-          latest=$(npm view @elastic/elasticsearch --json | jq -r '.["dist-tags"].latest')
+          latest=$(npm view @elastic/elasticsearch dist-tags.latest)
           next=$(npx -y 'semver@^7.7.0' -i minor "$latest")
           unstable_version="$next-$unstable_tag"
 
@@ -128,7 +128,7 @@ jobs:
           # if no meta info on the version (e.g. a '-alpha.1' prefix), publish as a stable release
           if [[ -z "$tag_meta" ]]; then
             # get latest version on npm
-            latest=$(npm view @elastic/elasticsearch --json | jq -r '.["dist-tags"].latest')
+            latest=$(npm view @elastic/elasticsearch dist-tags.latest)
 
             # if $version is higher than the most recently published version, publish as-is
             if [[ $(yes | npx semver "$version" "$latest" | tail -n1) == "$version" ]]; then


### PR DESCRIPTION
## Summary

The [unstable publish job on main](https://github.com/elastic/elasticsearch-js/actions/runs/29767994648/job/88438819870) failed with:

```
jq: error (at <stdin>:577): Cannot index array with string "dist-tags"
```

npm 12.0.0 has a breaking change: `npm view --json` now always returns an array, even for a single result ([npm/cli#9160](https://github.com/npm/cli/pull/9160)). Since the workflow runs `npm install -g npm` before publishing, it picked up npm 12 and `jq -r '.["dist-tags"].latest'` started failing on the array output.

This replaces the `--json | jq` pipeline with `npm view @elastic/elasticsearch dist-tags.latest`, which prints the plain version string on both npm 11 and 12. Verified locally against both versions. Fixed in both places the pattern appears (unstable publish and release publish).

## Test plan

- [ ] Next push to main that touches `src/**` should publish an unstable build successfully