### PR TITLE
chore: release 9.4.3

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -20,6 +20,18 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elasticsearch-javascript-client-next-fixes]
 % \*
 
+## 9.4.3 [elasticsearch-javascript-client-9.4.3]
+
+### Features and enhancements [elasticsearch-javascript-client-9.4.3-features-enhancements]
+
+- **`maxPathLength` option:** Adds a `maxPathLength` client option to reject requests whose path and query string exceed a configurable byte length before they are sent, preventing uncaught errors from HAProxy or Elasticsearch's `http.max_initial_line_length` limit.
+
+## 9.4.2 [elasticsearch-javascript-client-9.4.2]
+
+### Fixes [elasticsearch-javascript-client-9.4.2-fixes]
+
+- Only throw an error when `bulk` API's `operations` value is truly empty
+
 ## 9.4.1 [elasticsearch-javascript-client-9.4.1]
 
 ### Fixes [elasticsearch-javascript-client-9.4.1-fixes]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/elasticsearch",
-  "version": "9.4.2",
-  "versionCanary": "9.4.2-canary.0",
+  "version": "9.4.3",
+  "versionCanary": "9.4.3-canary.0",
   "description": "The official Elasticsearch client for Node.js",
   "type": "commonjs",
   "main": "./index.js",


### PR DESCRIPTION
Backport of #3392 to 9.4. Includes release notes and version bump.