### PR TITLE
fix: move Apache Arrow optional type defs out of default import tree

### DIFF
--- a/docs/reference/client-helpers.md
+++ b/docs/reference/client-helpers.md
@@ -634,6 +634,27 @@ const result = await client.helpers
   .toRecords<EventLog>()
 ```
 
+#### Loading Arrow type definitions [_arrow-types]
+
+`apache-arrow` is an optional peer dependency, so its type definitions are not wired into the client by default. This keeps projects that never use the Arrow helpers from having to install `apache-arrow` to type-check. Until the definitions are loaded, `toArrowTable` returns `unknown` and `toArrowReader` returns `unknown`; both still work at runtime.
+
+To get precise types (`Table` and `AsyncRecordBatchStreamReader`), install `apache-arrow` and add a single side-effect import once, anywhere in your project:
+
+```ts
+// Loads the apache-arrow type definitions for the ES|QL Arrow helpers.
+// A side-effect import: no bindings are needed, and it is erased at runtime.
+import '@elastic/elasticsearch/helpers-arrow'
+
+import { Client } from '@elastic/elasticsearch'
+
+const client = new Client({ node: 'http://localhost:9200' })
+
+// `table` is now typed as `Table`, and `reader` as `AsyncRecordBatchStreamReader`
+const table = await client.helpers
+  .esql({ query: 'FROM sample_data' })
+  .toArrowTable()
+```
+
 #### `toArrowReader` [_toarrowreader]
 
 Added in `v8.16.0`

--- a/docs/reference/client-helpers.md
+++ b/docs/reference/client-helpers.md
@@ -642,7 +642,8 @@ To get precise types (`Table` and `AsyncRecordBatchStreamReader`), install `apac
 
 ```ts
 // Loads the apache-arrow type definitions for the ES|QL Arrow helpers.
-// A side-effect import: no bindings are needed, and it is erased at runtime.
+// This is a type-only augmentation: at runtime it just loads an empty module.
+// It imports no bindings, so nothing else needs to change.
 import '@elastic/elasticsearch/helpers-arrow'
 
 import { Client } from '@elastic/elasticsearch'
@@ -654,6 +655,8 @@ const table = await client.helpers
   .esql({ query: 'FROM sample_data' })
   .toArrowTable()
 ```
+
+The opt-in module is resolved through the package `exports` map, so your project must use a modern TypeScript module resolution mode: `node16`, `nodenext`, or `bundler`. Under the legacy `node`/`node10` mode, `exports` is ignored and the import does not resolve; the Arrow helpers stay typed as `unknown`.
 
 #### `toArrowReader` [_toarrowreader]
 

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -15,6 +15,18 @@ Breaking changes can impact your Elastic applications, potentially disrupting no
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
 
+## 9.6.0 [elasticsearch-javascript-client-960-breaking-changes]
+
+::::{dropdown} ES|QL Arrow types moved to an opt-in module
+The `apache-arrow` type definitions are no longer referenced from the package entrypoint. Previously, `esm/helpers.d.ts` imported them directly, which broke `tsc` type-checking for every ESM consumer under `nodenext` resolution—even those not using the Arrow helpers or without `apache-arrow` installed (error `TS2307`).
+
+For more information, check [#3419](https://github.com/elastic/elasticsearch-js/issues/3419).
+
+**Impact**<br> `esql().toArrowTable()` returns `unknown` and `toArrowReader()` returns `unknown` by default. Runtime behavior is unchanged.
+
+**Action**<br> To restore the precise `Table` and `AsyncRecordBatchStreamReader` types, install `apache-arrow` and add a single side-effect import once in your project: `import '@elastic/elasticsearch/helpers-arrow'`.
+::::
+
 ## 9.4.0 [elasticsearch-javascript-client-940-breaking-changes]
 
 ::::{dropdown} Minimum supported Node.js version raised to 20

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -24,7 +24,7 @@ For more information, check [#3419](https://github.com/elastic/elasticsearch-js/
 
 **Impact**<br> `esql().toArrowTable()` returns `unknown` and `toArrowReader()` returns `unknown` by default. Runtime behavior is unchanged.
 
-**Action**<br> To restore the precise `Table` and `AsyncRecordBatchStreamReader` types, install `apache-arrow` and add a single side-effect import once in your project: `import '@elastic/elasticsearch/helpers-arrow'`.
+**Action**<br> To restore the precise `Table` and `AsyncRecordBatchStreamReader` types, install `apache-arrow` and add a single side-effect import once in your project: `import '@elastic/elasticsearch/helpers-arrow'`. This opt-in module resolves through the package `exports` map, so it requires a modern TypeScript module resolution mode (`node16`, `nodenext`, or `bundler`); under the legacy `node`/`node10` mode the import does not resolve and the Arrow helpers stay typed as `unknown`.
 ::::
 
 ## 9.4.0 [elasticsearch-javascript-client-940-breaking-changes]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -20,6 +20,12 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elasticsearch-javascript-client-next-fixes]
 % \*
 
+## 9.6.0 [elasticsearch-javascript-client-9.6.0]
+
+### Fixes [elasticsearch-javascript-client-9.6.0-fixes]
+
+- **ES|QL Arrow types no longer break ESM type-checking:** The `apache-arrow` type definitions were removed from the package entrypoint and moved to an opt-in `@elastic/elasticsearch/helpers-arrow` module. Previously, ESM consumers using `nodenext` resolution hit a `TS2307` error even without using the Arrow helpers. See [breaking changes](breaking-changes.md) for details ([#3419](https://github.com/elastic/elasticsearch-js/issues/3419)).
+
 ## 9.5.1 [elasticsearch-javascript-client-9.5.1]
 
 ### Fixes [elasticsearch-javascript-client-9.5.1-fixes]

--- a/scripts/fix-esm-require.js
+++ b/scripts/fix-esm-require.js
@@ -44,3 +44,35 @@ injectCreateRequire(
   content => content.includes('require(\'apache-arrow/'),
   content => content.replace(/require\('apache-arrow\/Arrow\.node\.js'\)/g, 'require(\'apache-arrow/Arrow.node\')')
 )
+
+// Fix module specifiers in emitted ESM declaration files that tsc-esm-fix gets wrong:
+//  1. It appends `.js` to bare specifiers pointing at external packages
+//     (e.g. `apache-arrow/Arrow.node` -> `.node.js`). A published package never ships
+//     a `.js.d.ts`, so that suffix never resolves for type-checking. Strip it.
+//  2. It does NOT append `.js` to relative `declare module './x'` specifiers, so ESM
+//     module augmentation fails to match its target under NodeNext. Append it.
+// Relative/absolute specifiers are left untouched.
+function fixEsmDeclarations (dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      fixEsmDeclarations(fullPath)
+    } else if (entry.name.endsWith('.d.ts')) {
+      const content = fs.readFileSync(fullPath, 'utf8')
+      let fixed = content.replace(/((?:from|import\()\s*)(['"])([^'"]+)\.js\2/g, (match, pre, quote, spec) => {
+        if (spec.startsWith('.') || spec.startsWith('/')) return match
+        return `${pre}${quote}${spec}${quote}`
+      })
+      fixed = fixed.replace(/(declare module\s+)(['"])(\.[^'"]+)\2/g, (match, pre, quote, spec) => {
+        if (/\.(js|mjs|cjs|json)$/.test(spec)) return match
+        return `${pre}${quote}${spec}.js${quote}`
+      })
+      if (fixed !== content) {
+        fs.writeFileSync(fullPath, fixed, 'utf8')
+        console.log(`Fixed declaration specifiers in ${fullPath}`)
+      }
+    }
+  }
+}
+
+fixEsmDeclarations(path.join(__dirname, '..', 'esm'))

--- a/src/helpers-arrow.ts
+++ b/src/helpers-arrow.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Opt-in types for the ES|QL Arrow helpers. Import this module once
+// (`import '@elastic/elasticsearch/helpers-arrow'`) in a project that has
+// apache-arrow installed to give `esql().toArrowTable()` and `toArrowReader()`
+// their precise apache-arrow types. Projects that never import it do not need
+// apache-arrow installed to type-check the rest of the client.
+import type { Table, TypeMap, AsyncRecordBatchStreamReader } from 'apache-arrow/Arrow.node'
+
+declare module './helpers' {
+  interface EsqlArrowRegistry {
+    table: Table<TypeMap>
+    reader: AsyncRecordBatchStreamReader
+  }
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,10 +7,18 @@ import assert from 'node:assert'
 import * as timersPromises from 'node:timers/promises'
 import { Readable } from 'node:stream'
 import { errors, TransportResult, TransportRequestOptions, TransportRequestOptionsWithMeta } from '@elastic/transport'
-import type { Table, TypeMap, AsyncRecordBatchStreamReader } from 'apache-arrow/Arrow.node'
 import Client from './client'
 import * as T from './api/types'
 import { Id } from './api/types'
+
+// Augmentation seam. apache-arrow is an optional peer dependency, so its types
+// must not be referenced from this always-reachable module: doing so forces every
+// consumer to install apache-arrow to type-check, even when they never touch Arrow.
+// Importing '@elastic/elasticsearch/helpers-arrow' augments this registry with the
+// precise apache-arrow types. Until then, the Arrow helpers resolve to `unknown`.
+export interface EsqlArrowRegistry {}
+type EsqlArrowTable = EsqlArrowRegistry extends { table: infer T } ? T : unknown
+type EsqlArrowReader = EsqlArrowRegistry extends { reader: infer T } ? T : unknown
 
 function loadArrow (): typeof import('apache-arrow/Arrow.node') {
   try {
@@ -143,8 +151,8 @@ export interface EsqlColumn {
 
 export interface EsqlHelper {
   toRecords: <TDocument>() => Promise<EsqlToRecords<TDocument>>
-  toArrowTable: () => Promise<Table<TypeMap>>
-  toArrowReader: () => Promise<AsyncRecordBatchStreamReader>
+  toArrowTable: () => Promise<EsqlArrowTable>
+  toArrowReader: () => Promise<EsqlArrowReader>
 }
 
 export interface EsqlToRecords<TDocument> {
@@ -1017,7 +1025,7 @@ export default class Helpers {
         return { records, columns }
       },
 
-      async toArrowTable (): Promise<Table<TypeMap>> {
+      async toArrowTable (): Promise<EsqlArrowTable> {
         const { tableFromIPC } = loadArrow()
         if (metaHeader !== null) {
           reqOptions.headers = reqOptions.headers ?? {}
@@ -1031,7 +1039,7 @@ export default class Helpers {
         return tableFromIPC(response)
       },
 
-      async toArrowReader (): Promise<AsyncRecordBatchStreamReader> {
+      async toArrowReader (): Promise<EsqlArrowReader> {
         const { AsyncRecordBatchStreamReader } = loadArrow()
         if (metaHeader !== null) {
           reqOptions.headers = reqOptions.headers ?? {}

--- a/test/unit/dts-bare-specifiers.test.ts
+++ b/test/unit/dts-bare-specifiers.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test } from 'tap'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const root = join(__dirname, '..', '..')
+
+function declarationFiles (dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...declarationFiles(full))
+    else if (entry.name.endsWith('.d.ts')) out.push(full)
+  }
+  return out
+}
+
+// Bare specifier: an external package import, not a relative or absolute path.
+function bareSpecifiers (content: string): string[] {
+  const specs: string[] = []
+  const re = /(?:from|import\()\s*(['"])([^'"]+)\1/g
+  let match
+  while ((match = re.exec(content)) !== null) {
+    const spec = match[2]
+    if (!spec.startsWith('.') && !spec.startsWith('/')) specs.push(spec)
+  }
+  return specs
+}
+
+test('esm declaration files have no bare specifier ending in .js', async t => {
+  for (const file of declarationFiles(join(root, 'esm'))) {
+    for (const spec of bareSpecifiers(readFileSync(file, 'utf8'))) {
+      t.notMatch(spec, /\.js$/, `${relative(root, file)}: bare specifier '${spec}' must not end in .js`)
+    }
+  }
+})
+
+test('esm and lib declaration files agree on bare specifiers', async t => {
+  for (const esmFile of declarationFiles(join(root, 'esm'))) {
+    const rel = relative(join(root, 'esm'), esmFile)
+    const libFile = join(root, 'lib', rel)
+    let libContent: string
+    try {
+      libContent = readFileSync(libFile, 'utf8')
+    } catch {
+      continue // esm-only files (e.g. package.json shims) have no lib counterpart
+    }
+    t.same(
+      bareSpecifiers(readFileSync(esmFile, 'utf8')).sort(),
+      bareSpecifiers(libContent).sort(),
+      `bare specifiers must match between esm/${rel} and lib/${rel}`
+    )
+  }
+})
+
+// apache-arrow is an optional peer dependency. Its types must stay out of the
+// always-reachable declaration graph so that importing the client does not force
+// consumers to install apache-arrow to type-check. Precise types are opt-in via
+// the standalone helpers-arrow module.
+test('apache-arrow is only referenced from the opt-in helpers-arrow module', async t => {
+  for (const dir of ['esm', 'lib']) {
+    for (const file of declarationFiles(join(root, dir))) {
+      const rel = relative(root, file)
+      if (/helpers-arrow\.d\.ts$/.test(file)) {
+        t.match(readFileSync(file, 'utf8'), /apache-arrow/, `${rel} should carry the opt-in apache-arrow types`)
+        continue
+      }
+      t.notMatch(readFileSync(file, 'utf8'), /apache-arrow/, `${rel} must not reference apache-arrow`)
+    }
+  }
+})

--- a/test/unit/helpers/esql.test.ts
+++ b/test/unit/helpers/esql.test.ts
@@ -7,6 +7,8 @@ import { test } from 'tap'
 import * as arrow from 'apache-arrow'
 import { connection } from '../../utils'
 import { Client, errors } from '../../../'
+// Opt in to precise apache-arrow types for the ES|QL Arrow helpers.
+import '@elastic/elasticsearch/helpers-arrow'
 
 test('ES|QL helper', t => {
   test('toRecords', t => {


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch-js/issues/3419
