### PR TITLE
Make SecurityGlobalPrivilege application attribute optional

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -36517,7 +36517,7 @@ export interface SecurityFieldSecurity {
 }
 
 export interface SecurityGlobalPrivilege {
-  application: SecurityApplicationGlobalUserPrivileges
+  application?: SecurityApplicationGlobalUserPrivileges
   /** A list of data source privilege entries, used to grant access to ES|QL data sources.
     * @remarks This property is not supported on Elastic Cloud Serverless. */
   data_source?: SecurityDataSourcePrivileges[]


### PR DESCRIPTION
The application attribute of SecurityGlobalPrivilege should be optional, here's an explain of it being omitted - https://www.elastic.co/docs/reference/query-languages/esql/esql-data-federation-security#privileges
