### PR TITLE
fix: prevent unhandled rejection in SniffingTransport error handling

### DIFF
--- a/src/sniffingTransport.ts
+++ b/src/sniffingTransport.ts
@@ -29,12 +29,16 @@ export default class SniffingTransport extends Transport {
       })
       .catch(err => {
         this.isSniffing = false
-        err.meta.sniff = { hosts: [], reason: opts.reason }
+        // non-transport errors, like the AssertionError thrown on an
+        // unexpected body, don't have a meta object to attach sniff data to
+        if (isObject(err?.meta)) {
+          err.meta.sniff = { hosts: [], reason: opts.reason }
+        }
         this.diagnostic.emit('sniff', err, null)
       })
   }
 }
 
 function isObject (obj: any): obj is Record<string, any> {
-  return typeof obj === 'object'
+  return typeof obj === 'object' && obj !== null
 }

--- a/test/unit/sniffingTransport.test.ts
+++ b/test/unit/sniffingTransport.test.ts
@@ -60,5 +60,51 @@ test('SniffingTransport', t => {
     transport.sniff({ reason: 'test' })
   })
 
+  t.test('sniff - null body emits sniff event with error', t => {
+    t.plan(2)
+
+    const MockConnection = connection.buildMockConnection({
+      onRequest (_params) {
+        return { body: null }
+      }
+    })
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+      Connection: MockConnection
+    })
+
+    const transport = client.transport as SniffingTransport
+    transport.diagnostic.once('sniff', (err, result) => {
+      t.ok(err != null, 'the sniff event should carry the error')
+      t.equal(transport.isSniffing, false)
+    })
+
+    transport.sniff({ reason: 'test' })
+  })
+
+  t.test('sniff - body without nodes emits sniff event with error', t => {
+    t.plan(2)
+
+    const MockConnection = connection.buildMockConnection({
+      onRequest (_params) {
+        return { body: { hello: 'world' } }
+      }
+    })
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+      Connection: MockConnection
+    })
+
+    const transport = client.transport as SniffingTransport
+    transport.diagnostic.once('sniff', (err, result) => {
+      t.ok(err != null, 'the sniff event should carry the error')
+      t.equal(transport.isSniffing, false)
+    })
+
+    transport.sniff({ reason: 'test' })
+  })
+
   t.end()
 })


### PR DESCRIPTION
Closes #3407

## What this does

`SniffingTransport.sniff()` could turn a background sniff failure into an unhandled promise rejection, because its `.catch` handler assumed every error carries a transport `meta` object:

```ts
.catch(err => {
  this.isSniffing = false
  err.meta.sniff = { hosts: [], reason: opts.reason }  // throws if err has no meta
  this.diagnostic.emit('sniff', err, null)             // never reached
})
```

Transport errors do have `meta`, but errors thrown inside the `.then` handler do not — e.g. the `AssertionError` from `assert(isObject(result.body))`, or a `TypeError` from `nodesToHost` when the body has no `nodes`. Since `sniff()` is fire-and-forget, the secondary throw became an unhandled rejection (fatal by default on modern Node.js) and the `sniff` diagnostic event was silently swallowed.

Two changes:

1. The `.catch` only attaches sniff metadata when `err.meta` exists, so `diagnostic.emit('sniff', err, null)` is always reached.
2. `isObject` now rejects `null` (`typeof null === 'object'`), so a JSON `null` sniff body fails the assertion instead of slipping through to `result.body.nodes`.

## Tests

Two new unit tests in `test/unit/sniffingTransport.test.ts` using `buildMockConnection`:

- a sniff response with a JSON `null` body
- a sniff response without a `nodes` property

Both assert the `sniff` diagnostic event fires with an error and `isSniffing` is reset. Verified both tests fail against the previous implementation (the unhandled rejection kills the test process) and pass with this change. Full `npm test` passes cleanly with coverage thresholds met.
