### PR TITLE
docs: add claude build skills

### DIFF
--- a/.claude/skills/build-failure.md
+++ b/.claude/skills/build-failure.md
@@ -1,0 +1,24 @@
+---
+name: build-failure
+description: Diagnose elasticsearch-js CI and local build failures.
+---
+
+# Build failure
+
+Read the failing job log before changing code.
+
+Edited `src/api/`: revert it. Fix `elastic/elasticsearch-specification` or a hand-maintained file under `src/` instead.
+
+Lint / eslint: `npm run lint:fix`, then review the diff. Do not disable rules to go green.
+
+License checker: only MIT, Apache-2.0, Apache1.1, ISC, BSD-3-Clause, BSD-2-Clause, 0BSD in production deps.
+
+Missing SPDX header: `npm run license-header` names the files. Use the Elasticsearch B.V. Apache-2.0 header.
+
+Windows-only JSON or path failures: no `echo '...'` for JSON; use `node -e` and `path.join`.
+
+Coverage / tap thresholds: `npm test` enforces coverage excluding `**/api/**`. Do not lower thresholds.
+
+`npm test` skipped in CI when only docs changed: that is the paths-filter, not a broken build.
+
+Bun failures: `bun install` and `bun run lint` / `bun run test:unit-bun`. Still keep npm as the source of truth.

--- a/.claude/skills/build.md
+++ b/.claude/skills/build.md
@@ -1,0 +1,24 @@
+---
+name: build
+description: Install, compile, and verify a clean elasticsearch-js checkout.
+---
+
+# Build
+
+Node.js 22+. Always `npm`, never yarn or pnpm.
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+`npm test` already runs `npm run build` then lint and unit tests. Outputs CJS to `lib/` and ESM to `esm/`.
+
+```bash
+npm run lint
+npm run license-checker
+npm run license-header
+```
+
+Do not edit `src/api/`. Change hand-maintained files under `src/` (except `src/api/`) and tests under `test/`. Code must work on Linux, macOS, and Windows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ Always use `npm` commands, not `yarn`, `pnpm` or any other third-party packaging
 - Fix linter issues: `npm run lint:fix`
 - Build TypeScript (outputs both ESM and CommonJS): `npm run build`
 
+Node.js 22+. Do not edit `src/api/`; it is generated from `elastic/elasticsearch-specification`.
+
 ## Testing
 
 **The entire test suite (`npm test`) must pass and exit cleanly before you commit code.**
@@ -51,6 +53,6 @@ node -e "require('fs').writeFileSync('file.json', JSON.stringify({type:'module'}
 
 All markdown instructions authored for other agents must be as concise as possible.
 
-If a specific action you learned to do better will be useful to other agents doing the same task in the future, but may not be needed for ALL agent-related tasks, create or update skills in `.github/skills/`.
+If a specific action you learned to do better will be useful to other agents doing the same task in the future, but may not be needed for ALL agent-related tasks, create or update skills in `.claude/skills/`.
 
 If you learned something that will be useful to any contributor to this project, update `AGENTS.md`.


### PR DESCRIPTION
moves the Build stage from documented commands (level 1) to agent-invokable skills (level 2): `.claude/skills/build.md` and `.claude/skills/build-failure.md`.