### PR TITLE
feat: expose maxPathLength client option

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "zx": "8.8.5"
   },
   "dependencies": {
-    "@elastic/transport": "^9.3.5",
+    "@elastic/transport": "^9.4.0",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -181,6 +181,9 @@ export interface ClientOptions {
   /** @property maxCompressedResponseSize When configured, verifies that the compressed response size is lower than the configured number. If it's higher, it will abort the request. It cannot be higher than `buffer.constants.MAX_LENGTH`
     * @defaultValue null */
   maxCompressedResponseSize?: number
+  /** @property maxPathLength Maximum allowed byte length of the request path (`path` + optional `?querystring`). Does not include scheme or hostname. When exceeded, the request is rejected before it is sent. Aligns with Elasticsearch's `http.max_initial_line_length` (default 4kb); leave headroom for the HTTP method and version. Disabled when unset.
+    * @defaultValue null */
+  maxPathLength?: number | null
   /** @property redaction Options for how to redact potentially sensitive data from metadata attached to `Error` objects
     * @remarks Read https://www.elastic.co/docs/reference/elasticsearch/clients/javascript/advanced-config#redaction for more details
     * @defaultValue Configuration that will replace known sources of sensitive data */
@@ -291,6 +294,7 @@ export default class Client extends API {
       enableMetaHeader: true,
       maxResponseSize: null,
       maxCompressedResponseSize: null,
+      maxPathLength: null,
       serverMode: 'stack'
     }, opts, { headers, redaction })
 
@@ -414,6 +418,7 @@ export default class Client extends API {
       productCheck: 'Elasticsearch',
       maxResponseSize: options.maxResponseSize,
       maxCompressedResponseSize: options.maxCompressedResponseSize,
+      maxPathLength: options.maxPathLength,
       redaction: options.redaction,
 
       // @ts-ignore enableMetaHeader will be available in transport v9.1.1

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -872,3 +872,23 @@ test('custom transport: disable otel via env var', async t => {
   t.equal(exporter.getFinishedSpans().length, 0)
   t.end()
 })
+
+test('Passes maxPathLength to Transport', t => {
+  let captured: Record<string, unknown> | undefined
+  class CaptureTransport extends Transport {
+    constructor (opts: ConstructorParameters<typeof Transport>[0]) {
+      super(opts)
+      captured = opts as unknown as Record<string, unknown>
+    }
+  }
+
+  // eslint-disable-next-line no-new
+  new Client({
+    node: 'http://localhost:9200',
+    Transport: CaptureTransport as typeof Transport,
+    maxPathLength: 3500
+  })
+
+  t.equal(captured?.maxPathLength, 3500)
+  t.end()
+})


### PR DESCRIPTION
Backport of #3380 to 9.5.