### PR TITLE
fix(ci): add --allow-empty-coverage to integration test tap run

### DIFF
--- a/.buildkite/run-client.sh
+++ b/.buildkite/run-client.sh
@@ -35,7 +35,7 @@ docker run \
   --name elasticsearch-js \
   --rm \
   elastic/elasticsearch-js \
-  bash -c "npm run test:integration-build; BUILD_EXIT=\$?; echo \"=== integration-build exit: \$BUILD_EXIT ===\"; if [ \$BUILD_EXIT -ne 0 ]; then exit \$BUILD_EXIT; fi; ./node_modules/.bin/tap run --jobs=1 --disable-coverage --reporter=junit --reporter-file=report-junit.xml generated-tests/; TAP_EXIT=\$?; echo \"=== tap exit: \$TAP_EXIT ===\"; if [ -f ./report-junit.xml ]; then echo \"JUnit testcases: \$(grep -c '<testcase' ./report-junit.xml || true)\"; echo \"JUnit failures: \$(grep -c '<failure' ./report-junit.xml || true)\"; mv ./report-junit.xml /junit-output/junit-$BUILDKITE_JOB_ID.xml; else echo 'No JUnit artifact found'; fi; exit \$TAP_EXIT"
+  bash -c "npm run test:integration-build; BUILD_EXIT=\$?; echo \"=== integration-build exit: \$BUILD_EXIT ===\"; if [ \$BUILD_EXIT -ne 0 ]; then exit \$BUILD_EXIT; fi; ./node_modules/.bin/tap run --jobs=1 --disable-coverage --allow-empty-coverage --reporter=junit --reporter-file=report-junit.xml generated-tests/; TAP_EXIT=\$?; echo \"=== tap exit: \$TAP_EXIT ===\"; if [ -f ./report-junit.xml ]; then echo \"JUnit testcases: \$(grep -c '<testcase' ./report-junit.xml || true)\"; echo \"JUnit failures: \$(grep -c '<failure' ./report-junit.xml || true)\"; mv ./report-junit.xml /junit-output/junit-$BUILDKITE_JOB_ID.xml; else echo 'No JUnit artifact found'; fi; exit \$TAP_EXIT"
 
 if [ ! -f "$repo/junit-output/junit-$BUILDKITE_JOB_ID.xml" ]; then
   echo "No JUnit artifact produced, creating empty placeholder"


### PR DESCRIPTION
`--disable-coverage` prevents c8 from collecting coverage data but doesn't gate tap's built-in report teardown. After all tests complete, `execute-test-suite.js` runs `report()` as a teardown, which checks `.tap/coverage` and exits 1 if it's empty - even when coverage was intentionally disabled. Adding `--allow-empty-coverage` suppresses that exit.

