### PR TITLE
Backport #3062 to 8.19: codegen succeeds when no changes

### DIFF
--- a/.github/make.sh
+++ b/.github/make.sh
@@ -208,8 +208,7 @@ if [[ "$CMD" == "codegen" ]]; then
   if [ -n "$(git status --porcelain)" ]; then
     echo -e "\033[32;1mTARGET: successfully generated client v$VERSION\033[0m"
   else
-    echo -e "\033[31;1mTARGET: failed generating client v$VERSION\033[0m"
-    exit 1
+    echo -e "\033[33;1mTARGET: codegen completed for v$VERSION (no changes - code already up to date)\033[0m"
   fi
 fi
 


### PR DESCRIPTION
## Summary

The weekly codegen job failed for 8.19 this week because the spec's 8.19 branch had no new commits, and `make.sh codegen` on this branch exits 1 when the generator produces an empty diff. All other active branches already treat "no changes" as success (see the same fix on main); this backports it so quiet weeks stop showing up as failures.

## Test plan

- Clean cherry-pick, one-line behavior change in `.github/make.sh`
- Next weekly run with no 8.19 spec changes should report success and skip PR creation